### PR TITLE
Update travis setup for Hatchet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ site
 
 /.envrc
 repos/*
+
+#Venv
+buildpack/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 rvm:
 - 2.4.4
 before_script:
+  - bash etc/ci-setup.sh
   - gem install bundler -v 1.16.2
   - bundle exec rake hatchet:setup_travis
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ before_script:
   - bash etc/ci-setup.sh
   - gem install bundler -v 1.16.2
   - bundle exec rake hatchet:setup_travis
-addons:
-  apt:
-    sources:
-    - heroku
-    packages:
-    - heroku-toolbelt
 jobs:
   include:
   - stage: Bash linting (shellcheck)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: ruby
 dist: trusty
+sudo: required
 rvm:
 - 2.4.4
 before_script:
   - gem install bundler -v 1.16.2
   - bundle exec rake hatchet:setup_travis
+before_install:
+  - sudo bash etc/ci-setup.sh
 jobs:
   include:
   - stage: Bash linting (shellcheck)
     sudo: false
     before_install:
-    - bash etc/ci-setup.sh
     - wget -c https://goo.gl/ZzKHFv -O - | tar -xvJ -C /tmp/
     - PATH="/tmp/shellcheck-latest:$PATH"
     script: make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 rvm:
 - 2.4.4
 before_script:
-  - bash etc/ci-setup.sh
   - gem install bundler -v 1.16.2
   - bundle exec rake hatchet:setup_travis
 jobs:
@@ -11,6 +10,7 @@ jobs:
   - stage: Bash linting (shellcheck)
     sudo: false
     before_install:
+    - bash etc/ci-setup.sh
     - wget -c https://goo.gl/ZzKHFv -O - | tar -xvJ -C /tmp/
     - PATH="/tmp/shellcheck-latest:$PATH"
     script: make check

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,0 +1,3 @@
+sudo apt-get -qq update
+sudo apt-get install software-properties-common -y
+curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 sudo apt-get -qq update
 sudo apt-get install software-properties-common -y
 curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 sudo apt-get -qq update
-sudo apt-get install software-properties-common -y
+sudo apt-get install software-properties-common
 curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh


### PR DESCRIPTION
Hatchet has a Heroku CLI dependency that until recently, directly used the Toolbelt. This has changed, so the Travis test setup requires some changes before builds will succeed again.
