### PR TITLE
fix: drop broken version check

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -93,6 +93,5 @@ python_sqlite3_check() {
   MIN_PYTHON_2="python-2.7.15"
 
   ( python2_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_2" ) \
-    || ( python3_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_3" ) \
-    || ( version_gte "$VERSION" "3.7.0" )
+    || ( python3_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_3" )
 }


### PR DESCRIPTION
Due to how the version checks work - via sorting, not actual comparison - this previously resulted in _always_ installing sqlite3, even though it was already bundled for lower versions of python. The second version check also encompasses 3.7.0+, so there is no need to respecify the check.