### PR TITLE
Update pipenv-to-pip to read file in `r` mode

### DIFF
--- a/vendor/pipenv-to-pip
+++ b/vendor/pipenv-to-pip
@@ -7,7 +7,7 @@ import sys
 def main():
     INFILE = sys.argv[1]
 
-    with open(INFILE, 'rb') as f:
+    with open(INFILE, 'r') as f:
         lockfile = json.load(f)
 
     packages = []


### PR DESCRIPTION
I tested `pipenv-to-pip` locally, seems to work as expected.

```
# On branch master
$ python3.4 vendor/pipenv-to-pip <path_to_Pipfile.lock>
Traceback (most recent call last):
  File "vendor/pipenv-to-pip", line 23, in <module>
    main()
  File "vendor/pipenv-to-pip", line 11, in main
    lockfile = json.load(f)
  File "/home/fds/lang/python/lib64/python3.4/json/__init__.py", line 268, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/home/fds/lang/python/lib64/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'

# On branch fix-pipenv-to-pip
$ python3.4 vendor/pipenv-to-pip <path_to_Pipfile.lock>
# Prints out `requirements.txt`-style requirements
```

Also tested that it still works for `python2.7` and `python3.6`.