### PR TITLE
Do not upgrade system pip

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -44,7 +44,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         export PIPENV_VERSION="2018.5.18"
 
         # Install pipenv.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null
+        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
         # Install the dependencies.
         if [[ ! -f Pipfile.lock ]]; then


### PR DESCRIPTION
Try to fix https://github.com/heroku/heroku-buildpack-python/issues/762

Pip is upgraded to lastet version during installing pipenv. This may cause unexpected circumstances in building process. This also makes later steps which relys on specific pip version fails.