### PR TITLE
Temporary revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Sqlite3 Update:
   - Add Tests
   - Test for Pysqlite
-- Bug fix: pipenv no longer installs twice on CI
 - Add support for staging binary testing
 --------------------------------------------------------------------------------
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -60,16 +60,10 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         # avoid this eager behavior.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
-        # Install the test dependencies, for CI.
-        if [ "$INSTALL_TEST" ]; then
-            puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
-
         # Install the dependencies.
-        elif [[ ! -f Pipfile.lock ]]; then
+        if [[ ! -f Pipfile.lock ]]; then
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
-
         else
             pipenv-to-pip Pipfile.lock > requirements.txt
             "$BIN_DIR/steps/pip-uninstall"
@@ -78,6 +72,12 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
 
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
+        fi
+
+        # Install the test dependencies, for CI.
+        if [ "$INSTALL_TEST" ]; then
+            puts-step "Installing test dependencies…"
+            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
         fi
     fi
 else


### PR DESCRIPTION
Temporarily reverting this fix for installing pipenv dependencies twice in CI, so it can go out in its own release next week. 