### PR TITLE
Fix #277 - Install libffi with django[bcrypt] req.

### DIFF
--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -20,7 +20,7 @@ source $BIN_DIR/utils
 bpwatch start libffi_install
 
 # If a package using cffi exists within requirements, use vendored libffi.
-if (pip-grep -s requirements.txt bcrypt cffi cryptography pyOpenSSL PyOpenSSL requests[security] &> /dev/null) then
+if (pip-grep -s requirements.txt bcrypt cffi cryptography django[bcrypt] Django[bcrypt] pyOpenSSL PyOpenSSL requests[security] &> /dev/null) then
 
   if [ -d ".heroku/vendor/lib/libffi-3.1.1" ]; then
     export LIBFFI=$(pwd)/vendor


### PR DESCRIPTION
This ensures that libffi, required by bcrypt, is installed when Django
is installed with the bcrypt dependency declared as an extra
(django[bcrypt] or Django[bcrypt]).