### PR TITLE
Reapply pipenv-ci bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Master
 
+- Bugfix: Pipenv no longer installs twice in CI
 - Python 2.7.17 now available on Heroku 18 and 16.
 
 --------------------------------------------------------------------------------

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -60,10 +60,16 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
         # avoid this eager behavior.
         /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
+        # Install the test dependencies, for CI.
+        if [ "$INSTALL_TEST" ]; then
+            puts-step "Installing test dependencies…"
+            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
+
         # Install the dependencies.
-        if [[ ! -f Pipfile.lock ]]; then
+        elif [[ ! -f Pipfile.lock ]]; then
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
+
         else
             pipenv-to-pip Pipfile.lock > requirements.txt
             "$BIN_DIR/steps/pip-uninstall"
@@ -72,12 +78,6 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
 
             puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
             /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
-        fi
-
-        # Install the test dependencies, for CI.
-        if [ "$INSTALL_TEST" ]; then
-            puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
         fi
     fi
 else


### PR DESCRIPTION
Re-apply user-submitted pipenv-ci bugfix (pipenv installs dependencies twice on CI currently) and release now that the latest binaries are out.

This release was ordered this way so that in the event of a rollback, the new Python versions released last week and this weekend would still be available. Now that those versions are released, we can move forward with this change 👏 
