### PR TITLE
Tweak python language back for django settings.py DATABASE_URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,16 +66,11 @@ try:
             'HOST':     url.hostname,
             'PORT':     url.port,
         }
-        print 1
         if url.scheme == 'postgres':
             DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
-            print 2
-            print DATABASES
         if url.scheme == 'mysql':
             DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
-            print 3
 except:
-    print 4
     print "Unexpected error:", sys.exc_info()
 
 EOF


### PR DESCRIPTION
tweaking settings to be safer, and removing requirement of psycopg2 for django
