### PR TITLE
Make django settings injection optional

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -81,7 +81,7 @@ fi
 
 
 # if Django, append settings
-if [ "$NAME" = "Python/Django" ]; then
+if [ "$NAME" = "Python/Django" ] && ! grep HEROKU_NO_DJANGO_SETTINGS **/settings.py > /dev/null; then
   echo "-----> Django settings injection"
 
   SETTINGS_FILE=$(ls **/settings.py | head -1)


### PR DESCRIPTION
I understand that settings injection is necessary so using vanilla django on Heroku would be possible, but I think there should be an "I know what I'm doing switch" to make it optional.

For example, I opted to put the DATABASE_URL mechanism in my settings file explicitly so it will be least astonishing and easily customizable (for example, I added a sqlite:// url that can be used in unit tests).
