### PR TITLE
Upgrade/rebase onto upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,31 @@
-![python](https://cloud.githubusercontent.com/assets/51578/13712821/b68a42ce-e793-11e5-96b0-d8eb978137ba.png)
+Specify an SSH Key
+------------------
 
-# Heroku Buildpack: Python
-
-[![Build Status](https://travis-ci.org/heroku/heroku-buildpack-python.svg?branch=master)](https://travis-ci.org/heroku/heroku-buildpack-python)
-
-This is the official [Heroku buildpack](https://devcenter.heroku.com/articles/buildpacks) for Python apps, powered by [Pipenv](http://docs.pipenv.org/), [pip](https://pip.pypa.io/) and other excellent software.
-
-Recommended web frameworks include **Django** and **Flask**. The recommended webserver is **Gunicorn**. There are no restrictions around what software can be used (as long as it's pip-installable). Web processes must bind to `$PORT`, and only the HTTP protocol is permitted for incoming connections.
-
-Python packages with C dependencies that are not [available on the stack image](https://devcenter.heroku.com/articles/stack-packages) are generally not supported, unless `manylinux` wheels are provided by the package maintainers (common). For recommended solutions, check out [this article](https://devcenter.heroku.com/articles/python-c-deps) for more information. 
-
-See it in Action
-----------------
-
-Deploying a Python application couldn't be easier:
-
-    $ ls
-    Pipfile		Pipfile.lock	Procfile	web.py
-
-    $ heroku create --buildpack heroku/python
-
-    $ git push heroku master
-    …
-    -----> Python app detected
-    -----> Installing python-3.6.6
-    -----> Installing pip
-    -----> Installing requirements with Pipenv 2018.5.18…
-           ...
-           Installing dependencies from Pipfile…
-    -----> Discovering process types
-           Procfile declares types -> (none)
-
-A `Pipfile` or `requirements.txt` must be present at the root of your application's repository.
-
-You can also specify the latest production release of this buildpack for upcoming builds of an existing application:
-
-    $ heroku buildpacks:set heroku/python
+If you need to install dependencies stored in private repositories, but you don't want to hardcode passwords in the code,
+you can use the following approach.
 
 
-Specify a Python Runtime
-------------------------
+- Generate or use an existing a new SSH key pair (https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
 
-Specific versions of the Python runtime can be specified in your `Pipfile`:
+  For this example, assume that you named the key `deploy_key`.
 
-    [requires]
-    python_version = "2.7"
+- Add the public ssh key to your private repository account.
 
-Or, more specifically:
+  * Github: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/
 
-    [requires]
-    python_full_version = "2.7.15"
+  * Bitbucket: https://confluence.atlassian.com/bitbucket/add-an-ssh-key-to-an-account-302811853.html
 
-Or, with a `runtime.txt` file:
+- Add CUSTOM_SSH_KEY and CUSTOM_SSH_KEY_HOSTS environment variables to you heroku app
 
-    $ cat runtime.txt
-    python-2.7.15
+  * CUSTOM_SSH_KEY must be base64 encoded
+  * CUSTOM_SSH_KEY_HOSTS is a comma separated list of the hosts that will use the custom SSH key
 
-Runtime options include:
+  ```
+  # OSX
+  $ heroku config:set CUSTOM_SSH_KEY=$(base64 --input ~/.ssh/deploy_key.pub) CUSTOM_SSH_KEY_HOSTS=bitbucket.org,github.com
 
-- `python-3.7.0`
-- `python-3.6.6`
-- `python-2.7.15`
+  # Linux
+  $ heroku config:set CUSTOM_SSH_KEY=$(base64 ~/.ssh/deploy_key.pub | tr -d '\n') CUSTOM_SSH_KEY_HOSTS=bitbucket.org,github.com
+  ```
+
+- Deploy your app and enjoy!

--- a/bin/compile
+++ b/bin/compile
@@ -222,6 +222,9 @@ if [[ $BUILD_DIR != '/app' ]]; then
     # Note: .heroku/src is copied in later.
 fi
 
+# Set Up SSH deploy-key.
+source $BIN_DIR/steps/sshkey
+
 # Download / Install Python, from pre-build binaries available on Amazon S3.
 # This step also bootstraps pip / setuptools.
 (( start=$(nowms) ))

--- a/bin/release
+++ b/bin/release
@@ -16,7 +16,7 @@ EOF
 if [[ $MANAGE_FILE ]]; then
 cat <<EOF
 
-addons:
-  - heroku-postgresql
+#addons:
+#  - heroku-postgresql
 EOF
 fi

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -25,7 +25,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     fi
 
 
-    /app/.heroku/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
+    /app/.heroku/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --process-dependency-links --no-cache-dir 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e
 
@@ -46,7 +46,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     if [ "$INSTALL_TEST" ]; then
         if [[ -f "$1/requirements-test.txt" ]]; then
             puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pip install -r "$1/requirements-test.txt" --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
+            /app/.heroku/python/bin/pip install -r "$1/requirements-test.txt" --exists-action=w --src=./.heroku/src --disable-pip-version-check --process-dependency-links --no-cache-dir 2>&1 | cleanup | indent
         fi
     fi
 fi

--- a/bin/steps/sshkey
+++ b/bin/steps/sshkey
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Generates an SSH config file for connections if a config var exists.
+
+# ENV_DIR=$3
+
+if [[ -f $ENV_DIR/CUSTOM_SSH_KEY && -f $ENV_DIR/CUSTOM_SSH_KEY_HOSTS ]]; then
+
+  #echo "" >&1
+  echo ""
+
+  # Ensure we have an ssh folder
+  if [ ! -d ~/.ssh ]; then
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+  fi
+
+  # Load the private key into custom_key file.
+  base64 --decode $ENV_DIR/CUSTOM_SSH_KEY > ~/.ssh/custom_key
+
+  # Change the permissions on the file to
+  # be read-only for this user.
+  chmod 400 ~/.ssh/custom_key
+
+  # Split $CUSTOM_SSH_KEY_HOSTS
+  (
+    IFS=',' ;for element in `cat $ENV_DIR/CUSTOM_SSH_KEY_HOSTS`;
+    do
+      echo -e "Host $element\n"\
+              "  IdentityFile ~/.ssh/custom_key\n"\
+              "  IdentitiesOnly yes\n"\
+              "  UserKnownHostsFile=/dev/null\n"\
+              "  StrictHostKeyChecking no"\
+              >> ~/.ssh/config
+    done
+
+    echo "-----> Successfully added custom SSH key"
+  )
+fi


### PR DESCRIPTION
# Purpose
Merge in all the upstream changes that happened in the last 4 years because we have been having very regular buildpack breakages due to the code being so old.

Fixes [ALTOS-16888](https://altschool.atlassian.net/browse/ALTOS-16888)

# Approach
First tried to merge the upstream into our master. That rust failed.

Then tried to rebase our master onto upstream, which also lead to lots of extensive conflicts.

Because our changes were few, I reapplied them in separate commits that correspond to the changes we had made on top of that 4-yo upstream/master branch.

Because our fork was an indirect fork of the official upstream through Mikhail's fork, I modified our repo to be a direct fork of the upstream repo. Github does not allow an account to have multiple forks of the same repo, even if their source (Mikhail vs Heroku) are different. I tried renaming the repo in case the problem was a name conflict, but it wasn't, so I transferred ownership of our fork to my private account (https://github.com/atzannes/heroku-buildpack-python-old), created a fresh AltSchool fork of the Heroku repo, and cherry-picked all the relevant changes from the transferred repo to this one.

