### PR TITLE
Fix some Bash issues

### DIFF
--- a/test/shunit2
+++ b/test/shunit2
@@ -25,9 +25,9 @@ SHUNIT_ERROR=2
 # enable strict mode by default
 SHUNIT_STRICT=${SHUNIT_STRICT:-${SHUNIT_TRUE}}
 
-_shunit_warn() { echo "shunit2:WARN $@" >&2; }
-_shunit_error() { echo "shunit2:ERROR $@" >&2; }
-_shunit_fatal() { echo "shunit2:FATAL $@" >&2; exit ${SHUNIT_ERROR}; }
+_shunit_warn() { echo "shunit2:WARN $*" >&2; }
+_shunit_error() { echo "shunit2:ERROR $*" >&2; }
+_shunit_fatal() { echo "shunit2:FATAL $*" >&2; exit ${SHUNIT_ERROR}; }
 
 # specific shell checks
 if [ -n "${ZSH_VERSION:-}" ]; then

--- a/test/utils
+++ b/test/utils
@@ -36,7 +36,7 @@ capture()
 
   LAST_COMMAND="$@"
 
-  $@ >${STD_OUT} 2>${STD_ERR}
+  "$@" >${STD_OUT} 2>${STD_ERR}
   RETURN=$?
   rtrn=${RETURN} # deprecated
 }

--- a/vendor/shunit2
+++ b/vendor/shunit2
@@ -25,9 +25,9 @@ SHUNIT_ERROR=2
 # enable strict mode by default
 SHUNIT_STRICT=${SHUNIT_STRICT:-${SHUNIT_TRUE}}
 
-_shunit_warn() { echo "shunit2:WARN $@" >&2; }
-_shunit_error() { echo "shunit2:ERROR $@" >&2; }
-_shunit_fatal() { echo "shunit2:FATAL $@" >&2; exit ${SHUNIT_ERROR}; }
+_shunit_warn() { echo "shunit2:WARN $*" >&2; }
+_shunit_error() { echo "shunit2:ERROR $*" >&2; }
+_shunit_fatal() { echo "shunit2:FATAL $*" >&2; exit ${SHUNIT_ERROR}; }
 
 # specific shell checks
 if [ -n "${ZSH_VERSION:-}" ]; then

--- a/vendor/test-utils
+++ b/vendor/test-utils
@@ -36,7 +36,7 @@ capture()
 
   LAST_COMMAND="$@"
 
-  $@ >${STD_OUT} 2>${STD_ERR}
+  "$@" >${STD_OUT} 2>${STD_ERR}
   RETURN=$?
   rtrn=${RETURN} # deprecated
 }


### PR DESCRIPTION
Argument mixes string and array. Use `*` or separate argument.
Assigning an array to a string! Assign as array, or use `*` instead of `@` to concatenate.
Double quote array expansions, otherwise they're like `$*` and break on spaces.