### PR TITLE
Update pylibmc to support nested requirements.

### DIFF
--- a/bin/steps/pylibmc
+++ b/bin/steps/pylibmc
@@ -16,7 +16,7 @@ VENDORED_MEMCACHED="http://cl.ly/0a191R3K160t1w1P0N25/vendor-libmemcached.tar.gz
 source $BIN_DIR/utils
 
 # If pylibmc exists within requirements, use vendored libmemcached.
-if (grep -Eiq "^\s*pylibmc" requirements.txt) then
+if (grep -Eiq "\s*pylibmc" requirements.txt) then
   echo "-----> Noticed pylibmc. Bootstrapping libmemcached."
   cd .heroku
 


### PR DESCRIPTION
The current regex assumes that pylibmc appears at the beginning of a line
(whitespace only precedes it), which is a fair assumption in a single 'flat'
requirements.txt file. However, if you are using nested requirements then
this is not the case - your pylibmc may exist in a sub-directory. This is
very similar to the way in which mercurial is installed if "hg+" is found
in the requirements file (see the /bin/compile script). By insisting that
pylibmc appear at the beginning of the file, it's impossible to fool the
compilation into installing libmemcached (as this script does) by simply
putting the phrase into a comment, which is what you _can_ do with 'hg+'.

I've updated the regex to remove the beginning of line restriction. This
means that you can add a comment to a top-level requirements.txt that
will trigger the install, without having to functionally alter your
nested requirements.

e.g. top-level requirements.txt:

```
# fake comment to trigger pylibmc script
# fake comment to trigger hg+ install
-r requirements/production.txt
```
