### PR TITLE
Add a build script for Python 2.7.12 with UCS-4 Unicode support

### DIFF
--- a/builds/runtimes/python-2.7.12
+++ b/builds/runtimes/python-2.7.12
@@ -3,13 +3,14 @@
 # Build Deps: libraries/sqlite
 
 OUT_PREFIX=$1
+VERSION="2.7.12"
 
-echo "Building Python..."
-SOURCE_TARBALL='https://python.org/ftp/python/2.7.12/Python-2.7.12.tgz'
+echo "Building Python ${VERSION}..."
+SOURCE_TARBALL="https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz"
 curl -L $SOURCE_TARBALL | tar xz
-mv Python-2.7.12 src
+mv "Python-${VERSION}" src
 cd src
 
-./configure --prefix=$OUT_PREFIX  --with-ensurepip=no
+./configure --prefix=$OUT_PREFIX --with-ensurepip=no
 make
 make install

--- a/builds/runtimes/python-2.7.13
+++ b/builds/runtimes/python-2.7.13
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+# Build Deps: libraries/sqlite
+
+OUT_PREFIX=$1
+VERSION="2.7.13"
+
+echo "Building Python ${VERSION}..."
+SOURCE_TARBALL="https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz"
+curl -L $SOURCE_TARBALL | tar xz
+mv "Python-${VERSION}" src
+cd src
+
+# The default Python build's unicode mode (until Python 3.3, when PEP 393 landed)
+# is UCS-2. However Ubuntu's system Python 2.7 is compiled in UCS-4 mode, so we
+# override the default for parity, and to avoid hard to debug unicode bugs. See:
+# https://github.com/heroku/heroku-buildpack-python/issues/305
+./configure --prefix=$OUT_PREFIX --with-ensurepip=no --enable-unicode=ucs4
+make
+make install

--- a/builds/runtimes/python-3.5.2
+++ b/builds/runtimes/python-3.5.2
@@ -3,11 +3,12 @@
 # Build Deps: libraries/sqlite
 
 OUT_PREFIX=$1
+VERSION="3.5.2"
 
-echo "Building Python..."
-SOURCE_TARBALL='https://python.org/ftp/python/3.5.2/Python-3.5.2.tgz'
+echo "Building Python ${VERSION}..."
+SOURCE_TARBALL="https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz"
 curl -L $SOURCE_TARBALL | tar xz
-mv Python-3.5.2 src
+mv "Python-${VERSION}" src
 cd src
 
 ./configure --prefix=$OUT_PREFIX --with-ensurepip=no
@@ -15,4 +16,3 @@ make
 make install
 
 # ln $OUT_PREFIX/bin/python3 $OUT_PREFIX/bin/python
-


### PR DESCRIPTION
**1) Clean up the latest Python 2.7 and 3.5 build scripts:**
- Switches to the canonical source tarball URL, to avoid the redirect
- Avoids the repetition of the version number & outputs it to console
- Whitespace cleanup

**2) Add a build script for Python 2.7.13 with UCS-4 Unicode support:**

The default Python build's unicode mode (until Python 3.3, when PEP 393 landed) is UCS-2. However Ubuntu's system Python 2.7 is compiled in UCS-4 mode. This new build script overrides the default for parity with system Python, and to avoid hard to debug unicode bugs.

Fixes #305.
