### PR TITLE
Use all requirements for checking hg+ and pylibmc, fixed #58

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -173,7 +173,7 @@ set -e
 source $BIN_DIR/steps/pylibmc
 
 # Install Mercurial if it appears to be required.
-if (grep -Fiq "hg+" requirements.txt) then
+if (in-req "hg+" requirements.txt) then
   pip install --use-mirrors mercurial | cleanup | indent
 fi
 

--- a/bin/steps/pylibmc
+++ b/bin/steps/pylibmc
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # This script serves as the Pylibmc build step of the
-# [**Python Buildpack**](https://github.com/heroku/heroku-buildpack-python) 
-# compiler. 
-# 
-# A [buildpack](http://devcenter.heroku.com/articles/buildpacks) is an 
+# [**Python Buildpack**](https://github.com/heroku/heroku-buildpack-python)
+# compiler.
+#
+# A [buildpack](http://devcenter.heroku.com/articles/buildpacks) is an
 # adapter between a Python application and Heroku's runtime.
 #
 # This script is invoked by [`bin/compile`](/).
@@ -12,8 +12,11 @@
 # The location of the pre-compiled libmemcached binary.
 VENDORED_MEMCACHED="http://cl.ly/0a191R3K160t1w1P0N25/vendor-libmemcached.tar.gz"
 
+# Syntax sugar.
+source $BIN_DIR/utils
+
 # If pylibmc exists within requirements, use vendored libmemcached.
-if (grep -Fiq "pylibmc" requirements.txt) then
+if (in-req "pylibmc" requirements.txt) then
   echo "-----> Noticed pylibmc. Bootstrapping libmemcached."
   cd .heroku
 

--- a/bin/utils
+++ b/bin/utils
@@ -50,3 +50,25 @@ function deep-mv (){
   rm -fr $1/!(tmp)
   find -H $1 -maxdepth 1 -name '.*' -a \( -type d -o -type f -o -type l \) -exec rm -fr '{}' \;
 }
+
+# Recursively finds requirements.txt files
+function list-req (){
+  echo $@
+  for req in $(grep -Fie "-r " $@ | sed 's/-r //g')
+    do
+      path="$(dirname $@)/$req"
+      list-req $path
+    done
+}
+
+# Find pattern in requirements files recursively
+# Usage: $ in-req pattern file
+function in-req (){
+  for file in $(list-req $2)
+    do
+      if (grep -Fiqe "$1" "$file") then
+        return 0
+      fi
+    done
+  return 1
+}


### PR DESCRIPTION
Instead of only looking at the root requirements this changes the compile script to find all the requirements files and look through them all to check for needed mercurial support and pylibmc support
