### PR TITLE
Correct changelog entries for v108, v109 and v110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,17 +28,17 @@ Linting, bugfixes.
 
 # 110
 
+Update default Python to 3.6.2.
+
+# 109
+
 Update Default Python to 3.6.1, bugfixes.
 
 - Fixed automatic pip uninstall of dependencies removed from requirements.txt.
 
-# 109
-
-Fix output for collectstatic step.
-
 # 108
 
-Updated setuptools.
+Fix output for collectstatic step.
 
 # 107
 


### PR DESCRIPTION
Found by diffing the published buildpack archives and looking at the git log to see what changed, as part of trying to work out the correct git refs for #448.

It looks like the v108 entry was accidentally added in #405, when the release being published there was actually v107. The setuptools update mentioned never happened, since the `SETUPTOOLS_VERSION` variable was found to be unused and instead removed.