### PR TITLE
Run compile.py on Python 2.6 or better instead of compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 # If Python 2.6 of better exists then run compile.py instead of this script
 COMPILE_PY="$BIN_DIR/compile.py"
 if [ -f $COMPILE_PY ]; then  # if compile.py exists
-PYTHON_VERSION=$(python -c "import sys; print(sys.version[:5].replace('.',''))")
+    PYTHON_VERSION=$(python -c "import sys; print(sys.version[:5].replace('.',''))")
     echo 'PYTHON_VERSION:' $PYTHON_VERSION
     if [ $PYTHON_VERSION -ge 260 ] ; then # Compile.py tested with Python 2.6 or better
         echo "Python $COMPILE_PY $1 $2 $3"


### PR DESCRIPTION
Goal: Deliver more of the tool chain in the language that this community understands best.

If compile.py exists and Python 2.6 or better exists then run compile.py instead of compile.

For me (and probably others) it is easier to understand, test, and debug Python than bash.  Much of the complexity of the tool chain (e.g. bpwatch CLI) can be reduced by coding the build process in Python instead of bash.

Would it be more future-proof to use $\* or $@ instead of $1 $2 $3?
