### PR TITLE
Downgrade pipenv version to v11.9.0

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -41,7 +41,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             export PIP_EXTRA_INDEX_URL
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        export PIPENV_VERSION="11.9.0"
 
         # Install pipenv.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null

--- a/test/fixtures/pipenv-lock/Pipfile.lock
+++ b/test/fixtures/pipenv-lock/Pipfile.lock
@@ -1,14 +1,14 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "09ad9dcae1870ba083f43c5a05ed8943b23bd4c27e61a13ecf4e16d18500ad98"
+            "sha256": "397f2c55e3558ea57d292e3fc19b34e483770e5ec02cdedfb1f330680cd26635"
         },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [
             {
                 "name": "pypi",
-                "url": "https://pypi.org/simple",
+                "url": "https://pypi.python.org/simple",
                 "verify_ssl": true
             }
         ]
@@ -24,10 +24,10 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:9783f4644a3ef8528a6f20374eeb434431a650c797ca6d8df0d81e30fffdfa24",
-                "sha256:9f8eb3277716a01faafaba553d629d3d60a1a624c7cf45daa600d2148c30020c"
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
             ],
-            "version": "==4.5.0"
+            "version": "==4.6.0"
         },
         "ptyprocess": {
             "hashes": [


### PR DESCRIPTION
Try to fix #704 #702

Pipenv with version newer than v11.9.0 has bug related with editable packages. It may related to https://github.com/pypa/pipenv/issues/2219. So downgrade it to versin v11.9.0.

When pipenv has fixed this bug, the version can be upgraded to latest version.