### PR TITLE
Specify $PYTHON_VERSION once to reduce redundancy

### DIFF
--- a/builds/runtimes/python-2.7.7
+++ b/builds/runtimes/python-2.7.7
@@ -3,7 +3,7 @@
 # Build Deps: libraries/sqlite
 
 OUT_PREFIX=$1
-PYTHON_VERSION="2.7.7". # =$2 as another possibility
+PYTHON_VERSION="2.7.7"  # =$2 as another possibility
 
 echo "Building Python..."
 SOURCE_TARBALL='http://python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz'


### PR DESCRIPTION
New style vendoring highlights the repetitive nature of the builds runtimes files.  Perhaps a syntax like: $ bob build runtimes/python 2.7.7 instead of: $ bob build runtimes/python-2.7.7 could reduce the repetitive builds runtimes files
