### PR TITLE
Prefer a 'manage.py' that exists higher up in the directory hierarchy

### DIFF
--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -2,7 +2,7 @@
 
 source $BIN_DIR/utils
 
-MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)
 MANAGE_FILE=${MANAGE_FILE:-fakepath}
 
 [ -f .heroku/collectstatic_disabled ] && DISABLE_COLLECTSTATIC=1


### PR DESCRIPTION
If you had multiple files named `manage.py` (for example if you have other django projects as submodules), the old collectstatic could be trying to run one of those files instead of the main one.

This change sorts `manage.py`s by their depth in the directory hierarchy, so that the shallowest one is chosen.