### PR TITLE
Change to fix an issue when DATABASES isn't declared in settings.py

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -94,8 +94,16 @@ import os, sys, urlparse
 urlparse.uses_netloc.append('postgres')
 urlparse.uses_netloc.append('mysql')
 try:
-    if os.environ.has_key('DATABASE_URL') and DATABASES != None:
+
+    #check to make sure DATABASES is set in settings.py file.If not default to {}
+    try:
+        DATABASES
+    except NameError:
+        DATABASES = {}
+
+    if os.environ.has_key('DATABASE_URL'):
         url = urlparse.urlparse(os.environ['DATABASE_URL'])
+
         DATABASES['default'] = {
             'NAME':     url.path[1:],
             'USER':     url.username,


### PR DESCRIPTION
The way it is setup right now if you don't declare DATABASES in your settings.py file it throws and error. I have made a little change to check if DATABASES is there or not, and if it isn't it sets up DATABASES so that the rest of the heroku DATABASES code will work as it should. 
