### PR TITLE
Exclude Python's test suite from generated Python archives

### DIFF
--- a/builds/runtimes/python-2.7.13
+++ b/builds/runtimes/python-2.7.13
@@ -13,3 +13,7 @@ cd src
 ./configure --prefix=$OUT_PREFIX  --enable-unicode=ucs4 --with-ensurepip=no
 make
 make install
+
+# Remove unneeded test directories, similar to the official Docker Python images:
+# https://github.com/docker-library/python
+find "${OUT_PREFIX}" \( -type d -a \( -name test -o -name tests \) \) -exec rm -rf '{}' +

--- a/builds/runtimes/python-3.6.2
+++ b/builds/runtimes/python-3.6.2
@@ -14,5 +14,8 @@ cd src
 make
 make install
 
-ln $OUT_PREFIX/bin/python3 $OUT_PREFIX/bin/python
+# Remove unneeded test directories, similar to the official Docker Python images:
+# https://github.com/docker-library/python
+find "${OUT_PREFIX}" \( -type d -a \( -name test -o -name tests \) \) -exec rm -rf '{}' +
 
+ln $OUT_PREFIX/bin/python3 $OUT_PREFIX/bin/python


### PR DESCRIPTION
This copies the official Docker Python images approach of stripping the Python test suite after building from source.

For Python 3.6.2 this reduces the output from 184MB to 121MB and removes the following directories:
```
.heroku/python/lib/python3.6/tkinter/test
.heroku/python/lib/python3.6/ctypes/test
.heroku/python/lib/python3.6/unittest/test
.heroku/python/lib/python3.6/distutils/tests
.heroku/python/lib/python3.6/sqlite3/test
.heroku/python/lib/python3.6/lib2to3/tests
.heroku/python/lib/python3.6/test
```

For Python 2.7.13 this reduces the output from 127MB to 91MB and removes the following directories:
```
.heroku/python/lib/python2.7/ctypes/test
.heroku/python/lib/python2.7/unittest/test
.heroku/python/lib/python2.7/distutils/tests
.heroku/python/lib/python2.7/bsddb/test
.heroku/python/lib/python2.7/lib-tk/test
.heroku/python/lib/python2.7/sqlite3/test
.heroku/python/lib/python2.7/lib2to3/tests
.heroku/python/lib/python2.7/json/tests
.heroku/python/lib/python2.7/email/test
.heroku/python/lib/python2.7/test
```

Fixes #424.