### PR TITLE
Create a HEROKU_RELEASE_ID file with a UUID4

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,8 @@ if [ -f "lib/python2.7" ]; then
   exit 1;
 fi
 
+# generate a new RELEASE_ID
+python -c 'import uuid ; print uuid.uuid4().hex' > HEROKU_RELEASE_ID
 
 # copy artifacts out of cache if exists
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
I humbly think Heroku should do this by default in every buildpack; the
choice of UUID4 was borderline arbitrary, any unique ID will be fine.

Quoting http://www.12factor.net/build-release-run
"Every release should always have a unique release ID, such as a
timestamp of the release (such as 2011-04-06-20:32:17) or an
incrementing number (such as v100). Releases are an append-only ledger
and a release cannot be mutated once it is created. Any change must
create a new release."
