### PR TITLE
fix(export-env): export app config vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -183,6 +183,9 @@ set -e
 
 mkdir -p $(dirname $PROFILE_PATH)
 
+# Export application's configuration variables
+sub-env $ENV_DIR
+
 # Install Python.
 source $BIN_DIR/steps/python
 

--- a/bin/utils
+++ b/bin/utils
@@ -92,17 +92,14 @@ sub-env() {
   export PYHONHOME=$BUILD_DIR/.heroku/python
   export PYTHONPATH=$BUILD_DIR/
 
-  (
-    if [ -d "$ENV_DIR" ]; then
-      for e in $(ls $ENV_DIR); do
-        echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" &&
-        export "$e=$(cat $ENV_DIR/$e)"
-        :
-      done
-    fi
-
+  if [ -d "$1" ]; then
+    for e in $(ls $1); do
+      echo "$e" | grep -E "$WHITELIST" | grep -qvE "$BLACKLIST" &&
+      export "$e=$(cat $1/$e)"
+      :
+    done
+  else
     $1
-
-  )
+  fi
 }
 


### PR DESCRIPTION
Explicitly call the sub-env function to export an app's config variables, which are in the ENV_DIR directory.

Also ensure the environment variables are exported in the main shell of the program instead of a subshell. The use case here is to pass flags to pip via PIP_* environment variables. https://pip.pypa.io/en/stable/user_guide/#environment-variables