### PR TITLE
don't hardcode python's location

### DIFF
--- a/vendor/bpwatch/bpwatch
+++ b/vendor/bpwatch/bpwatch
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 
 
 import os


### PR DESCRIPTION
try to use /usr/bin/env whenever possible for portability reasons between different systems.
