### PR TITLE
Run pip with the --upgrade flag

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -4,7 +4,7 @@ puts-step "Installing dependencies with pip"
 [ ! "$FRESH_PYTHON" ] && bpwatch start pip_install
 [ "$FRESH_PYTHON" ] && bpwatch start pip_install_first
 
-/app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=./.heroku/src --allow-all-external --disable-pip-version-check --no-cache-dir | cleanup | indent
+/app/.heroku/python/bin/pip install --upgrade -r requirements.txt --exists-action=w --src=./.heroku/src --allow-all-external --disable-pip-version-check --no-cache-dir | cleanup | indent
 
 # Smart Requirements handling
 cp requirements.txt .heroku/python/requirements-declared.txt


### PR DESCRIPTION
This way, the app is always built the same way as if it was from scratch.

I think it's undesirable to have the app build differently if it is built from scratch or re-built from a previous push. Pushing the same code to a new app and an existing app should have the same result.

Personally, I've run into issues where a dependency becomes a bit outdated, it becomes difficult to force Heroku to update it. You have to:

1. Install the [heroku-repo](https://github.com/heroku/heroku-repo) extension
2. Run the `purge_cache` task
3. Run the `reset` task
4. Re-push the code to the app