### PR TITLE
Fixing the compile hook scripts paths

### DIFF
--- a/bin/steps/hooks/post_compile
+++ b/bin/steps/hooks/post_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -f $BIN_DIR/post_compile ]; then
+if [ -f bin/post_compile ]; then
     echo "-----> Running post-compile hook"
-    chmod +x $BIN_DIR/post_compile
-    $BIN_DIR/post_compile
+    chmod +x bin/post_compile
+    bin/post_compile
 fi

--- a/bin/steps/hooks/pre_compile
+++ b/bin/steps/hooks/pre_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -f $BIN_DIR/pre_compile ]; then
+if [ -f bin/pre_compile ]; then
     echo "-----> Running pre-compile hook"
-    chmod +x $BIN_DIR/pre_compile
-    $BIN_DIR/pre_compile
+    chmod +x bin/pre_compile
+    bin/pre_compile
 fi


### PR DESCRIPTION
The compile script is run with the root of the git repo of the project
being pushed as the working directory.

$BIN_DIR is pointing to the bin directory of the buildpack which is not
where you would want to put the pre and post compile hooks.

Changing back to the old convention of looking for the hooks from the
bin directory at the root of the project.
