### PR TITLE
fix(utils): fix deep-rm searching behavior

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -67,8 +67,7 @@ deep-mv() {
 deep-rm() {
   # subshell to avoid surprising caller with shopts.
   (
-    shopt -s dotglob
-    rm -rf "$1"/!(tmp|.|..)
+    ls "$1" | grep -v "tmp" | xargs rm -rf
   )
 }
 


### PR DESCRIPTION
When a child directory exists in a specified directory, the buildpack would crash and burn. For example, with a [sample Tornado app](https://github.com/bacongobbler/helloworld-tornado) you could see this error:

```
rm: cannot remove `/app/notes': Directory not empty
```

This error only occurs with projects external to Heroku (i.e. https://github.com/flynn/slugbuilder), but the fix is semantically the same for Heroku apps. Logs below from a `heroku push`:

```
$ heroku create --buildpack https://github.com/bacongobbler/heroku-buildpack-python#fix-deep-rm
Creating ... done, stack is cedar
BUILDPACK_URL=https://github.com/bacongobbler/heroku-buildpack-python#fix-deep-rm
Git remote heroku added
$ git push heroku master
Initializing repository, done.
Counting objects: 17, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (10/10), done.
Writing objects: 100% (17/17), 1.81 KiB | 0 bytes/s, done.
Total 17 (delta 5), reused 17 (delta 5)

-----> Fetching custom git buildpack... done
-----> Python app detected
-----> No runtime.txt provided; assuming python-2.7.6.
-----> Preparing Python runtime (python-2.7.6)
-----> Installing Setuptools (2.1)
-----> Installing Pip (1.5.4)
-----> Installing dependencies using Pip (1.5.4)
       Downloading/unpacking tornado (from -r requirements.txt (line 1))
         Running setup.py (path:/tmp/pip_build_u17484/tornado/setup.py) egg_info for package tornado

       Downloading/unpacking backports.ssl-match-hostname (from tornado->-r requirements.txt (line 1))
         Downloading backports.ssl_match_hostname-3.4.0.2.tar.gz
         Running setup.py (path:/tmp/pip_build_u17484/backports.ssl-match-hostname/setup.py) egg_info for package backports.ssl-match-hostname

       Installing collected packages: tornado, backports.ssl-match-hostname
         Running setup.py install for tornado
           building 'tornado.speedups' extension
           gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/app/.heroku/python/include/python2.7 -c tornado/speedups.c -o build/temp.linux-x86_64-2.7/tornado/speedups.o
           tornado/speedups.c:46: warning: function declaration isn’t a prototype
           gcc -pthread -shared build/temp.linux-x86_64-2.7/tornado/speedups.o -o build/lib.linux-x86_64-2.7/tornado/speedups.so

         Running setup.py install for backports.ssl-match-hostname

       Successfully installed tornado backports.ssl-match-hostname
       Cleaning up...
-----> Discovering process types
       Procfile declares types -> web

-----> Compressing... done, 44.6MB
```
