### PR TITLE
Add support for PIP_EXTRA_INDEX_URL

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -8,6 +8,12 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     # Install dependencies with Pip.
     puts-step "Installing requirements with pip"
 
+    # Set PIP_EXTRA_INDEX_URL
+    if [[ -r $ENV_DIR/PIP_EXTRA_INDEX_URL ]]; then
+        PIP_EXTRA_INDEX_URL="$(cat "$ENV_DIR/PIP_EXTRA_INDEX_URL")"
+        export PIP_EXTRA_INDEX_URL
+    fi
+
     set +e
     
     # Measure that we're using pip.

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -13,6 +13,12 @@ if [[ -f Pipfile ]]; then
         # Measure that we're using Pipenv.
         mcount "tool.pipenv"
 
+        # Set PIP_EXTRA_INDEX_URL
+        if [[ -r $ENV_DIR/PIP_EXTRA_INDEX_URL ]]; then
+            PIP_EXTRA_INDEX_URL="$(cat "$ENV_DIR/PIP_EXTRA_INDEX_URL")"
+            export PIP_EXTRA_INDEX_URL
+        fi
+
         # Install pipenv.
         /app/.heroku/python/bin/pip install pipenv --upgrade &> /dev/null
 


### PR DESCRIPTION
Akin to #363 but exports only `PIP_EXTRA_INDEX_URL` so users don't have to store possibly sensitive extra index URL in their repository code.