### PR TITLE
Fix PYTHONPATH is not set when running collectstatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Python Buildpack Changelog
 
+# 125
+
+Set `PYTHONHOME` during collectstatic runs.
+
 # 124
 
 Update buildpack to automatically install [dev-packages] (Pipenv) during Heroku CI builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 125
 
-Set `PYTHONHOME` during collectstatic runs.
+Set `PYTHONPATH` during collectstatic runs.
 
 # 124
 

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -30,6 +30,7 @@ if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALL
     puts-step "$ python $MANAGE_FILE collectstatic --noinput"
 
     # Run collectstatic, cleanup some of the noisy output.
+    export PYTHONPATH=.
     python "$MANAGE_FILE" collectstatic --noinput --traceback 2>&1 | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
     COLLECTSTATIC_STATUS="${PIPESTATUS[0]}"
 


### PR DESCRIPTION
In command ```bin/steps/collectstatic```, PYTHONPATH is not set.

If manage.py file is not located at root folder but in the subfolder of a project and if ```import some_module_in_project``` is called in ```manage.py```, ```python somefolder/manage.py collectstatic --noinput``` will raise ```can not find module``` error. This is due to ```PYTHONPATH``` is not set for root folder and python can not import project's own module.