### PR TITLE
Make builds work when BUILD_DIR=/app

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,13 @@ BUILDPACK_VERSION=v28
 [ ! "$SLUG_ID" ] && SLUG_ID="defaultslug"
 [ ! "$REQUEST_ID" ] && REQUEST_ID=$SLUG_ID
 
+# Make bpwatch a no-op outside the Heroku environment
+case "$REQUEST_ID" in
+  defaultslug)
+    bpwatch() { :; }
+    ;;
+esac
+
 # Sanitizing environment variables.
 unset GIT_DIR PYTHONHOME PYTHONPATH LD_LIBRARY_PATH LIBRARY_PATH
 
@@ -64,15 +71,15 @@ TMP_APP_DIR=$CACHE_DIR/tmp_app_dir
 bpwatch start anvil_appdir_stage
   if [ "$SLUG_ID" ]; then
     mkdir -p $TMP_APP_DIR
-    deep-mv $APP_DIR $TMP_APP_DIR
+    [ "$BUILD_DIR" = "$APP_DIR" ] || deep-mv $APP_DIR $TMP_APP_DIR
   else
-    deep-rm $APP_DIR
+    [ "$BUILD_DIR" = "$APP_DIR" ] || deep-rm $APP_DIR
   fi
 bpwatch stop anvil_appdir_stage
 
 # Copy Application code in.
 bpwatch start appdir_stage
-  deep-mv $BUILD_DIR $APP_DIR
+  [ "$BUILD_DIR" = "$APP_DIR" ] || deep-mv $BUILD_DIR $APP_DIR
 bpwatch stop appdir_stage
 
 # Set new context.
@@ -268,12 +275,12 @@ bpwatch stop dump_cache
 
 # ### Fin.
 bpwatch start appdir_commit
-  deep-mv $BUILD_DIR $ORIG_BUILD_DIR
+  [ "$ORIG_BUILD_DIR" = "$APP_DIR" ] || deep-mv $BUILD_DIR $ORIG_BUILD_DIR
 bpwatch stop appdir_commit
 
 bpwatch start anvil_appdir_commit
   if [ "$SLUG_ID" ]; then
-    deep-mv $TMP_APP_DIR $APP_DIR
+    [ "$ORIG_BUILD_DIR" = "$APP_DIR" ] || deep-mv $TMP_APP_DIR $APP_DIR
   fi
 
 bpwatch stop anvil_appdir_commit


### PR DESCRIPTION
When building with either 'git push' or Anvil, BUILD_DIR is set to a
temporary directory (not /app). However, because the prebuilt Python
interpreter has a prefix of /app/.heroku/python baked into it, the
contents of BUILD_DIR need to be temporarily swapped into /app for the
rest of the buildpack to work.

This temporary swapping breaks other buildpack-compatible tools that
set BUILD_DIR=/app. So the fix is straightforward---skip the swapping
in this case.
