### PR TITLE
Remove cedar tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ jobs:
     services: docker
     env: STACK=heroku-16
     script: "./tests.sh"
-  - stage: Stack Unit Tests
-    services: docker
-    env: STACK=cedar-14
-    script: "./tests.sh"
   - stage: Hatchet Integration
     script: "bundle exec rspec"
 env:

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,6 @@ check:
 	@shellcheck -x bin/steps/collectstatic bin/steps/eggpath-fix  bin/steps/eggpath-fix2 bin/steps/gdal bin/steps/geo-libs bin/steps/mercurial bin/steps/nltk bin/steps/pip-install bin/steps/pip-uninstall bin/steps/pipenv bin/steps/pipenv-python-version bin/steps/pylibmc bin/steps/python
 	@shellcheck -x bin/steps/hooks/*
 
-test-cedar-14:
-	@echo "Running tests in docker (cedar-14)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=cedar-14" heroku/cedar:14 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
-	@echo ""
-
 test-heroku-16:
 	@echo "Running tests in docker (heroku-16)..."
 	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-16" heroku/heroku:16-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'


### PR DESCRIPTION
Cedar 14 is deprecated, and thus Travis tests and local docker tests failed on run.

Remove tests for deprecated stack to prevent false negatives:

- Remove Travis stack test for Cedar 14
- Remove make command test-cedar-14
