### PR TITLE
Update heroku-postgresql to be plan agnostic

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,6 +18,6 @@ if [[ $MANAGE_FILE ]]; then
 cat <<EOF
 
 addons:
-  heroku-postgresql:hobby-dev
+  heroku-postgresql
 EOF
 fi


### PR DESCRIPTION
This will result in selecting the lowest level plan for the add-on as opposed to a hard coded one which may change.