### PR TITLE
Allow ${ENVIRONMENT_VARIABLES} within requirements.txt

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -205,7 +205,7 @@ fi
 # Substitute environment variables in requirements.txt
 # TODO: allow cascading in included requirements files?
 if (grep -Fiq "\${" requirements.txt) then
-  echo "Substituting environment variables within requirements.txt" | indent
+  puts-step "Substituting environment variables within requirements.txt"
   env | sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > /tmp/env.sed && {
      sed -f /tmp/env.sed -i.orig requirements.txt && rm /tmp/env.sed
   }


### PR DESCRIPTION
So that sensitive/environment-specific credentials don't need to be stored in the (potentially shared/public) repository itself.

e.g. `-e git+https://${GITHUB_USER}:${GITHUB_PASSWORD}@github.com/my/private-repo.git`

I can't imagine `${` would appear in a requirements file ordinarily? If I'm mistaken, we could add an opt-in setting to enable the functionality instead of detecting those characters.

Ideally we'd allow SSH keys to be used for pip requirement retrieval instead/as well, but I'm finding this sufficient for now.
