### PR TITLE
Allow pipenv version override

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -3,10 +3,15 @@
 # Pipenv support (Generate requriements.txt with pipenv).
 if [[ -f Pipfile ]]; then
     if [[ ! -f requirements.txt ]]; then
-        puts-step "Installing requirements with latest pipenv..."
 
         # Install pipenv.
-        /app/.heroku/python/bin/pip install pipenv --upgrade &> /dev/null
+        if [[ -v PIPENV_VERSION ]]; then
+            puts-step "Installing requirements with pipenv ${PIPENV_VERSION}..."
+            /app/.heroku/python/bin/pip install pipenv=="${PIPENV_VERSION}" &> /dev/null
+        else
+            puts-step "Installing requirements with latest pipenv..."
+            /app/.heroku/python/bin/pip install pipenv --upgrade &> /dev/null
+        fi
 
         # Install the dependencies.
         /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent


### PR DESCRIPTION
My Django app started failing to deploy today:

```
-----> Python app detected
-----> Running pre-compile hook
-----> Installing python-3.6.1
-----> Installing pip
-----> Installing requirements with latest pipenv...
       No package provided, installing all dependencies.
       Installing dependencies from Pipfile.lock…
-----> Running post-compile hook
-----> Collecting static files...
       Traceback (most recent call last):
         File "manage.py", line 6, in <module>
           from django.core.management import execute_from_command_line
       ModuleNotFoundError: No module named 'django'
 !     Push rejected, failed to compile Python app.
 !     Push failed
```

At least while pipenv is under rapid development, I think there should be an option to disable the `--upgrade` option when pipenv is installed during builds.

