### PR TITLE
Remove shellcheck travis install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ jobs:
   include:
   - stage: Bash linting (shellcheck)
     sudo: false
-    before_install:
-    - wget -c https://goo.gl/ZzKHFv -O - | tar -xvJ -C /tmp/
-    - PATH="/tmp/shellcheck-latest:$PATH"
     script: make check
   - stage: Stack Unit Tests
     services: docker


### PR DESCRIPTION
Shellcheck is now installed on travis by default so we don't need to install it manually anymore: https://github.com/koalaman/shellcheck#travis-ci