### PR TITLE
PROPOSAL - call Django "manage.py migrate" in compile process

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -200,6 +200,9 @@ deep-cp /app/.heroku/src $BUILD_DIR/.heroku/src
 # Django collectstatic support.
 sub-env $BIN_DIR/steps/collectstatic
 
+# Django migrate support.
+sub-env $BIN_DIR/steps/django-migrate
+
 # Create .profile script for application runtime environment variables.
 set-env PATH '$HOME/.heroku/python/bin:$PATH'
 set-env PYTHONUNBUFFERED true

--- a/bin/django-utils
+++ b/bin/django-utils
@@ -1,0 +1,48 @@
+source $BIN_DIR/utils
+
+# Location of 'manage.py', if it exists.
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)
+MANAGE_FILE=${MANAGE_FILE:-fakepath}
+
+# Ensure that Django is explicitly specified in requirements.txt
+pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
+
+django-manage-command() {
+    set +e
+
+    puts-cmd "python $MANAGE_FILE $1 --noinput"
+
+    # Run command, cleanup some of the noisy output.
+    python $MANAGE_FILE $1 --noinput --traceback 2>&1 | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
+    COMMAND_STATUS="${PIPESTATUS[0]}"
+
+    set -e
+
+    # Display a warning if command failed.
+    [ $COMMAND_STATUS -ne 0 ] && {
+
+        echo
+        echo " !     Error while running '$ python $MANAGE_FILE $1 --noinput'."
+        echo "       See traceback above for details."
+        echo
+        echo "       You may need to update application code to resolve this error."
+        echo "       Or, you can disable migrate for this application:"
+        echo
+        echo "          $ heroku config:set $3=1"
+        echo
+        echo "       https://devcenter.heroku.com/articles/django-assets"
+
+        # Additionally, dump out the environment, if debug mode is on.
+        if [ "$2" ]; then
+            echo
+            echo "****** $1 environment variables:"
+            echo
+            env | indent
+        fi
+
+        # Abort the build.
+        exit 1
+    }
+
+    echo
+}

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -10,58 +10,15 @@
 #   - $DISABLE_COLLECTSTATIC: disables this functionality.
 #   - $DEBUG_COLLECTSTATIC: upon failure, print out environment variables.
 
-source $BIN_DIR/utils
-
-# Location of 'manage.py', if it exists.
-MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)
-MANAGE_FILE=${MANAGE_FILE:-fakepath}
+source $BIN_DIR/django-utils
 
 # Legacy file-based support for $DISABLE_COLLECTSTATIC
 [ -f .heroku/collectstatic_disabled ] && DISABLE_COLLECTSTATIC=1
 
-# Ensure that Django is explicitly specified in requirements.txt
-pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
-
 bpwatch start collectstatic  # metrics collection
 
 if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then
-    set +e
-
-    puts-cmd "python $MANAGE_FILE collectstatic --noinput"
-
-    # Run collectstatic, cleanup some of the noisy output.
-    python $MANAGE_FILE collectstatic --noinput --traceback 2>&1 | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
-    COLLECTSTATIC_STATUS="${PIPESTATUS[0]}"
-
-    set -e
-
-    # Display a warning if collectstatic failed.
-    [ $COLLECTSTATIC_STATUS -ne 0 ] && {
-
-        echo
-        echo " !     Error while running '$ python $MANAGE_FILE collectstatic --noinput'."
-        echo "       See traceback above for details."
-        echo
-        echo "       You may need to update application code to resolve this error."
-        echo "       Or, you can disable collectstatic for this application:"
-        echo
-        echo "          $ heroku config:set DISABLE_COLLECTSTATIC=1"
-        echo
-        echo "       https://devcenter.heroku.com/articles/django-assets"
-
-        # Additionally, dump out the environment, if debug mode is on.
-        if [ "$DEBUG_COLLECTSTATIC" ]; then
-            echo
-            echo "****** Collectstatic environment variables:"
-            echo
-            env | indent
-        fi
-
-        # Abort the build.
-        exit 1
-    }
-
-    echo
+    django-manage-command collectstatic $DEBUG_COLLECTSTATIC "DISABLE_COLLECTSTATIC"
 fi
 
 bpwatch stop collectstatic  # metrics collection

--- a/bin/steps/django-migrate
+++ b/bin/steps/django-migrate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Django Collectstatic runner. If you have Django installed, collectstatic will
-# automatically be executed as part of the build process. If collectstatic
+# Django migrate runner. If you have Django installed, migrate will
+# automatically be executed as part of the build process. If migrate
 # fails, your build fails.
 
 # This functionality will only activate if Django is in requirements.txt.
@@ -10,55 +10,12 @@
 #   - $DISABLE_DJANGOMIGRATE: disables this functionality.
 #   - $DEBUG_DJANGOMIGRATE: upon failure, print out environment variables.
 
-source $BIN_DIR/utils
-
-# Location of 'manage.py', if it exists.
-MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)
-MANAGE_FILE=${MANAGE_FILE:-fakepath}
-
-# Ensure that Django is explicitly specified in requirements.txt
-pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
+source $BIN_DIR/django-utils
 
 bpwatch start djangomigrate  # metrics collection
 
 if [ ! "$DISABLE_DJANGOMIGRATE" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then
-    set +e
-
-    puts-cmd "python $MANAGE_FILE migrate --noinput"
-
-    # Run collectstatic, cleanup some of the noisy output.
-    python $MANAGE_FILE migrate --noinput --traceback 2>&1 | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
-    MIGRATE_STATUS="${PIPESTATUS[0]}"
-
-    set -e
-
-    # Display a warning if collectstatic failed.
-    [ $MIGRATE_STATUS -ne 0 ] && {
-
-        echo
-        echo " !     Error while running '$ python $MANAGE_FILE migrate --noinput'."
-        echo "       See traceback above for details."
-        echo
-        echo "       You may need to update application code to resolve this error."
-        echo "       Or, you can disable migrate for this application:"
-        echo
-        echo "          $ heroku config:set DISABLE_DJANGOMIGRATE=1"
-        echo
-        echo "       https://devcenter.heroku.com/articles/django-assets"
-
-        # Additionally, dump out the environment, if debug mode is on.
-        if [ "$DEBUG_MIGRATE" ]; then
-            echo
-            echo "****** Collectstatic environment variables:"
-            echo
-            env | indent
-        fi
-
-        # Abort the build.
-        exit 1
-    }
-
-    echo
+    django-manage-command migrate $DEBUG_DJANGOMIGRATE "DISABLE_DJANGOMIGRATE"
 fi
 
 bpwatch stop djangomigrate  # metrics collection

--- a/bin/steps/django-migrate
+++ b/bin/steps/django-migrate
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Django Collectstatic runner. If you have Django installed, collectstatic will
+# automatically be executed as part of the build process. If collectstatic
+# fails, your build fails.
+
+# This functionality will only activate if Django is in requirements.txt.
+
+# Runtime arguments:
+#   - $DISABLE_DJANGOMIGRATE: disables this functionality.
+#   - $DEBUG_DJANGOMIGRATE: upon failure, print out environment variables.
+
+source $BIN_DIR/utils
+
+# Location of 'manage.py', if it exists.
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)
+MANAGE_FILE=${MANAGE_FILE:-fakepath}
+
+# Ensure that Django is explicitly specified in requirements.txt
+pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
+
+bpwatch start djangomigrate  # metrics collection
+
+if [ ! "$DISABLE_DJANGOMIGRATE" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then
+    set +e
+
+    puts-cmd "python $MANAGE_FILE migrate --noinput"
+
+    # Run collectstatic, cleanup some of the noisy output.
+    python $MANAGE_FILE migrate --noinput --traceback 2>&1 | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
+    MIGRATE_STATUS="${PIPESTATUS[0]}"
+
+    set -e
+
+    # Display a warning if collectstatic failed.
+    [ $MIGRATE_STATUS -ne 0 ] && {
+
+        echo
+        echo " !     Error while running '$ python $MANAGE_FILE migrate --noinput'."
+        echo "       See traceback above for details."
+        echo
+        echo "       You may need to update application code to resolve this error."
+        echo "       Or, you can disable migrate for this application:"
+        echo
+        echo "          $ heroku config:set DISABLE_DJANGOMIGRATE=1"
+        echo
+        echo "       https://devcenter.heroku.com/articles/django-assets"
+
+        # Additionally, dump out the environment, if debug mode is on.
+        if [ "$DEBUG_MIGRATE" ]; then
+            echo
+            echo "****** Collectstatic environment variables:"
+            echo
+            env | indent
+        fi
+
+        # Abort the build.
+        exit 1
+    }
+
+    echo
+fi
+
+bpwatch stop djangomigrate  # metrics collection


### PR DESCRIPTION
I think it's useful for deploy pipeline with migrations (instead of run `migrate` command after deploy with `heroku run`  command)