### PR TITLE
Fix new shellcheck warnings breaking periodic CI

### DIFF
--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -11,7 +11,7 @@
 #   - $DEBUG_COLLECTSTATIC: upon failure, print out environment variables.
 
 # shellcheck source=bin/utils
-source $BIN_DIR/utils
+source "$BIN_DIR/utils"
 
 # Location of 'manage.py', if it exists.
 MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' -printf '%d\t%P\n' | sort -nk1 | cut -f2 | head -1)

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # shellcheck source=bin/utils
-source $BIN_DIR/utils
+source "$BIN_DIR/utils"
 
 if [ ! "$SKIP_PIP_INSTALL" ]; then
 

--- a/bin/steps/pip-uninstall
+++ b/bin/steps/pip-uninstall
@@ -3,7 +3,7 @@
 set +e
 # Install dependencies with Pip.
 # shellcheck source=bin/utils
-source $BIN_DIR/utils
+source "$BIN_DIR/utils"
 
 if [ ! "$SKIP_PIP_INSTALL" ]; then
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -3,7 +3,7 @@
 # export CLINT_FORCE_COLOR=1
 # export PIPENV_FORCE_COLOR=1
 # shellcheck source=bin/utils
-source $BIN_DIR/utils
+source "$BIN_DIR/utils"
 set -e
 
 if [[ -f Pipfile.lock ]]; then


### PR DESCRIPTION
New warnings were found in our periodic (CRON) CI jobs.

Fixes https://travis-ci.org/heroku/heroku-buildpack-python/jobs/383404864