### PR TITLE
Add PyPy 5.0.1

### DIFF
--- a/builds/runtimes/pypy-5.0.1
+++ b/builds/runtimes/pypy-5.0.1
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+# Build Deps: libraries/sqlite
+
+# NOTICE: This formula only works for the cedar-14 stack, not cedar.
+
+OUT_PREFIX=$1
+
+echo "Building PyPy..."
+SOURCE_TARBALL='https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux64.tar.bz2'
+curl -L $SOURCE_TARBALL | tar jx
+cp -R pypy-5.0.1-linux64/* $OUT_PREFIX
+
+ln $OUT_PREFIX/bin/pypy $OUT_PREFIX/bin/python


### PR DESCRIPTION
There was also a 5.0.0 release, but 5.0.1 was released days after as a [bugfix release](http://doc.pypy.org/en/latest/release-5.0.1.html). I could include it for completeness sake if desired.