### PR TITLE
NLTK support: Fix passing of multiple corpora identifiers

### DIFF
--- a/bin/steps/nltk
+++ b/bin/steps/nltk
@@ -21,10 +21,10 @@ if sp-grep -s nltk; then
 
     if [ -f "$nltk_packages_definition" ]; then
 
-        nltk_packages=$(tr "\n" " " < "$nltk_packages_definition")
-        puts-step "Downloading NLTK packages: $nltk_packages"
+        readarray -t nltk_packages < "$nltk_packages_definition"
+        puts-step "Downloading NLTK packages: ${nltk_packages[*]}"
 
-        python -m nltk.downloader -d "$BUILD_DIR/.heroku/python/nltk_data" "$nltk_packages"  | indent
+        python -m nltk.downloader -d "$BUILD_DIR/.heroku/python/nltk_data" "${nltk_packages[@]}" | indent
         set_env NLTK_DATA "/app/.heroku/python/nltk_data"
 
     else
@@ -32,4 +32,3 @@ if sp-grep -s nltk; then
         puts-warn "Learn more: https://devcenter.heroku.com/articles/python-nltk"
     fi
 fi
-

--- a/test/fixtures/nltk/nltk.txt
+++ b/test/fixtures/nltk/nltk.txt
@@ -1,1 +1,2 @@
-wordnet
+city_database
+stopwords

--- a/test/run
+++ b/test/run
@@ -24,7 +24,7 @@ testGEOS() {
 
 testNLTK() {
   compile "nltk"
-  assertCaptured "wordnet"
+  assertCaptured "Downloading NLTK packages: city_database stopwords"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
**1) Update NLTK test to use multiple corpora**
So that the incorrect handling of multiple IDs seen in #444 would have been caught. Also switches to some of the smaller corpora, to reduce time spent downloading during tests (see sizes on http://www.nltk.org/nltk_data/).

Example failing CI job with the updated test but without the fix below:
https://travis-ci.org/edmorley/heroku-buildpack-python/builds/271986505

**2) Fix passing of multiple NLTK corpora identifiers**
As part of fixing the shellcheck warnings in #438, double quotes had been placed around `$nltk_packages` passed to the `nltk.downloader`, which causes multiple identifiers to be treated as though it were just one identifier that contains spaces - which results in the downloader failing to find them.

The docs for the shellcheck warning in question recommend using arrays if the intended behaviour really is to split on spaces:
https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions

As such, `readarray` has been used, which is present in bash >=4.

The `[*]` array form is used in the log message, to prevent shellcheck warning [SC2145](https://github.com/koalaman/shellcheck/wiki/SC2145), whereas `[@]` is used when passed to `nltk.downloader` to ensure the array elements are unpacked as required.

Note: Both before and after this fix, using anything but unix line endings in `nltk.txt` will also cause breakage. I'm happy to add a fix for that too if Windows CRLF line endings are something that should be supported.

Fixes #444.