### PR TITLE
Preserve original build directory (including previously-installed programs) when moving app to /app during build.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -83,7 +83,7 @@ if [[ ! "$DOCKER_BUILD" ]]; then
 
   # Copy Application code in.
   bpwatch start appdir_stage
-    deep-mv $BUILD_DIR $APP_DIR
+    deep-cp $BUILD_DIR $APP_DIR
   bpwatch stop appdir_stage
 fi
 
@@ -218,6 +218,7 @@ bpwatch stop dump_cache
 if [[ ! "$DOCKER_BUILD" ]]; then
 
   bpwatch start appdir_commit
+    rm -rf $ORIG_BUILD_DIR
     deep-mv $BUILD_DIR $ORIG_BUILD_DIR
   bpwatch stop appdir_commit
 


### PR DESCRIPTION
This means that binaries installed in $BUILD_DIR/.heroku/node (let's say) will remain available during build, at the paths previous buildpacks established.