### PR TITLE
Allow other pipenv versions than 2018.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Master
 
+- Allow other Pipenv versions than 2018.5.18
 - Update requirements.txt builds to use Pip 20.0.2
 - Download get-pip.py to tmpdir instead of root dir
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -52,7 +52,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        export PIPENV_VERSION="${PIPENV_VERSION:-2018.5.18}"
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip


### PR DESCRIPTION
Following the issue https://github.com/heroku/heroku-buildpack-python/issues/786 and the PR https://github.com/heroku/heroku-buildpack-python/pull/820 that has not been merged (and is now out of date with the master branch), I am changing a bit the code of https://github.com/heroku/heroku-buildpack-python/pull/820 to allow other pipenv versions to be installed while keeping the default at `2018.5.18`