### PR TITLE
Replaced hardcoded /app with $BUILD_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -87,6 +87,7 @@ export PATH=$PATH:$ROOT_DIR/vendor/:$ROOT_DIR/vendor/pip-pop
 unset GIT_DIR PYTHONHOME PYTHONPATH
 unset RECEIVE_DATA RUN_KEY BUILD_INFO DEPLOY LOG_TOKEN
 unset CYTOKINE_LOG_FILE GEM_PATH
+export PYTHONPATH="$BUILD_DIR"
 
 # Import the utils script, which contains helper functions used throughout the buildpack.
 # shellcheck source=bin/utils
@@ -101,7 +102,7 @@ source "$BIN_DIR/warnings"
 # to `/app`.
 # Symlinks are required, since Python is not a portable installation.
 # More on this topic later.
-mkdir -p /app/.heroku
+mkdir -p "BUILD_DIR/.heroku"
 
 # This buildpack programatically generates (or simply copies) a number of files for
 # buildpack machinery: an export script, and a number of `.profile.d` scripts. This
@@ -119,7 +120,7 @@ export BUILD_DIR CACHE_DIR BIN_DIR PROFILE_PATH EXPORT_PATH
 # Notes on each variable included.
 
 # PATH is relatively obvious, we need to be able to execute 'python'.
-export PATH=/app/.heroku/python/bin:/app/.heroku/vendor/bin:$PATH
+export PATH="$BUILD_DIR/.heroku/python/bin:$BUILD_DIR/.heroku/vendor/bin:$PATH"
 # Tell Python to not buffer it's stdin/stdout.
 export PYTHONUNBUFFERED=1
 # Set the locale to a well-known and expected standard.
@@ -127,11 +128,11 @@ export LANG=en_US.UTF-8
 # `~/.heroku/vendor` is an place where the buildpack may stick pre-build binaries for known
 # C dependencies (e.g. libmemcached on cedar-14). This section configures Python (GCC, more specifically)
 # and pip to automatically include these paths when building binaries.
-export C_INCLUDE_PATH=/app/.heroku/vendor/include:/app/.heroku/python/include:$C_INCLUDE_PATH
-export CPLUS_INCLUDE_PATH=/app/.heroku/vendor/include:/app/.heroku/python/include:$CPLUS_INCLUDE_PATH
-export LIBRARY_PATH=/app/.heroku/vendor/lib:/app/.heroku/python/lib:$LIBRARY_PATH
-export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:/app/.heroku/python/lib:$LD_LIBRARY_PATH
-export PKG_CONFIG_PATH=/app/.heroku/vendor/lib/pkg-config:/app/.heroku/python/lib/pkg-config:$PKG_CONFIG_PATH
+export C_INCLUDE_PATH="$BUILD_DIR/.heroku/vendor/include:$BUILD_DIR/.heroku/python/include:$C_INCLUDE_PATH"
+export CPLUS_INCLUDE_PATH="$BUILD_DIR/.heroku/vendor/include:$BUILD_DIR/.heroku/python/include:$CPLUS_INCLUDE_PATH"
+export LIBRARY_PATH="$BUILD_DIR/.heroku/vendor/lib:$BUILD_DIR/.heroku/python/lib:$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$BUILD_DIR/.heroku/vendor/lib:$BUILD_DIR/.heroku/python/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$BUILD_DIR/.heroku/vendor/lib/pkg-config:$BUILD_DIR/.heroku/python/lib/pkg-config:$PKG_CONFIG_PATH"
 
 # The Application Code
 # --------------------
@@ -208,15 +209,16 @@ fi
 # Create the directory for .profile.d, if it doesn't exist.
 mkdir -p "$(dirname "$PROFILE_PATH")"
 # Create the directory for editable source code installation, if it doesn't exist.
-mkdir -p /app/.heroku/src
+mkdir -p "$BUILD_DIR/.heroku/src"
 
 # On Heroku CI, builds happen in `/app`. Otherwise, on the Heroku platform,
 # they occur in a temp directory. Beacuse Python is not portable, we must create
 # symlinks to emulate that we are operating in `/app` during the build process.
 # This is (hopefully obviously) because apps end up running from `/app` in production.
-if [[ $BUILD_DIR != '/app' ]]; then
+if [[ "$BUILD_DIR" != '/app' ]]; then
     # python expects to reside in /app, so set up symlinks
     # we will not remove these later so subsequent buildpacks can still invoke it
+    mkdir -p /app/.heroku
     ln -nsf "$BUILD_DIR/.heroku/python" /app/.heroku/python
     ln -nsf "$BUILD_DIR/.heroku/vendor" /app/.heroku/vendor
     # Note: .heroku/src is copied in later.
@@ -307,8 +309,7 @@ mtime "nltk.download.time" "${start}"
 # and copying it into the proper place (the logical place to do this was early, but it must be done here).
 # In CI, $BUILD_DIR is /app.
 if [[ ! "$BUILD_DIR" == "/app" ]]; then
-  rm -fr "$BUILD_DIR/.heroku/src"
-  deep-cp /app/.heroku/src "$BUILD_DIR/.heroku/src"
+  ln -nsf "$BUILD_DIR/.heroku/src" /app/.heroku/src
 fi
 
 
@@ -340,13 +341,12 @@ set_default_env PYTHONHASHSEED random
 # Tell Python to look for Python modules in the /app dir. Don't change this.
 set_default_env PYTHONPATH "\$HOME"
 
-# Python expects to be in /app, if at runtime, it is not, set
+# Python expects to be in "$BUILD_DIR," if at runtime, it is not, set
 # up symlinks… this can occur when the subdir buildpack is used.
 cat <<EOT >> "$PROFILE_PATH"
-if [[ \$HOME != "/app" ]]; then
-    mkdir -p /app/.heroku
-    ln -nsf "\$HOME/.heroku/python" /app/.heroku/python
-    ln -nsf "\$HOME/.heroku/vendor" /app/.heroku/vendor
+if [[ \$HOME != "$BUILD_DIR" ]]; then
+    ln -nsf "\$HOME/.heroku/python" "$BUILD_DIR/.heroku/python"
+    ln -nsf "\$HOME/.heroku/vendor" "$BUILD_DIR/.heroku/vendor"
 fi
 EOT
 

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -30,12 +30,11 @@ if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALL
     puts-step "$ python $MANAGE_FILE collectstatic --noinput"
 
     # Run collectstatic, cleanup some of the noisy output.
-    PYTHONPATH=${PYTHONPATH:-.}
+    PYTHONPATH=${PYTHONPATH:-$BUILD_DIR}
     export PYTHONPATH
 
     # Create a temporary file for collecting the collectstaic logs.
     COLLECTSTATIC_LOG=$(mktemp)
-
     python "$MANAGE_FILE" collectstatic --noinput --traceback 2>&1 | tee "$COLLECTSTATIC_LOG" | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
     COLLECTSTATIC_STATUS="${PIPESTATUS[0]}"
 

--- a/bin/steps/gdal
+++ b/bin/steps/gdal
@@ -12,7 +12,7 @@
 # The location of the pre-compiled cryptography binary.
 VENDORED_GDAL="${VENDOR_URL}/libraries/vendor/gdal.tar.gz"
 
-PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
+PKG_CONFIG_PATH="$BUILD_DIR/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # Syntax sugar.
 # shellcheck source=bin/utils

--- a/bin/steps/geo-libs
+++ b/bin/steps/geo-libs
@@ -14,7 +14,7 @@ VENDORED_GDAL="${VENDOR_URL}/libraries/vendor/gdal.tar.gz"
 VENDORED_GEOS="${VENDOR_URL}/libraries/vendor/geos.tar.gz"
 VENDORED_PROJ="${VENDOR_URL}/libraries/vendor/proj.tar.gz"
 
-PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
+PKG_CONFIG_PATH="$BUILD_DIR/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # Syntax sugar.
 # shellcheck source=bin/utils
@@ -33,7 +33,7 @@ if [[ "$BUILD_WITH_GEO_LIBRARIES" ]]; then
 
     # Copy libjasper from build image to slug.
     if [[ "$STACK" == "heroku-16" ]]; then
-      cp /usr/lib/x86_64-linux-gnu/libjasper.so* ".heroku/vendor/lib/."
+      cp /usr/lib/x86_64-linux-gnu/libjasper.so* ".heroku/vendor/lib/"
     fi
 
   fi

--- a/bin/steps/mercurial
+++ b/bin/steps/mercurial
@@ -3,7 +3,7 @@
 # Install Mercurial if it appears to be required.
 if [[ -f "requirements.txt" ]]; then
 	if (grep -Fiq "hg+" requirements.txt) then
-		/app/.heroku/python/bin/pip install  mercurial | cleanup | indent
+		"$BUILD_DIR/.heroku/python/bin/pip" install  mercurial | cleanup | indent
 	fi
 fi
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -25,7 +25,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     fi
 
 
-    /app/.heroku/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
+    "$BUILD_DIR/.heroku/python/bin/pip" install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src="$BUILD_DIR/.heroku/src" --disable-pip-version-check --no-cache-dir 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e
 
@@ -38,7 +38,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
     # Smart Requirements handling
     cp requirements.txt .heroku/python/requirements-declared.txt
-    /app/.heroku/python/bin/pip freeze --disable-pip-version-check > .heroku/python/requirements-installed.txt
+    "$BUILD_DIR/.heroku/python/bin/pip" freeze --disable-pip-version-check > .heroku/python/requirements-installed.txt
 
     echo
 
@@ -46,7 +46,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     if [ "$INSTALL_TEST" ]; then
         if [[ -f "$1/requirements-test.txt" ]]; then
             puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pip install -r "$1/requirements-test.txt" --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
+            "$BUILD_DIR/.heroku/python/bin/pip" install -r "$1/requirements-test.txt" --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
         fi
     fi
 fi

--- a/bin/steps/pip-uninstall
+++ b/bin/steps/pip-uninstall
@@ -20,7 +20,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
     if [[ -s .heroku/python/requirements-stale.txt ]]; then
       puts-step "Uninstalling stale dependencies"
-      /app/.heroku/python/bin/pip uninstall -r .heroku/python/requirements-stale.txt -y --exists-action=w --disable-pip-version-check | cleanup | indent
+      "$BUILD_DIR/.heroku/python/bin/pip" uninstall -r .heroku/python/requirements-stale.txt -y --exists-action=w --disable-pip-version-check | cleanup | indent
     fi
   fi
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -12,7 +12,7 @@ if [[ -f Pipfile.lock ]]; then
             # Measure that we're using Pipenv.
             mcount "tool.pipenv"
 
-            # Don't skip installation of there are git deps.
+            # Don't skip installation if there are git deps.
             if ! grep -q 'git' Pipfile.lock; then
                 echo "Skipping installation, as Pipfile.lock hasn't changed since last deploy." | indent
 
@@ -44,12 +44,12 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         export PIPENV_VERSION="2018.5.18"
 
         # Install pipenv.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null
+        "$BUILD_DIR/.heroku/python/bin/pip" install pipenv==$PIPENV_VERSION --upgrade &> /dev/null
 
         # Install the dependencies.
         if [[ ! -f Pipfile.lock ]]; then
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
-            /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
+            "$BUILD_DIR/.heroku/python/bin/pipenv" install --system --skip-lock 2>&1 | indent
         else
             pipenv-to-pip Pipfile.lock > requirements.txt
             "$BIN_DIR/steps/pip-uninstall"
@@ -57,13 +57,13 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             openssl dgst -sha256 Pipfile.lock > .heroku/python/Pipfile.lock.sha256
 
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
-            /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
+            "$BUILD_DIR/.heroku/python/bin/pipenv" install --system --deploy 2>&1 | indent
         fi
 
         # Install the test dependencies, for CI.
         if [ "$INSTALL_TEST" ]; then
             puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
+            "$BUILD_DIR/.heroku/python/bin/pipenv" install --dev --system --deploy 2>&1 | cleanup | indent
         fi
     fi
 else

--- a/bin/steps/pipenv-python-version
+++ b/bin/steps/pipenv-python-version
@@ -2,13 +2,13 @@
 
 # Detect Python-version with Pipenv.
 
-if [[ -f $BUILD_DIR/Pipfile ]]; then
+if [[ -f "$BUILD_DIR/Pipfile" ]]; then
 
-    if [[ ! -f $BUILD_DIR/runtime.txt ]]; then
-        if [[ ! -f $BUILD_DIR/Pipfile.lock ]]; then
+    if [[ ! -f "$BUILD_DIR/runtime.txt" ]]; then
+        if [[ ! -f "$BUILD_DIR/Pipfile.lock" ]]; then
             puts-warn "No 'Pipfile.lock' found! We recommend you commit this into your repository."
         fi
-        if [[ -f $BUILD_DIR/Pipfile.lock ]]; then
+        if [[ -f "$BUILD_DIR/Pipfile.lock" ]]; then
             set +e
             PYTHON=$(jq -r '._meta.requires.python_full_version' "$BUILD_DIR/Pipfile.lock")
             if [[ "$PYTHON" != "null" ]]; then

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -35,7 +35,7 @@ else
           echo "       Using supported version of Python 3.6 ($PYTHON_VERSION)"
         fi
       else
-        puts-warn "Heroku supports runtime versions $LATEST_37, $LATEST_36 and $LATEST_2." 
+        puts-warn "Heroku supports runtime versions $LATEST_37, $LATEST_36 and $LATEST_2."
         puts-warn "You are using $PYTHON_VERSION, which is unsupported."
         puts-warn "We recommend upgrading by specifying the default supported version ($LATEST_36)."
         echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
@@ -96,11 +96,11 @@ if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
   puts-step "Installing pip"
 
   # Remove old installations.
-  rm -fr /app/.heroku/python/lib/python*/site-packages/pip-*
-  rm -fr /app/.heroku/python/lib/python*/site-packages/setuptools-*
+  rm -fr "$BUILD_DIR/.heroku/python/lib/python*/site-packages/pip-*"
+  rm -fr "$BUILD_DIR/.heroku/python/lib/python*/site-packages/setuptools-*"
 
-  /app/.heroku/python/bin/python "$ROOT_DIR/vendor/get-pip.py" pip=="$PIP_UPDATE" &> /dev/null
-  /app/.heroku/python/bin/pip install "$ROOT_DIR/vendor/setuptools-39.0.1-py2.py3-none-any.whl" &> /dev/null
+  "$BUILD_DIR/.heroku/python/bin/python" "$ROOT_DIR/vendor/get-pip.py" pip=="$PIP_UPDATE" &> /dev/null
+  "$BUILD_DIR/.heroku/python/bin/pip" install "$ROOT_DIR/vendor/setuptools-39.0.1-py2.py3-none-any.whl" &> /dev/null
 
 fi
 

--- a/builds/libraries/vendor/gdal
+++ b/builds/libraries/vendor/gdal
@@ -4,7 +4,7 @@
 OUT_PREFIX=$1
 
 # Use new path, containing autoconf.
-export PATH="/app/.heroku/python/bin/:$PATH"
+export PATH="$BUILD_DIR/.heroku/python/bin/:$PATH"
 hash -r
 
 

--- a/builds/libraries/vendor/geos
+++ b/builds/libraries/vendor/geos
@@ -4,7 +4,7 @@
 OUT_PREFIX=$1
 
 # Use new path, containing autoconf.
-export PATH="/app/.heroku/python/bin/:$PATH"
+export PATH="$BUILD_DIR.heroku/python/bin/:$PATH"
 hash -r
 
 

--- a/builds/libraries/vendor/libffi
+++ b/builds/libraries/vendor/libffi
@@ -9,7 +9,7 @@ if [[ $S3_PREFIX == "heroku-16" ]]; then
 fi
 
 # Use new path, containing autoconf.
-export PATH="/app/.heroku/python/bin/:$PATH"
+export PATH="$BUILD_DIR/.heroku/python/bin/:$PATH"
 hash -r
 
 

--- a/builds/libraries/vendor/proj
+++ b/builds/libraries/vendor/proj
@@ -4,7 +4,7 @@
 OUT_PREFIX=$1
 
 # Use new path, containing autoconf.
-export PATH="/app/.heroku/python/bin/:$PATH"
+export PATH="$BUILD_DIR/.heroku/python/bin/:$PATH"
 hash -r
 
 


### PR DESCRIPTION
This PR is to replace many "/app" references with $BUILD_DIR

Heroku builds the environment within $BUILD_DIR before copying it to /app upon success.

This is to address an issue with the python buildpack where it's building everything in the /app directory which causes issues with other buildpacks and exported environment variables which are correctly using the $BUILD_DIR directory.

All build files are now installed within $BUILD_DIR, and exported environment variables (in /export) are now pointing to folders under $BUILD_DIR.

The "/app/..." symlinks were left but may not be necessary for many builds.

Environment variables exported with .profile.d were not changed because these are post-build.  In the future, it may be worth changing these from /app to $HOME.