### PR TITLE
(Update): Adding .python-compile-env env var support for pip install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -287,6 +287,7 @@ buildpack_sqlite3_install
 mtime "sqlite3.install.time" "${start}"
 
 # Source compile variables
+# shellcheck source=.python-compile-env
 if [ -f .python-compile-env ]; then
   source .python-compile-env
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -286,11 +286,6 @@ source "$BIN_DIR/steps/sqlite3"
 buildpack_sqlite3_install
 mtime "sqlite3.install.time" "${start}"
 
-# Source compile variables
-# shellcheck source=.python-compile-env
-if [ -f .python-compile-env ]; then
-  source .python-compile-env
-fi
 
 # pip install
 # -----------

--- a/bin/compile
+++ b/bin/compile
@@ -286,6 +286,11 @@ source "$BIN_DIR/steps/sqlite3"
 buildpack_sqlite3_install
 mtime "sqlite3.install.time" "${start}"
 
+# Source compile variables
+if [ -f .python-compile-env ]; then
+  source .python-compile-env
+fi
+
 # pip install
 # -----------
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -16,6 +16,15 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
     set +e
 
+    # Set SLUGIFY_USES_TEXT_UNIDECODE, for Airflow support
+    if [[ -r $ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE ]]; then
+        SLUGIFY_USES_TEXT_UNIDECODE="$(cat "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE")"
+        export SLUGIFY_USES_TEXT_UNIDECODE
+        echo "SLUGIFY_USES_TEXT_UNIDECODE set to " + SLUGIFY_USES_TEXT_UNIDECODE
+    fi
+
+    set +e
+
     # Measure that we're using pip.
     mcount "tool.pip"
 


### PR DESCRIPTION
Continued from #750 - our Travis tests need creds to run, so commit was rolled over from `tomasbielskis:master` so tests could run using my creds.

Recap: [Airflow](https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#airflow-110) requires an env var. This is a bit tricky in an ephemeral build environment and (confirmed) can't be addressed by independently setting app env vars.

<3 Airflow