### PR TITLE
switching curl from using -O option to -o because it is a little safer.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,9 +68,9 @@ then
     if [ -d "vendor/lib/sasl2" ]; then
       export LIBMEMCACHED=$(pwd)/vendor
     else
-      curl -s -L -O $VENDORED_MEMCACHED
-      tar -zxvf vendor-libmemcached.tar.gz > /dev/null
-      rm vendor-libmemcached.tar.gz
+      curl -s -L -o tmp-libmemcached.tar.gz $VENDORED_MEMCACHED
+      tar -zxvf tmp-libmemcached.tar.gz > /dev/null
+      rm tmp-libmemcached.tar.gz
       export LIBMEMCACHED=$(pwd)/vendor
     fi
 


### PR DESCRIPTION
It is usually safer to use the -o option in curl to specify your own temp file name in scripts because if the file changes in the url then your local file will also change and it will result in an error since you have that name hard coded in the next few lines (tar, rm). This is most common when you change your url, and are unaware of the fact that the name of the file matters to the script. 

This is a little safer, it removes the dependency on your script from the name of the file on the server, so if the file on the server changes names, everything else will keep on working.

I did change the name of the file just incase there was something special with the other name. Feel free to change the name back to the original name if you want.

I normally put the name of the temp file in a variable as well, but since it was all used in this one spot, and I didn't want to make any more changes then needed, I kept it the way it was before.  Ideally it should be a variable though. 

Once again, a very minor change, but I usually find it is a worthwhile one.
