### PR TITLE
Increase search depth for settings.py to reflect Django 1.4 default layout shift

### DIFF
--- a/bin/steps/django
+++ b/bin/steps/django
@@ -23,7 +23,7 @@ pip install --use-mirrors dj-database-url==0.1.1 | indent
 
 echo "-----> Injecting Django settings..."
 
-SETTINGS_FILE=$(find . -maxdepth 2 -type f -name 'settings.py' | head -1)
+SETTINGS_FILE=$(find . -maxdepth 3 -type f -name 'settings.py' | head -1)
 PROJECT=$(dirname $SETTINGS_FILE)
 
 echo "Injecting code into $SETTINGS_FILE to read from DATABASE_URL" | indent


### PR DESCRIPTION
I and others often end up with Heroku / Django projects with the following layout:

```
$ ls -1
Procfile
django_project_dir
```

With Django 1.4, in this case, standard location for `settings.py` is `django_project_dir/project/settings.py`, where before it would have been `django_project_dir/settings.py`, and a `find` with `-maxdepth 2` will now no longer detect it.

Part of me wonders as to the purpose of the `maxdepth` - just an optimisation, or something more discerning?
