### PR TITLE
Release the snakes! (Python 3.7.4 and 3.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Python Buildpack Changelog
 
+# 156 (2019-08)
+
+Move get-pip utility to S3
+Build utility and documentation updates
+Python 3.6.9 and 3.7.4 now available.
+
+# 155 (2019-08-22)
+
+add docs and make target for heroku-18 bob builds
+
 # 154 (2019-07-17)
 
 Fix python 3.5.7 formula actually building 3.7.2

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-DEFAULT_PYTHON_VERSION="python-3.6.8"
-LATEST_36="python-3.6.8"
-LATEST_37="python-3.7.3"
+DEFAULT_PYTHON_VERSION="python-3.6.9"
+LATEST_36="python-3.6.9"
+LATEST_37="python-3.7.4"
 LATEST_35="python-3.5.7"
 LATEST_34="python-3.4.10"
 LATEST_27="python-2.7.16"


### PR DESCRIPTION
Long awaited and blocked by several things, here are the binaries and related changelog update (to be updated with a specific day after the buildpack is released)

