### PR TITLE
Upgrade to pip-9.0.1 and setuptools-28.8.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,8 +34,8 @@ LEGACY_TRIGGER="lib/python2.7"
 DEFAULT_PYTHON_VERSION="python-2.7.12"
 DEFAULT_PYTHON_STACK="cedar-14"
 PYTHON_EXE="/app/.heroku/python/bin/python"
-PIP_VERSION="8.1.2"
-SETUPTOOLS_VERSION="25.2.0"
+PIP_VERSION="9.0.1"
+SETUPTOOLS_VERSION="28.8.0"
 
 # Common Problem Warnings
 export WARNINGS_LOG=$(mktemp)


### PR DESCRIPTION
This would REQUIRE that the latest versions are placed into:
https://github.com/heroku/heroku-buildpack-python/tree/master/vendor

https://pypi.python.org/pypi/pip
https://pypi.python.org/pypi/setuptools