### PR TITLE
Update pipenv to remove broken option.

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -5,6 +5,6 @@ if [[ -f Pipfile ]]; then
 
         /app/.heroku/python/bin/pip install pipenv --upgrade &> /dev/null
 
-        /app/.heroku/python/bin/pipenv lock --requirements --no-hashes > $BUILD_DIR/requirements.txt 2> /dev/null
+        /app/.heroku/python/bin/pipenv lock --requirements > $BUILD_DIR/requirements.txt 2> /dev/null
     fi
 fi


### PR DESCRIPTION
In pipenv 4.0.0, `--no-dashes` is removed and causes the command to fail:

```
$ pipenv lock --requirements --no-hashes
Error: no such option: --no-hashes
```

As far as I can tell, this breaks all heroku deployments that use pipenv since there's no way to specify a version of pipenv.  Removing the flag will presumably fix this.