### PR TITLE
Rebase from upstream (heroku/heroku-buildpack-python)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -136,6 +136,19 @@ export PKG_CONFIG_PATH=/app/.heroku/vendor/lib/pkg-config:/app/.heroku/python/li
 # The Application Code
 # --------------------
 
+# Add heroku-buildpack-apt paths
+export PATH=$PATH:/app/.apt/usr/bin
+export C_INCLUDE_PATH=$C_INCLUDE_PATH:/app/.apt/usr/include:/app/.apt/usr/include/xmlsec1
+export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/app/.apt/usr/include:/app/.apt/usr/include/xmlsec1
+export INCLUDE_PATH=/app/.apt/usr/include:/app/.apt/usr/include/xmlsec1:$INCLUDE_PATH
+export LIBRARY_PATH=$LIBRARY_PATH:/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/.apt/usr/lib/x86_64-linux-gnu:/app/.apt/usr/lib/i386-linux-gnu:/app/.apt/usr/lib
+# export PYTHONPATH=/app/.apt/usr/lib/python2.7/dist-packages/
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/app/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/app/.apt/usr/lib/i386-linux-gnu/pkgconfig:/app/.apt/usr/lib/pkgconfig
+export CPATH=/app/.apt/usr/include:$CPATH
+export CPPPATH=/app/.apt/usr/include:$CPPPATH
+export SWIG_LIB=/app/.apt/usr/share/swig2.0/
+
 # Switch to the repo's context.
 cd "$BUILD_DIR"
 


### PR DESCRIPTION
Trello card: https://trello.com/c/t79y3Fdd/2244-update-our-fork-of-heroku-buildpack-python

This rebases with the current version of the upstream fork heroku/heroku-buildpack-python.

I chose to rebase over a straight merge in order to keep our changes at the top of the commit history. I find it a little cleaner than having a bunch of "merge" commits scattered in-between.
