### PR TITLE
Add PyPy 5.7.0

### DIFF
--- a/builds/runtimes/pypy-5.7.0
+++ b/builds/runtimes/pypy-5.7.0
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+# Build Deps: libraries/sqlite
+
+# NOTICE: This formula only works for the cedar-14 stack, not cedar.
+
+OUT_PREFIX=$1
+
+echo "Building PyPy..."
+SOURCE_TARBALL='https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux64.tar.bz2'
+curl -L $SOURCE_TARBALL | tar jx
+cp -R pypy2-v5.7.0-linux64/* $OUT_PREFIX
+
+ln $OUT_PREFIX/bin/pypy $OUT_PREFIX/bin/python

--- a/builds/runtimes/pypy3-5.7.0
+++ b/builds/runtimes/pypy3-5.7.0
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+# Build Deps: libraries/sqlite
+
+# NOTICE: This formula only works for the cedar-14 stack, not cedar.
+
+OUT_PREFIX=$1
+
+echo "Building PyPy..."
+SOURCE_TARBALL='https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-linux64.tar.bz2'
+curl -L $SOURCE_TARBALL | tar jx
+cp -R pypy3-v5.7.0-linux64/* $OUT_PREFIX
+
+ln $OUT_PREFIX/bin/pypy3 $OUT_PREFIX/bin/python


### PR DESCRIPTION
This release updates the pypy2 stdlib to 2.7.13 and the pypy3 stdlib to 3.5.3

https://morepypy.blogspot.com/2017/03/pypy27-and-pypy35-v57-two-in-one-release.html