### PR TITLE
Detect pyOpenSSL

### DIFF
--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -20,7 +20,7 @@ source $BIN_DIR/utils
 bpwatch start libffi_install
 
 # If pylibmc exists within requirements, use vendored cryptography.
-if (pip-grep -s requirements.txt bcrypt cffi cryptography PyOpenSSL &> /dev/null) then
+if (pip-grep -s requirements.txt bcrypt cffi cryptography pyOpenSSL PyOpenSSL &> /dev/null) then
 
   if [ -d ".heroku/vendor/lib/libffi-3.1.1" ]; then
     export LIBFFI=$(pwd)/vendor


### PR DESCRIPTION
Some people use pyOpenSSL (it is the literal name, e.g.: https://pypi.python.org/pypi/pyOpenSSL) so how about we just detect both?