### PR TITLE
Upgrade Pipenv to 2018.11.26

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -52,7 +52,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        export PIPENV_VERSION="${PIPENV_VERSION:-2018.11.26}"
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip


### PR DESCRIPTION
Hi! This is related to https://github.com/heroku/heroku-buildpack-python/issues/786

We're using Pipenv at my team but we've had problems with the version this buildpack pinned, `2018.5.18`. In the end we leveraged the compile hooks to install a different version, because this was a blocker and I didn't know a better way to do it... aside from upgrading the version upstream, which is what this PR is about.

This upgrades Pipenv to `2018.11.26`, but also allows the variable to be overriden, similar to how it is done in [other sections of the code][1].

The only thing I'm still confused about is how to test the overriding part. I've read `test/run` a bit, and I think I can create a new `testOverridenPipenv` function that exports the variable, then unsets it after success. Will it be enough?

[1]: https://github.com/heroku/heroku-buildpack-python/blob/master/bin/compile#L20