### PR TITLE
Specify pip version when running get-pip.py

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -67,7 +67,7 @@ if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
   rm -fr /app/.heroku/python/lib/python*/site-packages/pip-*
   rm -fr /app/.heroku/python/lib/python*/site-packages/setuptools-*
 
-  /app/.heroku/python/bin/python "$ROOT_DIR/vendor/get-pip.py" &> /dev/null
+  /app/.heroku/python/bin/python "$ROOT_DIR/vendor/get-pip.py" pip=="$PIP_UPDATE" &> /dev/null
   /app/.heroku/python/bin/pip install "$ROOT_DIR/vendor/setuptools-39.0.1-py2.py3-none-any.whl" &> /dev/null
 
 fi


### PR DESCRIPTION
Since the release of PIP 10, some of our Heroku projects have been failing to build. There is already a `PIP_UPDATE` environment variable present but was not being respected in `vendor/get-pip.py`.

**Passerby**: If you are currently experiencing problems with Python builds due to PIP 10, you can change your buildpack to `https://github.com/jordaneb/heroku-buildpack-python.git#f650a9cdd5f76ccf74766b0a2520f62bbed72d85` in the meantime! :)