### PR TITLE
Fix pip uninstall by moving it prior to pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Python Buildpack Changelog
 
+# Unreleased
+
+Fixed automatic pip uninstall of dependencies removed from requirements.txt.
+
 # 109
 
 Fix output for collectstatic step.

--- a/bin/compile
+++ b/bin/compile
@@ -170,15 +170,15 @@ sub-env $BIN_DIR/steps/geo-libs
 # GDAL support.
 source $BIN_DIR/steps/gdal
 
-# Install dependencies with Pip (where the magic happens).
-let start=$(nowms)
-source $BIN_DIR/steps/pip-install
-mtime "pip.install.time" "${start}"
-
 # Uninstall removed dependencies with Pip.
 let start=$(nowms)
 source $BIN_DIR/steps/pip-uninstall
 mtime "pip.uninstall.time" "${start}"
+
+# Install dependencies with Pip (where the magic happens).
+let start=$(nowms)
+source $BIN_DIR/steps/pip-install
+mtime "pip.install.time" "${start}"
 
 # Support for NLTK corpora.
 let start=$(nowms)

--- a/test/run
+++ b/test/run
@@ -62,6 +62,16 @@ testPython3() {
   assertCapturedSuccess
 }
 
+testSmartRequirements() {
+  local cache_dir="$(mktmpdir)"
+  compile "requirements-standard" "$cache_dir"
+  assertFile "requests" ".heroku/python/requirements-declared.txt"
+  assertCapturedSuccess
+  compile "psycopg2" "$cache_dir"
+  assertCaptured "Uninstalling requests"
+  assertFile "psycopg2" ".heroku/python/requirements-declared.txt"
+  assertCapturedSuccess
+}
 
 
 


### PR DESCRIPTION
The pip-uninstall step stopped working when it was moved to after the pip-install step in f27a84e.

This regression was temporarily fixed by part of #397, however that PR was reverted in #404.

Adds a test to hopefully catch any future regressions :-)

Fixes #393.