### PR TITLE
use pkg_resources to check for distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Python Buildpack Changelog
 
+# 104
+
+unreleased
+
+- Use `pkg_resources` to check if a distribution is installed instead of
+  parsing `requirements.txt`. ([#395][395])
+
+[395]: https://github.com/heroku/heroku-buildpack-python/pull/395
+
 ## 103
 
 Bug fixes and improvements.

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -20,7 +20,7 @@ MANAGE_FILE=${MANAGE_FILE:-fakepath}
 [ -f .heroku/collectstatic_disabled ] && DISABLE_COLLECTSTATIC=1
 
 # Ensure that Django is explicitly specified in requirements.txt
-pip-grep -s requirements.txt django Django && DJANGO_INSTALLED=1
+pip-grep -s Django && DJANGO_INSTALLED=1
 
 
 if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then

--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -18,7 +18,7 @@ PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 source $BIN_DIR/utils
 
 # If a package using cffi exists within requirements, use vendored libffi.
-if (pip-grep -s requirements.txt argon2-cffi bcrypt cffi cryptography django[argon2] Django[argon2] django[bcrypt] Django[bcrypt] PyNaCl pyOpenSSL PyOpenSSL requests[security] misaka &> /dev/null) then
+if (pip-grep -s argon2-cffi bcrypt cffi cryptography PyNaCl pyOpenSSL PyOpenSSL misaka &> /dev/null) then
 
   if [ ! -d ".heroku/vendor/lib/libffi-3.1" ]; then
     echo "-----> Noticed cffi. Bootstrapping libffi."

--- a/bin/steps/gdal
+++ b/bin/steps/gdal
@@ -18,7 +18,7 @@ PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 source $BIN_DIR/utils
 
 # If GDAL exists within requirements, use vendored gdal.
-if (pip-grep -s requirements.txt GDAL gdal pygdal &> /dev/null) then
+if (pip-grep -s GDAL pygdal &> /dev/null) then
 
   if [ ! -f ".heroku/vendor/bin/gdalserver" ]; then
     echo "-----> Noticed GDAL. Bootstrapping gdal."

--- a/bin/steps/pylibmc
+++ b/bin/steps/pylibmc
@@ -17,7 +17,7 @@ source $BIN_DIR/utils
 
 
 # If pylibmc exists within requirements, use vendored libmemcached.
-if (pip-grep -s requirements.txt pylibmc &> /dev/null) then
+if (pip-grep -s pylibmc &> /dev/null) then
 
   if [ ! -d ".heroku/vendor/lib/sasl2" ]; then
     echo "-----> Noticed pylibmc. Bootstrapping libmemcached."

--- a/bin/steps/setuptools
+++ b/bin/steps/setuptools
@@ -3,7 +3,7 @@
 # Syntax sugar.
 source $BIN_DIR/utils
 
-if (pip-grep -s requirements.txt setuptools distribute &> /dev/null) then
+if (pip-grep -s setuptools distribute &> /dev/null) then
 
   puts-warn 'The package setuptools/distribute is listed in requirements.txt.'
   puts-warn 'Please remove to ensure expected behavior. '

--- a/vendor/pip-pop/pip-grep
+++ b/vendor/pip-pop/pip-grep
@@ -2,58 +2,26 @@
 # -*- coding: utf-8 -*-
 
 """Usage:
-  pip-grep [-s] <reqfile> <package>...
+  pip-grep [-s] <package>...
 
 Options:
   -h --help     Show this screen.
 """
-import os
 from docopt import docopt
-from pip.req import parse_requirements
-from pip.index import PackageFinder
-from pip._vendor.requests import session
-
-requests = session()
+from pkg_resources import DistributionNotFound, get_distribution
 
 
-class Requirements(object):
-    def __init__(self, reqfile=None):
-        super(Requirements, self).__init__()
-        self.path = reqfile
-        self.requirements = []
+def has_any_distribution(names, silent=False):
+    for name in names:
+        try:
+            get_distribution(name)
+        except DistributionNotFound:
+            continue
 
-        if reqfile:
-            self.load(reqfile)
-
-    def __repr__(self):
-        return '<Requirements \'{}\'>'.format(self.path)
-
-    def load(self, reqfile):
-        if not os.path.exists(reqfile):
-            raise ValueError('The given requirements file does not exist.')
-
-        finder = PackageFinder([], [], session=requests)
-        for requirement in parse_requirements(reqfile, finder=finder, session=requests):
-            if requirement.req:
-                if not getattr(requirement.req, 'name', None):
-                    # Prior to pip 8.1.2 the attribute `name` did not exist.
-                    requirement.req.name = requirement.req.project_name
-                self.requirements.append(requirement.req)
-
-
-def grep(reqfile, packages, silent=False):
-    try:
-        r = Requirements(reqfile)
-    except ValueError:
         if not silent:
-            print('There was a problem loading the given requirement file.')
-        exit(os.EX_NOINPUT)
+            print('Package {name} found!'.format(name=name))
 
-    for req in r.requirements:
-        if req.name in packages:
-            if not silent:
-                print('Package {} found!'.format(req.name))
-            exit(0)
+        exit(0)
 
     if not silent:
         print('Not found.')
@@ -63,10 +31,7 @@ def grep(reqfile, packages, silent=False):
 
 def main():
     args = docopt(__doc__, version='pip-grep')
-
-    kwargs = {'reqfile': args['<reqfile>'], 'packages': args['<package>'], 'silent': args['-s']}
-
-    grep(**kwargs)
+    has_any_distribution(names=args['<package>'], silent=args['-s'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This changes the implementation of `pip-grep` to use `pkg_resources.get_distribution` instead of parsing `requirements.txt` manually. This makes the buildpack more accurate for some project configurations.

This change is backwards compatible, scripts calling this with a requirements file will continue to work, since "requirements.txt" is not a package.

fixes #359