### PR TITLE
Move SKIP_PIP_INSTALL=1 after pip-uninstall step

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -32,9 +32,6 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         # Measure that we're using Pipenv.
         mcount "tool.pipenv"
 
-        # Skip pip install, later.
-        export SKIP_PIP_INSTALL=1
-
         # Set PIP_EXTRA_INDEX_URL
         if [[ -r $ENV_DIR/PIP_EXTRA_INDEX_URL ]]; then
             PIP_EXTRA_INDEX_URL="$(cat "$ENV_DIR/PIP_EXTRA_INDEX_URL")"
@@ -65,6 +62,9 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             puts-step "Installing test dependencies…"
             /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
         fi
+
+        # Skip pip install, later.
+        export SKIP_PIP_INSTALL=1
     fi
 else
     export SKIP_PIP_INSTALL=1


### PR DESCRIPTION
Currently, deployment via pipenv won't uninstall requirements-stale.txt...

```export SKIP_PIP_INSTALL=1``` should be after ```"$BIN_DIR/steps/pip-uninstall"``` otherwise pip-uinstall step will be bypassed.