### PR TITLE
feat: allow stack url overrides using BUILDPACK_VENDOR_URL env var

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,6 +33,12 @@ ENV_DIR=$3
 
 export BUILD_DIR CACHE_DIR ENV_DIR
 
+VENDOR_URL="https://lang-python.s3.amazonaws.com/$STACK"
+if [[ -n ${BUILDPACK_VENDOR_URL:-} ]]; then
+    VENDOR_URL="$BUILDPACK_VENDOR_URL"
+fi
+export VENDOR_URL
+
 # Python defaults
 DEFAULT_PYTHON_VERSION="python-3.6.4"
 LATEST_3="python-3.6.4"

--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -15,7 +15,7 @@ if [[ "$STACK" == "heroku-16" ]]; then
 fi
 
 # The location of the pre-compiled libffi binary.
-VENDORED_LIBFFI="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/libffi.tar.gz"
+VENDORED_LIBFFI="${VENDOR_URL}/libraries/vendor/libffi.tar.gz"
 
 PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 

--- a/bin/steps/gdal
+++ b/bin/steps/gdal
@@ -10,7 +10,7 @@
 # This script is invoked by [`bin/compile`](/).
 
 # The location of the pre-compiled cryptography binary.
-VENDORED_GDAL="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/gdal.tar.gz"
+VENDORED_GDAL="${VENDOR_URL}/libraries/vendor/gdal.tar.gz"
 
 PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 

--- a/bin/steps/geo-libs
+++ b/bin/steps/geo-libs
@@ -10,9 +10,9 @@
 # This script is invoked by [`bin/compile`](/).
 
 # The location of the pre-compiled cryptography binary.
-VENDORED_GDAL="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/gdal.tar.gz"
-VENDORED_GEOS="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/geos.tar.gz"
-VENDORED_PROJ="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/proj.tar.gz"
+VENDORED_GDAL="${VENDOR_URL}/libraries/vendor/gdal.tar.gz"
+VENDORED_GEOS="${VENDOR_URL}/libraries/vendor/geos.tar.gz"
+VENDORED_PROJ="${VENDOR_URL}/libraries/vendor/proj.tar.gz"
 
 PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 

--- a/bin/steps/pylibmc
+++ b/bin/steps/pylibmc
@@ -15,7 +15,7 @@ if [[ "$STACK" == "heroku-16" ]]; then
 fi
 
 # The location of the pre-compiled libmemcached binary.
-VENDORED_MEMCACHED="https://lang-python.s3.amazonaws.com/$STACK/libraries/vendor/libmemcache.tar.gz"
+VENDORED_MEMCACHED="${VENDOR_URL}/libraries/vendor/libmemcache.tar.gz"
 
 # Syntax sugar.
 # shellcheck source=bin/utils

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -4,6 +4,9 @@ set +e
 runtime-fixer runtime.txt
 PYTHON_VERSION=$(cat runtime.txt)
 
+# The location of the pre-compiled python binary.
+VENDORED_PYTHON="${VENDOR_URL}/runtimes/$PYTHON_VERSION.tar.gz"
+
 if [[ $PYTHON_VERSION =~ ^python-2 ]]; then
   if [[ "$PYTHON_VERSION" != "$LATEST_2" ]]; then
     puts-warn "The latest version of Python 2 is $LATEST_2 (you are using $PYTHON_VERSION, which is unsupported)."
@@ -41,7 +44,7 @@ if [ ! "$SKIP_INSTALL" ]; then
 
     mcount "version.python.$PYTHON_VERSION"
 
-    if ! curl "https://lang-python.s3.amazonaws.com/$STACK/runtimes/$PYTHON_VERSION.tar.gz" -s | tar zxv -C .heroku/python &> /dev/null; then
+    if ! curl "${VENDORED_PYTHON}" -s | tar zxv -C .heroku/python &> /dev/null; then
       puts-warn "Requested runtime ($PYTHON_VERSION) is not available for this stack ($STACK)."
       puts-warn "Aborting.  More info: https://devcenter.heroku.com/articles/python-support"
       exit 1


### PR DESCRIPTION
This is useful if you'd like to customize python binaries without forking the entire buildpack.

Similar functionality was implemented in https://github.com/heroku/heroku-buildpack-ruby/pull/238