### PR TITLE
Set the LANG var to support non US-ASCII chars

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -12,6 +12,7 @@ config_vars:
   PYTHONUNBUFFERED: true
   LIBRARY_PATH: .heroku/vendor/lib
   LD_LIBRARY_PATH: .heroku/vendor/lib
+  LANG: en_US.UTF-8
 EOF
 
 


### PR DESCRIPTION
This it the same as the ruby buildpack.

Ref: https://support.heroku.com/tickets/42300?col=24470182&page=1
