### PR TITLE
Handle and produce leading 0 in WEB_CONCURRENCY

### DIFF
--- a/vendor/python.gunicorn.sh
+++ b/vendor/python.gunicorn.sh
@@ -1,29 +1,35 @@
+if [[ "${WEB_CONCURRENCY:-}" == 0* ]]; then
+  # another buildpack set a default value, with leading zero
+  unset WEB_CONCURRENCY
+fi
+
 case $(ulimit -u) in
 
 # Automatic configuration for Gunicorn's Workers setting.
+# Leading zero padding so a subsequent buildpack can figure out that we set a value, and not the user
 
 # Standard-1X (+Free, +Hobby) Dyno
 256)
   export DYNO_RAM=512
-  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-2}
+  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-02}
   ;;
 
 # Standard-2X Dyno
 512)
   export DYNO_RAM=1024
-  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-4}
+  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-04}
   ;;
 
 # Performance-M Dyno
 16384)
   export DYNO_RAM=2560
-  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-8}
+  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-08}
   ;;
 
 # Performance-L Dyno
 32768)
   export DYNO_RAM=6656
-  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-11}
+  export WEB_CONCURRENCY=${WEB_CONCURRENCY:-011}
   ;;
 
 esac


### PR DESCRIPTION
The Node buildpack now exports a leading zero in its numbers. This lets us detect that it (or another buildpack) set the value, and overwrite it accordingly.

Fixes the issue where adding the node buildpack to a Python app would cause only one gunicorn worker to be spawned for a 1X dyno, and not two.

We also need to again produce leading zeroes in the value, so that e.g. the PHP buildpack can do the same on boot.

/cc @hunterloftis 