### PR TITLE
Make vendored libraries available at compile time (fixes #57)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -79,11 +79,14 @@ ORIG_BUILD_DIR=$BUILD_DIR
 BUILD_DIR=$APP_DIR
 
 # Prepend proper path buildpack use.
-export PATH=$BUILD_DIR/.heroku/python/bin:$PATH
+export PATH=$BUILD_DIR/.heroku/python/bin:$BUILD_DIR/.heroku/vendor/bin:$PATH
 export PYTHONUNBUFFERED=1
 export LANG=en_US.UTF-8
-export LIBRARY_PATH=/app/.heroku/vendor/lib
-export LD_LIBRARY_PATH=/app/.heroku/vendor/lib
+export C_INCLUDE_PATH=/app/.heroku/vendor/include:$BUILD_DIR/.heroku/vendor/include
+export CPLUS_INCLUDE_PATH=/app/.heroku/vendor/include:$BUILD_DIR/.heroku/vendor/include
+export LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib
+export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib
+export PKG_CONFIG_PATH=/app/.heroku/vendor/lib/pkg-config:$BUILD_DIR/.heroku/vendor/lib/pkg-config
 
 # Switch to the repo's context.
 cd $BUILD_DIR


### PR DESCRIPTION
When building, `BUILD_DIR` is set to a temporary directory. Vendored libraries (e.g., pylibmc) are downloaded and unpacked in `$BUILD_DIR/.heroku/vendor/lib`, but this is not currently in `LIBRARY_PATH` or `LD_LIBRARY_PATH`.

Fix this by doing the following:
- Add `$BUILD_DIR/.heroku/vendor/lib` to `LIBRARY_PATH`/`LD_LIBRARY_PATH`
- Add `$BUILD_DIR/.heroku/vendor/include` to `C_INCLUDE_PATH`/`CPLUS_INCLUDE_PATH`
- Add `$BUILD_DIR/.heroku/vendor/bin` to `PATH`, so vendored commands can be used at compile time (e.g., curl-config)
- Add `$BUILD_DIR/.heroku/vendor/lib/pkg-config` to `PKG_CONFIG_PATH`, so vendored packages can be found with `pkg-config`
