### PR TITLE
feat: add docs and make target for heroku-18 bob builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,19 @@ buildenv-heroku-16:
 	@echo
 	@docker run -it --rm python-buildenv-heroku-16
 
+buildenv-heroku-18:
+	@echo "Creating build environment (heroku-18)..."
+	@echo
+	@docker build --pull -f Dockerfile.heroku-18 -t python-buildenv-heroku-18 .
+	@echo
+	@echo "Usage..."
+	@echo
+	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
+	@echo "  $$ bob build runtimes/python-2.7.13"
+	@echo "  $$ bob deploy runtimes/python-2.7.13"
+	@echo
+	@docker run -it --rm python-buildenv-heroku-18
+
 tools:
 	git clone https://github.com/kennethreitz/pip-pop.git
 	mv pip-pop/bin/* vendor/pip-pop/

--- a/builds/README.md
+++ b/builds/README.md
@@ -37,5 +37,11 @@ For Heroku-16 stack
 2. From the root of the buildpack repository, run: `make buildenv-heroku-16`
 3. Follow the instructions displayed!
 
+For Heroku-18 stack
+-------------------
+
+1. Ensure GNU Make and Docker are installed.
+2. From the root of the buildpack repository, run: `make buildenv-heroku-18`
+3. Follow the instructions displayed!
 
 Enjoy :)


### PR DESCRIPTION
This pull request adds a make target for building python packages under heroku-18. The dockerfile already existed, so a make target - plus the requisite docs - were added to simplify the process for users.