### PR TITLE
Fix typo

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 
 #
 # Create a Heroku app with the following buildpack:
-# https://github.com/ddollar/buildpack-tet
+# https://github.com/ddollar/buildpack-test
 #
 # Push this Python buildpack to that Heroku app to
 # run the tests.


### PR DESCRIPTION
I think this is meant to point to buildpack-test (which exists and looks like it's probably the right thing) instead of buildpack-tet (which is 404)
