### PR TITLE
Stop using find in deep-cp, deep-rm, etc.

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -46,10 +46,10 @@ deep-cp() {
 
   # cp doesn't like being called without source params,
   # so make sure they expand to something first.
-  # subshell to avoid surprising caller with nullglob.
+  # subshell to avoid surprising caller with shopts.
   (
-    shopt -s nullglob
-    set -- "$source"/!(tmp) "$source"/.{[!.],.?}*
+    shopt -s nullglob dotglob
+    set -- "$source"/!(tmp|.|..)
     [[ $# == 0 ]] || cp -a "$@" "$target"
   )
 }
@@ -62,7 +62,11 @@ deep-mv() {
 
 # Does some serious deleting.
 deep-rm() {
-  rm -rf "$1"/!(tmp) "$1"/.{[!.],.?}*
+  # subshell to avoid surprising caller with shopts.
+  (
+    shopt -s dotglob
+    rm -rf "$1"/!(tmp|.|..)
+  )
 }
 
 


### PR DESCRIPTION
These functions were written using `find` to avoid globbing with `.*` which
could accidentally traverse to the parent directory.  Since `extglob` is
already enabled, we can just use an extended glob to accomplish the same.

This pull request also fixes a trivial issue where `cp` could fail if nothing
matches the glob `!(tmp)`.

There's nothing urgent about this pull request, but it seems like something
nice to clean up the next time you're doing a round of testing anyway. :-)
