### PR TITLE
Update to latest pip

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ PY27="python-2.7"
 # Which stack is used (for binary downloading), if none is provided (e.g. outside of Heroku)?
 DEFAULT_PYTHON_STACK="cedar-14"
 # If pip doesn't match this version (the version we install), run the installer.
-PIP_UPDATE="9.0.2"
+PIP_UPDATE="18.1"
 
 export DEFAULT_PYTHON_VERSION DEFAULT_PYTHON_STACK PIP_UPDATE
 export LATEST_27 LATEST_36 LATEST_37 LATEST_35 LATEST_34

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -9,6 +9,13 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     puts-step "Installing requirements with pip"
 
     # Set Pip env vars
+    # Set git oauth key for private repo access
+    if [[ -r "$ENV_DIR/GIT_OAUTH_KEY" ]]; then
+        GIT_OAUTH_KEY="$(cat "$ENV_DIR/GIT_OAUTH_KEY")"
+        export GIT_OAUTH_KEY
+        mcount "buildvar.GIT_OAUTH_KEY"
+    fi
+
     # This reads certain environment variables set on the Heroku app config
     # and makes them accessible to the pip install process.
     #


### PR DESCRIPTION
Also allow GIT_OAUTH_KEY environment variable to be passed through to pip.

-----------------------
We wanted to be able to remove github oauth key values from our requirements.txt files that are checked into source control.  With later versions of pip (10+), it can read them from an environment variables.  This PR updates to the current latest pip (18.1), fixing https://github.com/heroku/heroku-buildpack-python/issues/740, and allows passthrough of a GIT_OAUTH_KEY env variable from heroku in order to meet this use case.