### PR TITLE
Output the found Python version when restoring from cache

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -25,11 +25,13 @@ if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
 fi
 
 if [ -f .heroku/python-version ]; then
-  if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
-      puts-step "Found $(cat .heroku/python-version), removing"
-      rm -fr .heroku/python
+  CACHED_PYTHON_VERSION="$(cat .heroku/python-version)"
+  if [[ "${CACHED_PYTHON_VERSION}" = "${PYTHON_VERSION}" ]]; then
+      puts-step "Using cached ${PYTHON_VERSION}"
+      SKIP_INSTALL=1
   else
-    SKIP_INSTALL=1
+      puts-step "Removing cached ${CACHED_PYTHON_VERSION}"
+      rm -fr .heroku/python
   fi
 fi
 

--- a/test/run
+++ b/test/run
@@ -88,8 +88,19 @@ testSmartRequirements() {
   assertFile "requests" ".heroku/python/requirements-declared.txt"
   assertCapturedSuccess
   compile "psycopg2" "$cache_dir"
+  assertCaptured "Using cached python-"
   assertCaptured "Uninstalling requests"
   assertFile "psycopg2" ".heroku/python/requirements-declared.txt"
+  assertCapturedSuccess
+}
+
+testPythonVersionChange() {
+  local cache_dir="$(mktmpdir)"
+  mkdir -p "${cache_dir}/.heroku"
+  echo "python-2.7.9" > "${cache_dir}/.heroku/python-version"
+  compile "python2" "$cache_dir"
+  assertCaptured "Removing cached python-2.7.9"
+  assertCaptured "Installing python-2.7.14"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This makes it clearer which Python version is in use (for people who are not pinning via `runtime.txt`), plus that a cache is being used (for people debugging and wondering why their eg review app has different behaviour from an existing app).

Also:
* makes the conditional clearer by inverting to avoid the negation
* avoids the duplicated `cat .heroku/python-version`
* uses bash quoting and test `[[` best practices
* adds a test for the Python version changing (previously untested)

Refs #453.