### PR TITLE
Remove shared db from release and add heroku-postgresql dev db

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,6 +18,6 @@ if [[ $MANAGE_FILE ]]; then
 cat <<EOF
 
 addons:
-  shared-database:5mb
+  heroku-postgresql:dev
 EOF
 fi


### PR DESCRIPTION
The shared-database plan has been deprecated and replaced by heroku-postgresql:dev
