### PR TITLE
Make gunicorn default access log to stdout

### DIFF
--- a/vendor/python.gunicorn.sh
+++ b/vendor/python.gunicorn.sh
@@ -1,3 +1,5 @@
 # Automatic configuration for Gunicorn's ForwardedAllowIPS setting.
 export FORWARDED_ALLOW_IPS='*'
+
+# Automatic configuration for Gunicorn's stdout access log setting.
 export GUNICORN_CMD_ARGS="--access-logfile -"

--- a/vendor/python.gunicorn.sh
+++ b/vendor/python.gunicorn.sh
@@ -1,2 +1,3 @@
 # Automatic configuration for Gunicorn's ForwardedAllowIPS setting.
 export FORWARDED_ALLOW_IPS='*'
+export GUNICORN_CMD_ARGS="--access-logfile -"


### PR DESCRIPTION
This pull request allows gunicorn to log to stdout for all incoming requests, which it does not by default.

This was not previously an option.