### PR TITLE
Do not fail if buildpack dir is readonly

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -52,22 +52,22 @@ if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_VERSION* ]]; then
 
   bpwatch start prepare_environment
 
+  TMPTARDIR=$(mktemp -d)
+  trap "rm -rf $TMPTARDIR" RETURN
+
   bpwatch start install_setuptools
     # Prepare it for the real world
     # puts-step "Installing Setuptools ($SETUPTOOLS_VERSION)"
-    cd $ROOT_DIR/vendor/
-    tar zxf setuptools-$SETUPTOOLS_VERSION.tar.gz
-    cd $ROOT_DIR/vendor/setuptools-$SETUPTOOLS_VERSION/
+    tar zxf $ROOT_DIR/vendor/setuptools-$SETUPTOOLS_VERSION.tar.gz -C $TMPTARDIR
+    cd $TMPTARDIR/setuptools-$SETUPTOOLS_VERSION/
     python setup.py install &> /dev/null
     cd $WORKING_DIR
   bpwatch stop install_setuptoools
 
   bpwatch start install_pip
     # puts-step "Installing Pip ($PIP_VERSION)"
-
-    cd $ROOT_DIR/vendor/
-    tar zxf pip-$PIP_VERSION.tar.gz
-    cd $ROOT_DIR/vendor/pip-$PIP_VERSION/
+    tar zxf $ROOT_DIR/vendor/pip-$PIP_VERSION.tar.gz -C $TMPTARDIR
+    cd $TMPTARDIR/pip-$PIP_VERSION/
     python setup.py install &> /dev/null
     cd $WORKING_DIR
 


### PR DESCRIPTION
After this change the buildpack directory can be mounted readonly, useful for development of the buildpack itself as described in [slugbuilder#buildpacks](https://github.com/flynn/flynn/tree/master/slugbuilder#buildpacks)  
