### PR TITLE
Adding .python-compile-env for to support exporting env vars for pip install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -287,7 +287,7 @@ buildpack_sqlite3_install
 mtime "sqlite3.install.time" "${start}"
 
 # Source compile variables
-if [ -f .python-compile-env ]; then
+if [ -s .python-compile-env ]; then
   source .python-compile-env
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -286,6 +286,11 @@ source "$BIN_DIR/steps/sqlite3"
 buildpack_sqlite3_install
 mtime "sqlite3.install.time" "${start}"
 
+# Source compile variables
+if [ -f .python-compile-env ]; then
+  source .python-compile-env
+fi
+
 # pip install
 # -----------
 


### PR DESCRIPTION
I added the ability to define config variables required for `pip install` to work for airflow 1.10. Airflow [now requires](https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#airflow-110) the environment variable `SLUGIFY_USES_TEXT_UNIDECODE` to be defined and exported for app build in order for airflow to install.

By creating a file `.python-compile-env` in the app source root, it will be sourced before `pip install` runs. The file simply exports environment variables:
```
export SLUGIFY_USES_TEXT_UNIDECODE=yes
```