### PR TITLE
Fix Python 3.6 message when using Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Python Buildpack Changelog
 
+# 139
+
+Improvements to Python install messaging
+
 # 138 (2018-08-01)
 
 Use stack image SQLite3 instead of vendoring

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -12,17 +12,29 @@ if [[ $PYTHON_VERSION =~ ^python-2 ]]; then
     puts-warn "The latest version of Python 2 is $LATEST_2 (you are using $PYTHON_VERSION, which is unsupported)."
     puts-warn "We recommend upgrading by specifying the latest version ($LATEST_2)."
     echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
+  else
+    echo "       Using supported version of Python 2 ($PYTHON_VERSION)"
   fi
 else
-  if [[ $PYTHON_VERSION =~ ^python-3.7 ]] && [[ "$PYTHON_VERSION" != "$LATEST_37" ]]; then
-    puts-warn "The latest version of Python 3.7 is $LATEST_37 (you are using $PYTHON_VERSION, which is unsupported)."
-    puts-warn "We recommend upgrading by specifying the latest version ($LATEST_37)."
-    echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
-  else
-    if [[ "$PYTHON_VERSION" != "$LATEST_36" ]]; then
-      puts-warn "The latest version of Python 3.6 is $LATEST_36 (you are using $PYTHON_VERSION, which is unsupported)."
-      puts-warn "We recommend upgrading by specifying the latest version ($LATEST_36)."
+  if [[ $PYTHON_VERSION =~ ^python-3 ]]; then
+    if [[ $PYTHON_VERSION =~ ^python-3.7 ]]; then
+      if [[ "$PYTHON_VERSION" != "$LATEST_37" ]]; then
+      puts-warn "The latest version of Python 3.7 is $LATEST_37 (you are using $PYTHON_VERSION, which is unsupported)."
+      puts-warn "We recommend upgrading by specifying the latest version ($LATEST_37)."
       echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
+      else
+        echo "       Using supported version of Python 3.7 ($PYTHON_VERSION)"
+      fi
+    else
+      if [[ $PYTHON_VERSION =~ ^python-3.6 ]]; then
+        if [[ "$PYTHON_VERSION" != "$LATEST_36" ]]; then
+          puts-warn "The latest version of Python 3.6 is $LATEST_36 (you are using $PYTHON_VERSION, which is unsupported)."
+          puts-warn "We recommend upgrading by specifying the latest version ($LATEST_36)."
+          echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
+        else
+          echo "       Using supported version of Python 3.6 ($PYTHON_VERSION)"
+        fi
+      fi
     fi
   fi
 fi
@@ -49,6 +61,7 @@ if [ -f .heroku/python-version ]; then
   fi
 fi
 
+
 if [ ! "$SKIP_INSTALL" ]; then
     puts-step "Installing $PYTHON_VERSION"
 
@@ -70,6 +83,7 @@ if [ ! "$SKIP_INSTALL" ]; then
 
   hash -r
 fi
+
 
 # If Pip isn't up to date:
 if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -34,6 +34,10 @@ else
         else
           echo "       Using supported version of Python 3.6 ($PYTHON_VERSION)"
         fi
+      else
+        puts-warn "Heroku supports the latest version of Python 2 $LATEST_37, Python 3.6 $LATEST_36 and Python 3.7 $LATEST_2." 
+        puts-warn "You are using $PYTHON_VERSION, which is unsupported."
+        puts-warn "We recommend upgrading by specifying the default supported version ($LATEST_36)."
       fi
     fi
   fi

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -35,9 +35,10 @@ else
           echo "       Using supported version of Python 3.6 ($PYTHON_VERSION)"
         fi
       else
-        puts-warn "Heroku supports the latest version of Python 2 $LATEST_37, Python 3.6 $LATEST_36 and Python 3.7 $LATEST_2." 
+        puts-warn "Heroku supports runtime versions $LATEST_37, $LATEST_36 and $LATEST_2." 
         puts-warn "You are using $PYTHON_VERSION, which is unsupported."
         puts-warn "We recommend upgrading by specifying the default supported version ($LATEST_36)."
+        echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
       fi
     fi
   fi


### PR DESCRIPTION
Was still seeing Python 3.6 error when creating 3.7 apps, so dug into the version nesting a bit.

Added nested layer for bucketing python 3 installs, then buckets for 3.6 and 3.7 independently.

Added catch for python 3 versions below 3.6 - these are not available on default stack, but deploy log now explicitly states that 3.4 and 3.5, etc, are not supported.