### PR TITLE
New Release: Changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 # Master
 
-- Bump Hatchet tests to point at new default python version.
+--------------------------------------------------------------------------------
+
+# 156 (2019-09-12)
 
 - Python 3.6.9 and 3.7.4 now available.
 
 - Move get-pip utility to S3
-
 - Build utility and documentation updates
-
---------------------------------------------------------------------------------
+- Bump Hatchet tests to point at new default python version.
 
 # 155 (2019-08-22)
 


### PR DESCRIPTION
Python Buildpack version 156 has been released! Included in this update:

- Python version 3.7.4 on all stacks 
- Python version 3.6.9 on all stacks

In addition:
- get-pip was updated to current and moved to S3 for easier updates and repo simplification
- Updating get-pip resource fixed pip issues on Cedar 14 with 3.7.* versions of python and on all stacks with latest python releases
- Changes to the build environments to help make new Python version releases smoother
- Changes to documentation on build environments

🎉 🎉 🎉 