### PR TITLE
HOTFIX for cedar-14 python builds

### DIFF
--- a/bin/steps/sqlite3
+++ b/bin/steps/sqlite3
@@ -4,7 +4,11 @@
 source "$BIN_DIR/utils"
 
 sqlite3_version() {
-  SQLITE3_VERSION=${SQLITE3_VERSION:-$(dpkg -s libsqlite3-0 | grep Version | sed 's/Version: //')}
+  if [ "$STACK" = "cedar-14" ]; then
+    SQLITE3_VERSION="3.8.2-1ubuntu2.2"
+  else
+    SQLITE3_VERSION=${SQLITE3_VERSION:-$(dpkg -s libsqlite3-0 | grep Version | sed 's/Version: //')}
+  fi
 
   export SQLITE3_VERSION
 }


### PR DESCRIPTION
This temporarily hardcodes the `libsqlite3` version check return value to a package version available at http://archive.ubuntu.com/ubuntu/pool/main/s/sqlite3/.

This may break again at any time for this stack or others.

Just a quick workaround for the next few days until we have the sqlite3 installation refactored to only use headers and link to them for `pip install` using the right env vars.