### PR TITLE
pypy-2.5.0

### DIFF
--- a/builds/runtimes/pypy-2.5.0
+++ b/builds/runtimes/pypy-2.5.0
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+# Build Deps: libraries/sqlite
+
+# NOTICE: This formula only works for the cedar-14 stack, not cedar.
+
+OUT_PREFIX=$1
+
+echo "Building PyPy..."
+SOURCE_TARBALL='https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2'
+curl -L $SOURCE_TARBALL | tar jx
+cp -R pypy-2.5.0-linux64/* $OUT_PREFIX
+
+ln $OUT_PREFIX/bin/pypy $OUT_PREFIX/bin/python


### PR DESCRIPTION
Issue: Execute bit is NOT yet set!

Should close issue https://github.com/heroku/heroku-buildpack-python/issues/202 and part of issue https://github.com/heroku/heroku-buildpack-python/issues/197