### PR TITLE
HOTFIX heroku-16 builds with sqlite3

### DIFF
--- a/bin/steps/sqlite3
+++ b/bin/steps/sqlite3
@@ -6,6 +6,8 @@ source "$BIN_DIR/utils"
 sqlite3_version() {
   if [ "$STACK" = "cedar-14" ]; then
     SQLITE3_VERSION="3.8.2-1ubuntu2.2"
+  elif [ "$STACK" = "heroku-16" ]; then
+    SQLITE3_VERSION="3.11.0-1ubuntu1.2"
   else
     SQLITE3_VERSION=${SQLITE3_VERSION:-$(dpkg -s libsqlite3-0 | grep Version | sed 's/Version: //')}
   fi


### PR DESCRIPTION
upstream version has changed to 3.11.0-1ubuntu1.2, but local package version is still on 3.11.0-1ubuntu1.1, so the download fails otherwise
