### PR TITLE
Upgrade pipenv and allow users to override the version installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Python Buildpack Changelog
 
+# Unreleased
+
+- Fix bug with the "latest version" message on 3.7.0
+- Add an `OVERRIDDEN_PIPENV_VERSION` option to override the version of Pipenv
+  used in the buildpack
+- Upgrade the `DEFAULT_PIPENV_VERSION` to `2018.7.1`
+
 # 136
 
 Upgrade to 3.6.6 and support 3.7.0 on all runtimes.

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -41,7 +41,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             export PIP_EXTRA_INDEX_URL
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        export PIPENV_VERSION="2018.7.1"
 
         # Install pipenv.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -6,21 +6,19 @@
 source "$BIN_DIR/utils"
 set -e
 
+export DEFAULT_PIPENV_VERSION="2018.7.1"
+
 if [[ -f Pipfile.lock ]]; then
     if [[ -f .heroku/python/Pipfile.lock.sha256 ]]; then
         if [[ $(openssl dgst -sha256 Pipfile.lock) == $(cat .heroku/python/Pipfile.lock.sha256) ]]; then
-            # Measure that we're using Pipenv.
-            mcount "tool.pipenv"
-
             # Don't skip installation of there are git deps.
             if ! grep -q 'git' Pipfile.lock; then
                 echo "Skipping installation, as Pipfile.lock hasn't changed since last deploy." | indent
 
-                mcount "tool.pipenv"
                 export SKIP_PIPENV_INSTALL=1
                 export SKIP_PIP_INSTALL=1
             fi
-
+            mcount "tool.pipenv"
         fi
     fi
 fi
@@ -29,9 +27,6 @@ fi
 if [ ! "$SKIP_PIPENV_INSTALL" ]; then
     # Pipenv support (Generate requriements.txt with pipenv).
     if [[ -f Pipfile ]]; then
-        # Measure that we're using Pipenv.
-        mcount "tool.pipenv"
-
         # Skip pip install, later.
         export SKIP_PIP_INSTALL=1
 
@@ -41,10 +36,12 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             export PIP_EXTRA_INDEX_URL
         fi
 
-        export PIPENV_VERSION="2018.7.1"
+        export PIPENV_VERSION="${OVERRIDDEN_PIPENV_VERSION:-$DEFAULT_PIPENV_VERSION}"
+        mcount "tool.pipenv"
+        mcount "version.pipenv.$PIPENV_VERSION"
 
         # Install pipenv.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null
+        /app/.heroku/python/bin/pip install "pipenv==$PIPENV_VERSION" --upgrade &> /dev/null
 
         # Install the dependencies.
         if [[ ! -f Pipfile.lock ]]; then


### PR DESCRIPTION
Pipenv is still in a state of extreme flux leading to incompatibilities and instabilities between releases. As a result, let's give users a lever to pull when they've chosen the tool but the default version on the platform doesn't satisfy their needs.

Closes #702 
Closes #704  
Closes #706 
Closes #727 

--

**Note** I included the changelog notes after a conversation with @dzuelke yesterday