### PR TITLE
Use a sed() function for unbuffered output.

### DIFF
--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-# Syntax sugar.
-indent() {
-  RE="s/^/       /"
-  [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
-}
+source $BIN_DIR/utils
 
 MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
 MANAGE_FILE=${MANAGE_FILE:-fakepath}

--- a/bin/utils
+++ b/bin/utils
@@ -1,16 +1,19 @@
 shopt -s extglob
 
-[ $(uname) == "Darwin" ] && SED_FLAG='-l' || SED_FLAG='-u'
+if [ $(uname) == Darwin ]; then
+    sed() { command sed -l "$@"; }
+else
+    sed() { command sed -u "$@"; }
+fi
 
 # Syntax sugar.
 indent() {
-  RE="s/^/       /"
-  sed $SED_FLAG "$RE"
+  sed "s/^/       /"
 }
 
 # Clean up pip output
 cleanup() {
-  sed $SED_FLAG -e 's/\.\.\.\+/.../g' | sed $SED_FLAG '/already satisfied/Id' | sed $SED_FLAG -e '/Overwriting/Id' |  sed $SED_FLAG -e '/python executable/Id' | sed $SED_FLAG -e '/no previously-included files/Id'
+  sed -e 's/\.\.\.\+/.../g' | sed -e '/already satisfied/Id' | sed -e '/Overwriting/Id' | sed -e '/python executable/Id' | sed -e '/no previously-included files/Id'
 }
 
 # Buildpack Steps.


### PR DESCRIPTION
In `bin/steps/collectstatic` the unbuffered output in `indent` is subverted by
calling `sed` first:

``` shell
python $MANAGE_FILE collectstatic --noinput  2>&1 | sed '/^Copying/d;/^$/d;/^ /d' | indent
```

This commit fixes this by making `sed` itself unbuffered rather than putting
that logic in the `indent` function.
