### PR TITLE
Tests: Make assertCaptured test failures easier to debug

### DIFF
--- a/test/utils
+++ b/test/utils
@@ -150,6 +150,11 @@ _assertContains()
     esac
 
     fail "${msg:-${default_msg}}"
+
+    if [ "${haystack_type}" == "file" ]; then
+      echo
+      cat "${haystack}"
+    fi
   fi
 }
 


### PR DESCRIPTION
Previously the contents of the file being searched was not output, making it hard to know how to fix a test so that it would pass.

Before:
```bash
$ make test-heroku-16
...
testCffi
ASSERT:Expected </tmp/shunit.ayVGAO/tmp/output.6gMs/stdout> to contain <ZZZZZZZ>
testPylibmc
```

After:
```bash
$ make test-heroku-16
...
testCffi
ASSERT:Expected </tmp/shunit.FXWeuI/tmp/output.7Vfx/stdout> to contain <ZZZZZZZ>
 !     Warning: Your application is missing a Procfile. This file tells Heroku how to run your application.
 !     Learn more: https://devcenter.heroku.com/articles/procfile
-----> Installing python-3.6.2
-----> Installing pip
-----> Installing requirements with pip
       Collecting cffi (from -r /tmp/testBoLG0/requirements.txt (line 1))
         Downloading cffi-1.10.0-cp36-cp36m-manylinux1_x86_64.whl (406kB)
       Collecting pycparser (from cffi->-r /tmp/testBoLG0/requirements.txt (line 1))
         Downloading pycparser-2.18.tar.gz (245kB)
       Installing collected packages: pycparser, cffi
         Running setup.py install for pycparser: started
           Running setup.py install for pycparser: finished with status 'done'
       Successfully installed cffi-1.10.0 pycparser-2.18

testPylibmc
```