### PR TITLE
Install libffi for bcrypt as well

### DIFF
--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -20,7 +20,7 @@ source $BIN_DIR/utils
 bpwatch start libffi_install
 
 # If pylibmc exists within requirements, use vendored cryptography.
-if (pip-grep -s requirements.txt cffi crytography &> /dev/null) then
+if (pip-grep -s requirements.txt bcrypt cffi crytography &> /dev/null) then
 
   if [ -d ".heroku/vendor/lib/libffi-3.1.1" ]; then
     export LIBFFI=$(pwd)/vendor


### PR DESCRIPTION
The `bcrypt` library also needs `libffi`, but that requirement isn't currently detected by the buildpack unless you explicitly add `cffi` to your `requirements.txt` file. This change allows the buildpack to automatically detect the requirement.
