### PR TITLE
Fix CLEAN_VIRTUALENV usage so it actually works.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -167,6 +167,10 @@ OUT=$(virtualenv --python $PYTHON_EXE --distribute --never-download --prompt='(v
   fi
   # If the virtualenv is old-style, the new one won't be
   if $LEGACY_VIRTUALENV; then
+    # Remove old artifacts in cache.
+    for dir in $CACHED_DIRS; do
+      rm -rf $CACHE_DIR/$dir
+    done
     VIRTUALENV_DIRS=$LEGACY_VIRTUALENV_DIRS
     VIRTUALENV_LOC=$MODERN_VIRTUALENV_LOC
     CACHED_DIRS=".heroku"


### PR DESCRIPTION
Purging the venv using the labs user_env_compile feature with the CLEAN_VIRTUALENV env var doesn't work: since commit 6aadf1683a2e2a3f9cca1ea90cf74bf809214328 VIRTUALENV_DIRS is unassigned, so nothing gets deleted.

I made the distinction between legacy- and modern-style virtualenvs. You may not want to merge this as-is because it will move legacy-venv from /app to /app/.heroku/venv and the user will have to update PYTHONHOME.
Does bin/release force PYTHONHOME to /app/.heroku/venv/ ? In this case we don't want any legacy venv and this commit is ok.

In fact I had the opposite problem after trying to purge my virtualenv with the purge branch (as documented here: http://stackoverflow.com/a/9463068/343834), the venv was moved to /app from /app/.heroku/venv and it broke my app by not being anymore in PYTHONHOME. If you have access to heroku support requests it's the #54723.
