### PR TITLE
link sqlite3 installation with python installation to fix unwanted cache clearing

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -168,8 +168,6 @@ cp -R "$CACHE_DIR/.heroku/python" .heroku/ &> /dev/null || true
 cp -R "$CACHE_DIR/.heroku/python-stack" .heroku/ &> /dev/null || true
 # A plain text file which contains the current python version being used (used for cache busting).
 cp -R "$CACHE_DIR/.heroku/python-version" .heroku/ &> /dev/null || true
-# A plain text file which contains the current sqlite3 version being used (used for cache busting).
-cp -R "$CACHE_DIR/.heroku/python-sqlite3-version" .heroku/ &> /dev/null || true
 # Any pre-compiled binaries, provided by the buildpack.
 cp -R "$CACHE_DIR/.heroku/vendor" .heroku/ &> /dev/null || true
 # "editable" installations of code repositories, via pip or pipenv.

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -83,13 +83,13 @@ fi
 
 if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
     puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
-    rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor .heroku/python .heroku/python-sqlite3-version
+    rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor .heroku/python
 fi
 
 # need to clear the cache for first time installing SQLite3,
 # since the version is changing and could lead to runtime errors
 # with compiled extensions.
-if [ -d .heroku/python ] && [ ! -f .heroku/python-sqlite3-version ] && python_sqlite3_check "$PYTHON_VERSION"; then
+if [ -d .heroku/python ] && [ ! -f .heroku/python/sqlite3-installed ] && python_sqlite3_check "$PYTHON_VERSION"; then
   puts-step "Need to update SQLite3, clearing cache"
   rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor
 fi

--- a/bin/steps/sqlite3
+++ b/bin/steps/sqlite3
@@ -57,22 +57,20 @@ sqlite3_install() {
 }
 
 buildpack_sqlite3_install() {
-  HEROKU_PYTHON_DIR="$BUILD_DIR/.heroku/python"
+  if [ ! -f "$BUILD_DIR/.heroku/python/sqlite3-installed" ]; then
+    puts-step "Installing SQLite3"
 
-  SQLITE3_VERSION_FILE="$BUILD_DIR/.heroku/python-sqlite3-version"
-  if [ -f "$SQLITE3_VERSION_FILE" ]; then
-    INSTALLED_SQLITE3_VERSION=$(cat "$SQLITE3_VERSION_FILE")
-  fi
+    if sqlite3_install "$BUILD_DIR/.heroku/python" ; then
+      echo "Sqlite3 successfully installed."
+      mcount "success.python.sqlite3"
+    else
+      echo "Sqlite3 failed to install."
+      mcount "failure.python.sqlite3"
+    fi
 
-  puts-step "Installing SQLite3"
-
-  if sqlite3_install "$BUILD_DIR/.heroku/python" ; then
-    echo "Sqlite3 successfully installed."
-    mcount "success.python.sqlite3"
+    echo 1 > "$BUILD_DIR/.heroku/python/sqlite3-installed"
   else
-    echo "Sqlite3 failed to install."
-    mcount "failure.python.sqlite3"
+    puts-step "SQLite3 has been installed before, skip it."
   fi
 
-  mkdir -p "$CACHE_DIR/.heroku/"
 }


### PR DESCRIPTION
## Why
As mentioned by ref: https://github.com/heroku/heroku-buildpack-python/issues/909, after https://github.com/heroku/heroku-buildpack-python/pull/907, the file `python-sqlite3-version` is no longer created after the SQLite3 installation. This leads to the unnecessary cache clearing
in [`step/python`](https://github.com/heroku/heroku-buildpack-python/blob/v162/bin/steps/python#L72), which slows down every build because all of the dependencies need to be installed from scratch.

## How

After https://github.com/heroku/heroku-buildpack-python/pull/907, the SQLite version is no longer relevant because it just installs the latest version.

The desired behavior would be linking the SQLite3's installation with the Python's installation:

- Whenever Python needs to be re-installed, install SQLite3.
- If there's an existing Python installation but no SQLite3 associated with it, clear cache and re-install both.
- If there's an existing Python installation **with** SQLite3 associated with it, keep the cache of both.


## What

- Cleanup unused variables in function `buildpack_sqlite3_install`
- Keep a file `sqlite3-installed` under python folder `.heroku/python` after SQLite3 installation, so that it can be cached/removed with python installation.
- Remove corresponding cache file references
