### PR TITLE
Improve UX when clearing cache due to the stack changing

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -4,7 +4,11 @@ set +e
 runtime-fixer runtime.txt
 PYTHON_VERSION=$(cat runtime.txt)
 
-# Install Python.
+if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
+    puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
+    rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor
+fi
+
 if [ -f .heroku/python-version ]; then
   if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
       puts-step "Found $(cat .heroku/python-version), removing"
@@ -13,12 +17,6 @@ if [ -f .heroku/python-version ]; then
     SKIP_INSTALL=1
   fi
 fi
-
-if [ ! "$STACK" = "$CACHED_PYTHON_STACK" ]; then
-    rm -fr .heroku/python .heroku/python-stack .heroku/vendor
-    unset SKIP_INSTALL
-fi
-
 
 if [ ! "$SKIP_INSTALL" ]; then
     puts-step "Installing $PYTHON_VERSION"

--- a/test/run
+++ b/test/run
@@ -76,6 +76,14 @@ testSmartRequirements() {
   assertCapturedSuccess
 }
 
+testStackChange() {
+  local cache_dir="$(mktmpdir)"
+  mkdir -p "${cache_dir}/.heroku"
+  echo "different-stack" > "${cache_dir}/.heroku/python-stack"
+  compile "requirements-standard" "$cache_dir"
+  assertFile "$STACK" ".heroku/python-stack"
+  assertCapturedSuccess
+}
 
 
 pushd $(dirname 0) >/dev/null

--- a/test/run
+++ b/test/run
@@ -81,6 +81,7 @@ testStackChange() {
   mkdir -p "${cache_dir}/.heroku"
   echo "different-stack" > "${cache_dir}/.heroku/python-stack"
   compile "requirements-standard" "$cache_dir"
+  assertCaptured "clearing cache"
   assertFile "$STACK" ".heroku/python-stack"
   assertCapturedSuccess
 }


### PR DESCRIPTION
**1) Adds a test to check that the cache is invalidated when the stack changes.**

**2) Improves the UX when clearing cache due to the stack changing.**
Now outputs a message informing that the cache was cleared, and clears the cache first to avoid a redundant message about removing an old Python version.


