### PR TITLE
Staging binary controller env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - Add Tests
   - Test for Pysqlite
 - Bug fix: pipenv no longer installs twice on CI
-
+- Add support for staging binary testing
 --------------------------------------------------------------------------------
 
 # 157 (2019-09-18)

--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,8 @@ export BUILD_DIR CACHE_DIR ENV_DIR
 VENDOR_URL="https://lang-python.s3.amazonaws.com/$STACK"
 if [[ -n ${BUILDPACK_VENDOR_URL:-} ]]; then
     VENDOR_URL="$BUILDPACK_VENDOR_URL"
+elif [[ -n ${USE_STAGING_BINARIES} ]]; then
+    VENDOR_URL="$USE_STAGING_BINARIES/$STACK"
 fi
 export VENDOR_URL
 

--- a/test/run-versions
+++ b/test/run-versions
@@ -4,8 +4,6 @@
 # shellcheck source=bin/default_pythons
 source "bin/default_pythons"
 
-assertCaptured "Installing SQLite3"
-
 testPythonDefault() {
   updateVersion "pythonDefault" $DEFAULT_PYTHON_VERSION
   compile "pythonDefault"


### PR DESCRIPTION
Initially I tried to use the default $BUILDPACK_VENDOR_URL provided, but it wasn't handling the $STACK var appropriately - this is a quick fix to concatenate the supplied staging binary with the current STACK provided to the build environment.

Related: #860 