### PR TITLE
Allowing pip-install to have access to config vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -166,7 +166,7 @@ source $BIN_DIR/steps/pylibmc
 source $BIN_DIR/steps/cryptography
 
 # Install dependencies with Pip.
-source $BIN_DIR/steps/pip-install
+sub-env $BIN_DIR/steps/pip-install
 
 # Django collectstatic support.
 sub-env $BIN_DIR/steps/collectstatic

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+source $BIN_DIR/utils
+
 # Install dependencies with Pip.
 puts-step "Installing dependencies with pip"
 


### PR DESCRIPTION
- Currently, `pip-install` does not have access to config vars. 
- This PR is particularly useful when installing a pip package that requires an apt-package. For example, `scipy` requires `libatlas-dev` -- in this case, I can use `heroku-buildpack-multi` and `heroku-buildpack-apt`, and config vars `BLAS=/app/.apt/usr/lib/libblas/libblas.a` would let the pip package `scipy` knows the location of the static library during `pip-install`. 
