### PR TITLE
Process dependency links

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -220,7 +220,7 @@ puts-step "Installing dependencies using Pip ($PIP_VERSION)"
 [ ! "$FRESH_PYTHON" ] && bpwatch start pip_install
 [ "$FRESH_PYTHON" ] && bpwatch start pip_install_first
 
-/app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=./.heroku/src --process-dependency-links --allow-all-external  | cleanup | indent
+/app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=./.heroku/src --process-dependency-links | cleanup | indent
 
 [ ! "$FRESH_PYTHON" ] && bpwatch stop pip_install
 [ "$FRESH_PYTHON" ] && bpwatch stop pip_install_first


### PR DESCRIPTION
This change allows external packages specified via the dependency_links attribute in `setup.py` files to be properly installed when using pip 1.5.
`--allow-all-external` was found to not affect this situation at all. If problems with unverified packages arise, the `--allow-unverified PACKAGE_NAME` is necessary anyway, which includes the `--allow-external PACKAGE_NAME` flag.
