### PR TITLE
Resolved #773 - feat: Add bin/test for python testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 --------------------------------------------------------------------------------
 
+# 161 (2019-11-02)
+
+- Add bin/test to support running tests with setup.py
+
 # 160 (2019-10-23)
 
 - Bugfix: Pipenv no longer installs twice in CI

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Locale support for Pipenv.
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+if [ ! -f "${1:-}/setup.py" ]; then
+  echo "No setup.py found. Please create a setup.py to run tests."
+  exit 1
+fi
+
+"python $(dirname "${1:-}")/setup.py test"


### PR DESCRIPTION
Working with Gitlab's Auto-Test python buildpack integration always errors out with `echo "Selected buildpack does not support test feature"` (as discussed in #773 & https://github.com/gliderlabs/herokuish/blob/master/include/buildpack.bash#L209). Adding bin/test resolves this partially.

I chose to implement with setup.py because auto-test ignores app.json and therefore it would be nice to have at least partial support.
If anybody has suggestions on how to make app.json support work for bin/test (with auto-test), as described on https://devcenter.heroku.com/articles/heroku-ci#python, please comment below.

Also; Maintainers, please let me know how I can improve this PR (it's my first for this project).