### PR TITLE
Allow Django's DATABASES to contain OPTIONS and other settings

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -104,13 +104,15 @@ try:
     if os.environ.has_key('DATABASE_URL'):
         url = urlparse.urlparse(os.environ['DATABASE_URL'])
 
-        DATABASES['default'] = {
+        # We use update here to preserve other keys we
+        # don't care about (like OPTIONS)
+        DATABASES['default'].update({
             'NAME':     url.path[1:],
             'USER':     url.username,
             'PASSWORD': url.password,
             'HOST':     url.hostname,
             'PORT':     url.port,
-        }
+        })
         if url.scheme == 'postgres':
             DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
         if url.scheme == 'mysql':


### PR DESCRIPTION
Instead of simply overwriting the entire DATABASES dictionary in settings.py, we use DATABASES.update(...) to allow backend-specific options in Django, as outlined here: https://docs.djangoproject.com/en/dev/ref/databases/
