### PR TITLE
Permit $PATH from prior buildpacks.

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -76,7 +76,7 @@ deep-rm() {
 sub-env() {
 
   WHITELIST=${2:-''}
-  BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
+  BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH)$'}
 
   (
     if [ -d "$ENV_DIR" ]; then


### PR DESCRIPTION
Multiple buildpack support means that prior buildpacks can export extra variables for use by later buildpacks. In particular, the `nodejs` buildpack, which is used for many asset pipelines, exports `node` and `npm` on `$PATH`.