### PR TITLE
Allow to add custom env variables before pip-install and collectstatic.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,3 +52,14 @@ Runtime options include:
 - `pypy-5.0.1` (unsupported, experimental)
 
 Other [unsupported runtimes](https://github.com/heroku/heroku-buildpack-python/tree/master/builds/runtimes) are available as well. Use at your own risk. 
+
+
+Add custom environment variables
+--------------------------------
+
+You may need to add custom environment variables during the build. They can be specified with a `.heroku-env` file:
+
+    $ cat .heroku-env
+    PYTHONPATH=/app/.heroku/python/lib/python3.4/site-packages:/app/.heroku/miniconda/envs/condaenv/lib/python3.4/site-packages:$PYTHONPATH
+
+They will be exported before installing packages with pip, and before the Django Collectstatic runner.

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -24,6 +24,8 @@ pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
 
 bpwatch start collectstatic  # metrics collection
 
+setup-custom-heroku-env
+
 if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then
     set +e
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -1,4 +1,5 @@
 # Install dependencies with Pip.
+setup-custom-heroku-env
 puts-cmd "pip install -r requirements.txt"
 
 [ ! "$FRESH_PYTHON" ] && bpwatch start pip_install

--- a/bin/utils
+++ b/bin/utils
@@ -106,3 +106,12 @@ sub-env() {
   )
 }
 
+setup-custom-heroku-env() {
+  if [ -f .heroku-env ]; then
+    puts-step "Applying custom environment variables"
+    set -a
+    source .heroku-env
+    set +a
+  fi
+}
+


### PR DESCRIPTION
For exemple we need this when using this buildpack with another buildpack installing packages from conda.

We use it with [jvenezia/heroku-buildpack-python](https://github.com/jvenezia/heroku-buildpack-python) witch installs specific packages with conda. Then the heroku-buildpack-python just have to pickup already installed packages during pip-install.

I'll be happy to discuss this feature and find a better solution. This is the cleanest way i found for my problem at this time.