### PR TITLE
Use $BIN_DIR in hooks.

### DIFF
--- a/bin/steps/hooks/post_compile
+++ b/bin/steps/hooks/post_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -f bin/post_compile ]; then
+if [ -f $BIN_DIR/post_compile ]; then
     echo "-----> Running post-compile hook"
-    chmod +x bin/post_compile
-    bin/post_compile
+    chmod +x $BIN_DIR/post_compile
+    $BIN_DIR/post_compile
 fi

--- a/bin/steps/hooks/pre_compile
+++ b/bin/steps/hooks/pre_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -f bin/pre_compile ]; then
+if [ -f $BIN_DIR/pre_compile ]; then
     echo "-----> Running pre-compile hook"
-    chmod +x bin/pre_compile
-    bin/pre_compile
+    chmod +x $BIN_DIR/pre_compile
+    $BIN_DIR/pre_compile
 fi


### PR DESCRIPTION
Due to where the compile script is run from `bin/pre_compile` doesn't exist. (Unless I've totally misunderstood where I should put things...)
