### PR TITLE
Speed up the multi-stage Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
 language: bash
-# sudo: required
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
-    packages:
-    - shellcheck
-services:
-  - docker
-# install: docker pull heroku/cedar:14
+dist: trusty
 jobs:
   include:
     - stage: "Bash linting (shellcheck)"
+      sudo: false
+      addons:
+        apt:
+          sources:
+          - debian-sid    # Grab shellcheck from the Debian repo (o_O)
+          packages:
+          - shellcheck
       script: make check
 
-    - stage: "Heroku-16 Stack Tests"
+    - stage: "Stack Tests"
+      services: docker
+      env: STACK=heroku-16
       script: ./tests.sh
-      env:
-        - STACK=heroku-16
 
-    - stage: "Cedar-14 Stack Tests"
+    - stage: "Stack Tests"
+      services: docker
+      env: STACK=cedar-14
       script: ./tests.sh
-      env:
-        - STACK=cedar-14


### PR DESCRIPTION
Reduces the impact on Travis runtime caused by #438, by:
* Making the shellcheck job run on the container infra (`sudo: false`) which has faster boot times.
* Running the heroku-16 and cedar-14 stack tests in parallel, since previously they were separate stages (which are run in series by design).

Reduces Travis end-to-end time from ~10 minutes to ~6 minutes.