### PR TITLE
Option to purge and recreate virtualenv

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -160,12 +160,14 @@ puts-step "Creating Virtualenv version $(virtualenv --version)"
 # Try to create the virtualenv.
 OUT=$(virtualenv --python $PYTHON_EXE --distribute --never-download --prompt='(venv) ' $VIRTUALENV_LOC 2>&1)
 
-# If there's an error, purge and recreate.
-[ $? -ne 0 ] && {
-  puts-warn "Virtualenv corrupt, rebuilding."
+[ $? -ne 0 -o -n "$CLEAN_VIRTUALENV" ] && {
+  if [ -n "$CLEAN_VIRTUALENV" ]
+    then echo " !     CLEAN_VIRTUALENV set, rebuilding virtualenv."
+    else echo " !     Virtualenv corrupt, rebuilding."
+  fi
   for dir in $VIRTUALENV_DIRS; do
     rm -fr $dir &> /dev/null || true
-  done
+  done  
   OUT=$(virtualenv --python $PYTHON_EXE --distribute --never-download  --prompt='(venv) ' $VIRTUALENV_LOC )
 }
 echo "$OUT" | indent


### PR DESCRIPTION
With the user_env_compile option letting us pass environment into buildpacks, I added a CLEAN_VIRTUALENV option which deletes the cached virtualenv and recreates it afresh. I found this really useful when trying to trim down the size of my slug.
