### PR TITLE
Remove test that asserts python 2.x fails on heroku-18

### DIFF
--- a/test/run
+++ b/test/run
@@ -88,13 +88,6 @@ testPython2() {
   fi
 }
 
-testNoPython2() {
-  if [[ "$STACK" == "heroku-18" ]]; then
-    compile "python2"
-    assertCapturedError
-  fi
-}
-
 testPython3() {
   compile "python3"
   assertCaptured "python-3.6.6"


### PR DESCRIPTION
This test is no longer needed now that python 2.x will be supported