### PR TITLE
Add PyNaCl to the list of packages that trigger libffi bootstrapping

### DIFF
--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -20,7 +20,7 @@ source $BIN_DIR/utils
 bpwatch start libffi_install
 
 # If a package using cffi exists within requirements, use vendored libffi.
-if (pip-grep -s requirements.txt bcrypt cffi cryptography django[bcrypt] Django[bcrypt] pyOpenSSL PyOpenSSL requests[security] &> /dev/null) then
+if (pip-grep -s requirements.txt bcrypt cffi cryptography django[bcrypt] Django[bcrypt] PyNaCl pyOpenSSL PyOpenSSL requests[security] &> /dev/null) then
 
   if [ -d ".heroku/vendor/lib/libffi-3.1.1" ]; then
     export LIBFFI=$(pwd)/vendor


### PR DESCRIPTION
To reduce confusion for users who have not explicitly listed cffi as a dependency.

Fixes #142.