### PR TITLE
fixed shebang in bpwatch to be more portable

### DIFF
--- a/vendor/bpwatch/bpwatch
+++ b/vendor/bpwatch/bpwatch
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 
 
 import os


### PR DESCRIPTION
# !/usr/bin/env python is more portable across different python installs.
