### PR TITLE
Update Heroku Postgresql default add-on to hobby-dev

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,6 +18,6 @@ if [[ $MANAGE_FILE ]]; then
 cat <<EOF
 
 addons:
-  heroku-postgresql:dev
+  heroku-postgresql:hobby-dev
 EOF
 fi


### PR DESCRIPTION
With [Heroku Postgres 2.0](https://postgres.heroku.com/blog/past/2013/11/11/heroku_postgres_20/), the free plan is now called `Hobby Dev`.
