### PR TITLE
Validate stack and python version prior to copying cache into build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -149,33 +149,7 @@ cd "$BUILD_DIR"
 # - Once the build is complete, `~/.heroku/{known-paths}` is copied back into the cache.
 
 # Create the cache directory, if it doesn't exist.
-mkdir -p "$CACHE_DIR"
-
-# Restore old artifacts from the cache.
-mkdir -p .heroku
-
-# The Python installation.
-cp -R "$CACHE_DIR/.heroku/python" .heroku/ &> /dev/null || true
-# A plain text file which contains the current stack being used (used for cache busting).
-cp -R "$CACHE_DIR/.heroku/python-stack" .heroku/ &> /dev/null || true
-# A plain text file which contains the current python version being used (used for cache busting).
-cp -R "$CACHE_DIR/.heroku/python-version" .heroku/ &> /dev/null || true
-# A plain text file which contains the current sqlite3 version being used (used for cache busting).
-cp -R "$CACHE_DIR/.heroku/python-sqlite3-version" .heroku/ &> /dev/null || true
-# Any pre-compiled binaries, provided by the buildpack.
-cp -R "$CACHE_DIR/.heroku/vendor" .heroku/ &> /dev/null || true
-# "editable" installations of code repositories, via pip or pipenv.
-if [[ -d "$CACHE_DIR/.heroku/src" ]]; then
-  cp -R "$CACHE_DIR/.heroku/src" .heroku/ &> /dev/null || true
-fi
-
-# The pre_compile hook. Customers rely on this. Don't remove it.
-# This part of the code is used to allow users to customize their build experience
-# without forking the buildpack by providing a `bin/pre_compile` script, which gets
-# run inline with the buildpack automatically.
-
-# shellcheck source=bin/steps/hooks/pre_compile
-source "$BIN_DIR/steps/hooks/pre_compile"
+mkdir -p .heroku "$CACHE_DIR/.heroku"
 
 # Sticky runtimes. If there was a previous build, and it used a given version of Python,
 # continue to use that version of Python in perpituity (warnings will be raised if
@@ -203,7 +177,55 @@ source "$BIN_DIR/steps/pipenv-python-version"
 # If no runtime was provided by the user, assume the default Python runtime version.
 if [ ! -f runtime.txt ]; then
   echo "$DEFAULT_PYTHON_VERSION" > runtime.txt
+  PYTHON_VERSION=$DEFAULT_PYTHON_VERSION
+else
+  runtime-fixer runtime.txt
+  PYTHON_VERSION=$(cat runtime.txt)
 fi
+
+# Restore old artifacts from the cache.
+if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
+  puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
+elif [ -d "$CACHE_DIR/.heroku/python" ] && [ ! -f "$CACHE_DIR/.heroku/python-sqlite3-version" ] && python_sqlite3_check "$PYTHON_VERSION"; then
+  # need to clear the cache for first time installing SQLite3,
+  # since the version is changing and could lead to runtime errors
+  # with compiled extensions.
+  puts-step "Need to update SQLite3, clearing cache"
+
+else
+  # A plain text file which contains the current stack being used (used for cache busting).
+  cp -R "$CACHE_DIR/.heroku/python-stack" .heroku/ &> /dev/null || true
+  # A plain text file which contains the current python version being used (used for cache busting).
+  cp -R "$CACHE_DIR/.heroku/python-version" .heroku/ &> /dev/null || true
+  # A plain text file which contains the current sqlite3 version being used (used for cache busting).
+  cp -R "$CACHE_DIR/.heroku/python-sqlite3-version" .heroku/ &> /dev/null || true
+  # Any pre-compiled binaries, provided by the buildpack.
+  cp -R "$CACHE_DIR/.heroku/vendor" .heroku/ &> /dev/null || true
+
+  # The Python installation.
+  if [ -f .heroku/python-version ]; then
+    if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
+      puts-step "Found $(cat .heroku/python-version), removing"
+    else
+      cp -R "$CACHE_DIR/.heroku/python" .heroku/ &> /dev/null || true
+      SKIP_INSTALL=1
+    fi
+  fi
+fi
+export SKIP_INSTALL PYTHON_VERSION
+
+# "editable" installations of code repositories, via pip or pipenv.
+if [[ -d "$CACHE_DIR/.heroku/src" ]]; then
+  cp -R "$CACHE_DIR/.heroku/src" .heroku/ &> /dev/null || true
+fi
+
+# The pre_compile hook. Customers rely on this. Don't remove it.
+# This part of the code is used to allow users to customize their build experience
+# without forking the buildpack by providing a `bin/pre_compile` script, which gets
+# run inline with the buildpack automatically.
+
+# shellcheck source=bin/steps/hooks/pre_compile
+source "$BIN_DIR/steps/hooks/pre_compile"
 
 # Create the directory for .profile.d, if it doesn't exist.
 mkdir -p "$(dirname "$PROFILE_PATH")"

--- a/bin/compile
+++ b/bin/compile
@@ -183,33 +183,34 @@ else
   PYTHON_VERSION=$(cat runtime.txt)
 fi
 
-# Restore old artifacts from the cache.
+# Validate cached python/stack/sqlite3
 if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
   puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
-elif [ -d "$CACHE_DIR/.heroku/python" ] && [ ! -f "$CACHE_DIR/.heroku/python-sqlite3-version" ] && python_sqlite3_check "$PYTHON_VERSION"; then
-  # need to clear the cache for first time installing SQLite3,
-  # since the version is changing and could lead to runtime errors
-  # with compiled extensions.
-  puts-step "Need to update SQLite3, clearing cache"
+elif [ -d "$CACHE_DIR/.heroku/python" ] && [ -f "$CACHE_DIR/.heroku/python-version" ]; then
+  CACHED_PYTHON_VERSION="$(cat "$CACHE_DIR/.heroku/python-version")"
+  if [ ! -f "$CACHE_DIR/.heroku/python-sqlite3-version" ] && python_sqlite3_check "$PYTHON_VERSION"; then
+    # need to clear the cache for first time installing SQLite3,
+    # since the version is changing and could lead to runtime errors
+    # with compiled extensions.
+    puts-step "Need to update SQLite3, clearing cache"
 
-else
-  # A plain text file which contains the current stack being used (used for cache busting).
-  cp -R "$CACHE_DIR/.heroku/python-stack" .heroku/ &> /dev/null || true
-  # A plain text file which contains the current python version being used (used for cache busting).
-  cp -R "$CACHE_DIR/.heroku/python-version" .heroku/ &> /dev/null || true
-  # A plain text file which contains the current sqlite3 version being used (used for cache busting).
-  cp -R "$CACHE_DIR/.heroku/python-sqlite3-version" .heroku/ &> /dev/null || true
-  # Any pre-compiled binaries, provided by the buildpack.
-  cp -R "$CACHE_DIR/.heroku/vendor" .heroku/ &> /dev/null || true
+  elif [[ "$CACHED_PYTHON_VERSION" == "$PYTHON_VERSION" ]]; then
+    # Restore old artifacts from the cache.
 
-  # The Python installation.
-  if [ -f .heroku/python-version ]; then
-    if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
-      puts-step "Found $(cat .heroku/python-version), removing"
-    else
-      cp -R "$CACHE_DIR/.heroku/python" .heroku/ &> /dev/null || true
-      SKIP_INSTALL=1
-    fi
+    # A plain text file which contains the current stack being used (used for cache busting).
+    cp -R "$CACHE_DIR/.heroku/python-stack" .heroku/ &> /dev/null || true
+    # A plain text file which contains the current python version being used (used for cache busting).
+    cp -R "$CACHE_DIR/.heroku/python-version" .heroku/ &> /dev/null || true
+    # A plain text file which contains the current sqlite3 version being used (used for cache busting).
+    cp -R "$CACHE_DIR/.heroku/python-sqlite3-version" .heroku/ &> /dev/null || true
+    # Any pre-compiled binaries, provided by the buildpack.
+    cp -R "$CACHE_DIR/.heroku/vendor" .heroku/ &> /dev/null || true
+    # The Python installation.
+    cp -R "$CACHE_DIR/.heroku/python" .heroku/ &> /dev/null || true
+
+    SKIP_INSTALL=1
+  else
+    puts-step "Found $CACHED_PYTHON_VERSION, removing"
   fi
 fi
 export SKIP_INSTALL PYTHON_VERSION

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 set +e
-runtime-fixer runtime.txt
-PYTHON_VERSION=$(cat runtime.txt)
 
 # The location of the pre-compiled python binary.
 VENDORED_PYTHON="${VENDOR_URL}/runtimes/$PYTHON_VERSION.tar.gz"
@@ -35,7 +33,7 @@ else
           echo "       Using supported version of Python 3.6 ($PYTHON_VERSION)"
         fi
       else
-        puts-warn "Heroku supports runtime versions $LATEST_37, $LATEST_36 and $LATEST_2." 
+        puts-warn "Heroku supports runtime versions $LATEST_37, $LATEST_36 and $LATEST_2."
         puts-warn "You are using $PYTHON_VERSION, which is unsupported."
         puts-warn "We recommend upgrading by specifying the default supported version ($LATEST_36)."
         echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"
@@ -43,29 +41,6 @@ else
     fi
   fi
 fi
-
-if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
-    puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
-    rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor .heroku/python .heroku/python-sqlite3-version
-fi
-
-# need to clear the cache for first time installing SQLite3,
-# since the version is changing and could lead to runtime errors
-# with compiled extensions.
-if [ -d .heroku/python ] && [ ! -f .heroku/python-sqlite3-version ] && python_sqlite3_check "$PYTHON_VERSION"; then
-  puts-step "Need to update SQLite3, clearing cache"
-  rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor
-fi
-
-if [ -f .heroku/python-version ]; then
-  if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
-      puts-step "Found $(cat .heroku/python-version), removing"
-      rm -fr .heroku/python
-  else
-    SKIP_INSTALL=1
-  fi
-fi
-
 
 if [ ! "$SKIP_INSTALL" ]; then
     puts-step "Installing $PYTHON_VERSION"


### PR DESCRIPTION
This is to address issue #764. The cache directories are only copied if the cache is a valid match, rather than always copying the directories and then deleting them if the cache is not a valid match.
