### PR TITLE
pin package versions for python-pip to bionic-security

### DIFF
--- a/Dockerfile.heroku-18
+++ b/Dockerfile.heroku-18
@@ -6,7 +6,7 @@ ENV WORKSPACE_DIR="/app/builds" \
     S3_PREFIX="heroku-18/" \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y python-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y python-pip-whl=9.0.1-2 python-pip=9.0.1-2 python-setuptools python-wheel && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app/
 RUN pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt


### PR DESCRIPTION
So that we do not get an update of libssl to 1.1.1, since the stack is still on 1.1.0

See https://github.com/heroku/heroku-buildpack-php/commit/0b05d2b45f360fd2685b74ca28f1c3b700281f71 for prior art