### PR TITLE
Make assertCapturedSuccess display stdout if stderr was empty

### DIFF
--- a/test/utils
+++ b/test/utils
@@ -93,8 +93,14 @@ assertNotCaptured()
 
 assertCapturedSuccess()
 {
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
-  assertEquals "Expected STD_ERR to be empty; was <$(cat ${STD_ERR})>" "" "$(cat ${STD_ERR})"
+  assertEquals "Captured exit code -" "0" "${RETURN}"
+  assertEquals "STD_ERR -" "" "$(cat ${STD_ERR})"
+
+  if [ $RETURN -ne 0 -a -z "$(cat ${STD_ERR})" ]; then
+    # Failing exit code but stderr was empty. Display stdout to help debugging.
+    cat $STD_OUT
+    echo
+  fi
 }
 
 # assertCapturedError [[expectedErrorCode] expectedErrorMsg]


### PR DESCRIPTION
In cases where there is no stderr there was previously no output, which made it hard to find the cause. The assertion messages have also been adjusted to remove the repetition (shunit2 already outputs expected vs actual itself).

Before:
```
testPipenv
ASSERT:Expected captured exit code to be 0; was <2> expected:<0> but was:<2>
testPipenvVersion
```

After:
```
testPipenv
ASSERT:Captured exit code - expected:<0> but was:<2>
 !     Warning: Your application is missing a Procfile. This file tells Heroku how to run your application.
 !     Learn more: https://devcenter.heroku.com/articles/procfile
-----> Installing python-2.7.13
-----> Installing pip
-----> Generating 'requirements.txt' with pipenv

testPipenvVersion
```

Fixes #389.