### PR TITLE
Fix #398 -- Set explict GDAL and GEOS location

### DIFF
--- a/bin/steps/geo-libs
+++ b/bin/steps/geo-libs
@@ -40,5 +40,10 @@ if [[ "$BUILD_WITH_GEO_LIBRARIES" ]]; then
 
   GDAL=$(pwd)/vendor
   export GDAL
+  # set path for post_compile hooks
+  export GDAL_LIBRARY_PATH="$BUILD_DIR/.heroku/vendor/lib/libgdal.so"
+  export GEOS_LIBRARY_PATH="$BUILD_DIR/.heroku/vendor/lib/libgeos_c.so"
+  # set path for runtime environmeht
+  set_env GDAL_LIBRARY_PATH "/app/.heroku/vendor/lib/libgdal.so"
+  set_env GEOS_LIBRARY_PATH "/app/.heroku/vendor/lib/libgeos_c.so"
 fi
-


### PR DESCRIPTION
Set GDAL and GEOS library locaiton explicitly in environment
variables:

*   `GDAL_LIBRARY_PATH="/app/.heroku/vendor/lib/libgdal.so"`
*   `GEOS_LIBRARY_PATH="/app/.heroku/vendor/lib/libgeos_c.so"`

Django has to settings with the same name. The setup now works as
described here:
https://devcenter.heroku.com/articles/postgis#geodjango-setup