### PR TITLE
update tests to expect success for all 2.7.15 builds

### DIFF
--- a/test/run
+++ b/test/run
@@ -81,17 +81,9 @@ testPylibmc() {
 }
 
 testPython2() {
-  if [[ "$STACK" == "heroku-16" ]] || [[ "$STACK" == "cedar-14" ]]; then
     compile "python2"
     assertCaptured "python-2.7.15"
     assertCapturedSuccess
-  fi
-}
-
-testNoPython2() {
-  if [[ "$STACK" == "heroku-18" ]]; then
-    compile "python2"
-    assertCapturedError
   fi
 }
 

--- a/test/run
+++ b/test/run
@@ -84,7 +84,6 @@ testPython2() {
     compile "python2"
     assertCaptured "python-2.7.15"
     assertCapturedSuccess
-  fi
 }
 
 testPython3() {


### PR DESCRIPTION
This is a small fix on a unit test that expected a fail case on Python 2.7 on Heroku 18. 

Update to expect success for 2.7 builds on all three stacks.