### PR TITLE
Django app Procfile generation broken

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -17,7 +17,7 @@ EOF
 
 [ "$NAME" = "Python/Django" ] || exit 0
 
-SETTINGS_FILE=$(ls $BUILD_DIR/**/settings.py | head -1)
+SETTINGS_FILE=$(cd $BUILD_DIR && ls **/settings.py | head -1)
 PROJECT=$(dirname $SETTINGS_FILE)
 
 cat <<EOF


### PR DESCRIPTION
Change b1f05b9 introduced an issue where the path to settings.py in the generate Procfile includes the full path at slug compilation time, which does not match where the app is being run.

This patch reverts to the old behaviour by finding settings.py relative to the app's root dir.
