### PR TITLE
Improve detect script: /bin/sh, look for Python/Django

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # This script serves as the
 # [**Python Buildpack**](https://github.com/heroku/heroku-buildpack-python)

--- a/bin/detect
+++ b/bin/detect
@@ -8,9 +8,8 @@
 # adapter between a Python application and Heroku's runtime.
 
 # ## Usage
-# Compiling an app into a slug is simple:
 #
-#     $ bin/detect <build-dir> <cache-dir>
+#     $ bin/detect <build-dir>
 
 BUILD_DIR=$1
 

--- a/bin/detect
+++ b/bin/detect
@@ -13,12 +13,11 @@
 
 BUILD_DIR=$1
 
-# Exit early if the app is not Python.
-if [ -f "$BUILD_DIR/manage.py" ]; then
-  echo "Python (Django)"
-
-elif [ -f "$BUILD_DIR/requirements.txt" ] || [ -f "$BUILD_DIR/setup.py" ]; then
+if [ -f "$BUILD_DIR/requirements.txt" ] || [ -f "$BUILD_DIR/setup.py" ]; then
   echo "Python"
+
+elif ! find "$BUILD_DIR" -maxdepth 2 -name manage.py -print -quit | grep -q .; then
+  echo "Python/Django"
 
 else
   exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -13,9 +13,13 @@
 
 BUILD_DIR=$1
 
-# Exit early if app is clearly not Python.
-if [ ! -f $BUILD_DIR/requirements.txt ] && [ ! -f $BUILD_DIR/setup.py ]; then
+# Exit early if the app is not Python.
+if [ -f "$BUILD_DIR/manage.py" ]; then
+  echo "Python (Django)"
+
+elif [ -f "$BUILD_DIR/requirements.txt" ] || [ -f "$BUILD_DIR/setup.py" ]; then
+  echo "Python"
+
+else
   exit 1
 fi
-
-echo Python


### PR DESCRIPTION
Without a requirements.txt and setup.py file in the root, it now will look for `manage.py` to detect a Django app.

This would allow for moving your requirements.txt file in the bin/pre_compile step.