### PR TITLE
Don't compile static versions of geo-libraries

### DIFF
--- a/builds/libraries/vendor/gdal
+++ b/builds/libraries/vendor/gdal
@@ -15,7 +15,7 @@ SOURCE_TARBALL='http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz'
 curl -L $SOURCE_TARBALL | tar zx
 
 cd gdal-1.11.1
-./configure --prefix=$OUT_PREFIX  &&
+./configure --prefix=$OUT_PREFIX --enable-static=no  &&
 make
 make install
 

--- a/builds/libraries/vendor/geos
+++ b/builds/libraries/vendor/geos
@@ -15,7 +15,7 @@ SOURCE_TARBALL='http://download.osgeo.org/geos/geos-3.4.2.tar.bz2'
 curl -L $SOURCE_TARBALL | tar xj
 
 cd geos-3.4.2
-./configure --prefix=$OUT_PREFIX  &&
+./configure --prefix=$OUT_PREFIX --enable-static=no &&
 make
 make install
 

--- a/builds/libraries/vendor/proj
+++ b/builds/libraries/vendor/proj
@@ -15,7 +15,7 @@ SOURCE_TARBALL='http://download.osgeo.org/proj/proj-4.8.0.tar.gz'
 curl -L $SOURCE_TARBALL | tar zx
 
 cd proj-4.8.0
-./configure --prefix=$OUT_PREFIX  &&
+./configure --prefix=$OUT_PREFIX --enable-static=no &&
 make
 make install
 


### PR DESCRIPTION
python uses dynamic linking, and the static libraries use 200 MB of disk
space in the dynos.