### PR TITLE
Update README to reflect new buildpack:set usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ Example usage:
 
 You can also add it to upcoming builds of an existing application:
 
-    $ heroku config:add BUILDPACK_URL=git://github.com/heroku/heroku-buildpack-python.git
+    $ heroku buildpack:set git://github.com/heroku/heroku-buildpack-python.git
 
 The buildpack will detect your app as Python if it has the file `requirements.txt` in the root.
 


### PR DESCRIPTION
`config:set BUILDPACK_URL` is no longer the preferred method of specifying a buildpack. This updates the README to reflect the current best practice.