### PR TITLE
Update GDAL version to 1.11.5

### DIFF
--- a/builds/libraries/vendor/gdal
+++ b/builds/libraries/vendor/gdal
@@ -15,10 +15,10 @@ SOURCE_TARBALL="http://download.osgeo.org/gdal/${VERSION}/gdal-${VERSION}.tar.gz
 
 curl -L $SOURCE_TARBALL | tar zx
 
-cd gdal-${VERSION}
+pushd "gdal-${VERSION}"
 ./configure --prefix=$OUT_PREFIX --enable-static=no  &&
 make
 make install
 
 # Cleanup
-cd ..
+popd

--- a/builds/libraries/vendor/gdal
+++ b/builds/libraries/vendor/gdal
@@ -10,11 +10,12 @@ hash -r
 
 echo "Building gdal..."
 
-SOURCE_TARBALL='http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz'
+VERSION="1.11.5"
+SOURCE_TARBALL="http://download.osgeo.org/gdal/${VERSION}/gdal-${VERSION}.tar.gz"
 
 curl -L $SOURCE_TARBALL | tar zx
 
-cd gdal-1.11.1
+cd gdal-${VERSION}
 ./configure --prefix=$OUT_PREFIX --enable-static=no  &&
 make
 make install


### PR DESCRIPTION
Update GDAL to latest bugfix release, see
http://trac.osgeo.org/gdal/wiki/Release/1.11.5-News

Fixes #428 
Fixes #398 

```
$ bob build libraries/vendor/gdal
...
Build complete: /app/.heroku/vendor/
```


### TODO:

- [ ] Compile for `cedar-14`
- [ ] Compile for `heroku-16`