### PR TITLE
Staging flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Master
 
 - Sqlite3 Update:
+  - Enable dynamic linking flags for staged binaries
   - Add Tests
   - Test for Pysqlite
 - Bug fix: pipenv no longer installs twice on CI

--- a/bin/compile
+++ b/bin/compile
@@ -294,6 +294,11 @@ mtime "sqlite3.install.time" "${start}"
 # pip install
 # -----------
 
+if [[ -n ${USE_STAGING_BINARIES} ]]; then
+  export CFLAGS="-I/app/.heroku/python/include ${CFLAGS:-}"
+  export LDFLAGS="-L/app/.heroku/lib/x86_64-linux-gnu ${LDFLAGS:-}"
+fi
+
 # Install dependencies with pip (where the magic happens).
 (( start=$(nowms) ))
 # shellcheck source=bin/steps/pip-install


### PR DESCRIPTION
For the new binaries being generated to work, they need the LD and C flags specified. This allows Python to actually make use of the dynamic linking.

For the currently staged binaries to work, they need these flags set, but only if we're using the staging binaries. 

This PR sets these flags, but only if it's specified to use the staged binaries.