### PR TITLE
Fix pipenv install twice in CI

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -60,10 +60,16 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         # avoid this eager behavior.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
+        # Install the test dependencies, for CI.
+        if [ "$INSTALL_TEST" ]; then
+            puts-step "Installing test dependencies…"
+            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
+
         # Install the dependencies.
-        if [[ ! -f Pipfile.lock ]]; then
+        elif [[ ! -f Pipfile.lock ]]; then
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
+
         else
             pipenv-to-pip Pipfile.lock > requirements.txt
             "$BIN_DIR/steps/pip-uninstall"
@@ -72,12 +78,6 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
 
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
-        fi
-
-        # Install the test dependencies, for CI.
-        if [ "$INSTALL_TEST" ]; then
-            puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
         fi
     fi
 else


### PR DESCRIPTION
I noticed I was getting pipenv dependencies installed twice in Heroku CI tests ( #824 ) which is redundant and time consuming during the tests as you can see here:

![image](https://user-images.githubusercontent.com/34052139/65035909-7bebde80-d974-11e9-8c1d-8db1934c3879.png)

As pipenv documentation shows it, installing dev dependencies includes all the main dependencies:

```
   Install all dependencies for a project (including dev):
   $ pipenv install --dev
```

https://github.com/pypa/pipenv

So made this PR and I tested this Heroku buildpack with Heroku CI test (it installs dev dependencies as currently) and Dyno build (it installs main dependencies as currently)

I moved the if-block responsible for test (main+dev) dependencies above the "if-block" for dyno build (main) dependencies which I changed into a "elif-block" to avoid the redundant install.

So it is the same behaviour as before except tests will be faster thanks to removed redundancy:

Tests in CI:
![image](https://user-images.githubusercontent.com/34052139/65495046-3d0fd880-dee0-11e9-9b06-0d49da28f936.png)

Dyno Build:
![image](https://user-images.githubusercontent.com/34052139/65495096-53b62f80-dee0-11e9-9b3f-c8d534b22688.png)

Let me know if I should change or improve anything