### PR TITLE
Create download_python function to reduce repetion

### DIFF
--- a/builds/runtimes/download_python
+++ b/builds/runtimes/download_python
@@ -3,14 +3,14 @@
 # Build Deps: libraries/sqlite
 
 # download_python(PYTHON_VERSION)
-# Example usage: download_python "2.7.7"
+# Example usage: download_python "2.7.8"
 download_python()
 {
     PYTHON_VERSION=$1
 
     if [ -z $PYTHON_VERSION ]
     then
-        $PYTHON_VERSION="2.7.7"
+        $PYTHON_VERSION="2.7.8"
     fi
 
     echo "Building Python $PYTHON_VERSION..."


### PR DESCRIPTION
Create a common download_python() function that allows most other files in the build/runtimes directory to be simplified to something of the form:

```
#!/usr/bin/env bash
# Build Path: /app/.heroku/python/
# Build Deps: libraries/sqlite

OUT_PREFIX=$1

source ./download_python
download_python "2.7.8"
cd src

./configure --prefix=$OUT_PREFIX
make
make install
```
