### PR TITLE
Add --upgrade to pip install

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -8,7 +8,7 @@ puts-step "Installing dependencies with pip"
 [ ! "$FRESH_PYTHON" ] && bpwatch start pip_install
 [ "$FRESH_PYTHON" ] && bpwatch start pip_install_first
 
-/app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=./.heroku/src --allow-all-external  | cleanup | indent
+/app/.heroku/python/bin/pip install -r requirements.txt --upgrade --exists-action=w --src=./.heroku/src --allow-all-external  | cleanup | indent
 
 # Smart Requirements handling
 cp requirements.txt .heroku/python/requirements-declared.txt


### PR DESCRIPTION
I’m building an app with dependencies defined in `setup.py` using [install_requires](https://pythonhosted.org/setuptools/setuptools.html#declaring-dependencies) to list them. In my `requirements.txt`, I have a line with `.` on it that installs my main module and all its dependencies.

Without the `--upgrade` option, pip does not recognize the addition of new requirements in builds over time and incorrectly skips them. This patch fixes the bug and correctly installs locates all installation requirements that may have changed in a new push to Heroku.