### PR TITLE
Update puts-step "Installing pip"

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -61,7 +61,7 @@ fi
 # If Pip isn't up to date:
 if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
 
-  puts-step "Installing pip"
+  puts-step "Installing pip $PIP_UPDATE"
 
   # Remove old installations.
   rm -fr /app/.heroku/python/lib/python*/site-packages/pip-*


### PR DESCRIPTION
Since the output of the actual pip install is redirected into /dev/null, one never knows (by just reading the deploy output) which pip version is installed. Adding the version to the puts-step should make for quicker debugging. It could be considered to also echo the version [in case it's already installed](https://github.com/heroku/heroku-buildpack-python/pull/711/files#diff-57a28f8b2bf70b3efa895ae239e9d986L62).

---------

#### On another note: 
Personally, I'd also be in favour of making it possible to configure the pip version that should be installed via a config variable. If this is wanted, I'll gladly work on it and submit a PR.