### PR TITLE
Update pipenv version

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -41,7 +41,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             export PIP_EXTRA_INDEX_URL
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        export PIPENV_VERSION="2018.7.1"
 
         # Install pipenv.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null


### PR DESCRIPTION
An issue with pipenv's --system --deploy options has been fixed in a newer release as described here
https://github.com/pypa/pipenv/blob/master/HISTORY.txt#L95

This was likely the casue of #704 and #702 so it would be nice to switch to the latest version