### PR TITLE
enable custom requirements-uninstall.txt

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -8,6 +8,11 @@ puts-step "Installing dependencies with pip"
 [ ! "$FRESH_PYTHON" ] && bpwatch start pip_install
 [ "$FRESH_PYTHON" ] && bpwatch start pip_install_first
 
+# if user wants to uninstall some packages first do so
+if [[ -f requirements-uninstall.txt ]]; then
+  pip uninstall -y -r requirements-uninstall.txt
+fi
+
 /app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=./.heroku/src --allow-all-external  | cleanup | indent
 
 # Smart Requirements handling


### PR DESCRIPTION
This change enables to run a custom pip uninstall of immediately before pip-install, e.g. to refresh some packages:

*Usage*
* add `requirements-uninstall.txt`
* git push

*How it works*
`steps/pip-install` will detect `requirements-uninstall.txt`, process all requirements in it (including support for -r inclusion of other requirements). Immediately afterwards, continues with `pip install`. 
