### PR TITLE
changing mkdir .heroku to mkdir -p .heroku since it is a little safer and won't throw error if directory already exists.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,7 +56,7 @@ echo "-----> Preparing virtualenv version $(virtualenv --version)"
 virtualenv --no-site-packages . | indent
 
 # create set-aside .heroku folder.
-mkdir .heroku
+mkdir -p .heroku
 
 
 # if pylibmc within requirements, use vendored libmemcached


### PR DESCRIPTION
mkdir .heroku didn't have the -p flag, not sure what the odds are of this directly already being created but, if it is the command will fail. If you add the -p flag it won't fail if the directly already exists. 

This change is really minor, and doesn't really effect much, I normally add the -p flag in scripts like this, because it is a little safer. Feel free to reject this if you don't think it is needed.
