### PR TITLE
Updated HATCHET_BUILDPACK_BASE to use TRAVIS_REPO_SLUG

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV['HATCHET_BUILDPACK_BASE'] = 'https://github.com/heroku/heroku-buildpack-python.git'
+ENV['HATCHET_BUILDPACK_BASE'] = 'https://github.com/' + ENV['TRAVIS_REPO_SLUG'] + '.git'
 
 require 'rspec/core'
 require 'rspec/retry'


### PR DESCRIPTION
In order for Travis-CI tests to work for outside repos, the tests must use those repo's.  Makes sense, right?

Otherwise, it always tested the heroku git repo using the branch from the Travis-CI build. This would of course fail if the heroku repo didn't have a branch by the same name.

TRAVIS_REPO_SLUG contains the git repo slug (in owner/repository format), so I included that in the HATCHET_BUILDPACK_BASE that's used for hatchet.

It passed Travis-CI: https://travis-ci.com/duanehutchins/heroku-buildpack-python/builds/87256182