### PR TITLE
Pin pip version used by pipenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Python Buildpack Changelog
 
+# 141 (2018-10-10)
+
+Switch to cautious upgrade for Pipenv install to ensure the pinned pip version
+is used with Pipenv
+
 # 140 (2018-10-09)
 
 Add support for detecting SLUGIFY_USES_TEXT_UNIDECODE, which is required to

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -13,7 +13,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     # and makes them accessible to the pip install process.
     #
     # PIP_EXTRA_INDEX_URL allows for an alternate pypi URL to be used.
-    if [[ -r $ENV_DIR/PIP_EXTRA_INDEX_URL ]]; then
+    if [[ -r "$ENV_DIR/PIP_EXTRA_INDEX_URL" ]]; then
         PIP_EXTRA_INDEX_URL="$(cat "$ENV_DIR/PIP_EXTRA_INDEX_URL")"
         export PIP_EXTRA_INDEX_URL
         mcount "buildvar.PIP_EXTRA_INDEX_URL"
@@ -22,7 +22,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     set +e
 
     # Set SLUGIFY_USES_TEXT_UNIDECODE, required for Airflow versions >=1.10
-    if [[ -r $ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE ]]; then
+    if [[ -r "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE" ]]; then
         SLUGIFY_USES_TEXT_UNIDECODE="$(cat "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE")"
         export SLUGIFY_USES_TEXT_UNIDECODE
         mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -20,7 +20,6 @@ if [[ -f Pipfile.lock ]]; then
                 export SKIP_PIPENV_INSTALL=1
                 export SKIP_PIP_INSTALL=1
             fi
-
         fi
     fi
 fi
@@ -40,14 +39,14 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         # and makes them accessible to the pip install process.
         #
         # PIP_EXTRA_INDEX_URL allows for an alternate pypi URL to be used.
-        if [[ -r $ENV_DIR/PIP_EXTRA_INDEX_URL ]]; then
+        if [[ -r "$ENV_DIR/PIP_EXTRA_INDEX_URL" ]]; then
             PIP_EXTRA_INDEX_URL="$(cat "$ENV_DIR/PIP_EXTRA_INDEX_URL")"
             export PIP_EXTRA_INDEX_URL
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
         # Set SLUGIFY_USES_TEXT_UNIDECODE, required for Airflow versions >=1.10
-        if [[ -r $ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE ]]; then
+        if [[ -r "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE" ]]; then
             SLUGIFY_USES_TEXT_UNIDECODE="$(cat "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE")"
             export SLUGIFY_USES_TEXT_UNIDECODE
             mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
@@ -56,7 +55,10 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         export PIPENV_VERSION="2018.5.18"
 
         # Install pipenv.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade &> /dev/null
+        # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip
+        # to latest if only --upgrade is specified. Specify upgrade strategy to
+        # avoid this eager behavior.
+        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
         # Install the dependencies.
         if [[ ! -f Pipfile.lock ]]; then


### PR DESCRIPTION
@jxltom submitted this change to the buildpack via #763 fixing weird combo error causing pipenv to upgrade to latest pip version. Testing suite still needs refactor, so submitting clean PR so test suite can run in Travis.

Essentially, the --upgrade pip flag causes eager upgrading behavior to be used - this is then used again, in pipenv's install process, to upgrade pip to the latest version rather than using the Buildpack default.

PR also contains some nearby bash cleanup.