### PR TITLE
Download get-pip.py to tmpdir instead of root dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Master
 
+- Download get-pip.py to tmpdir instead of root dir
 - New pythons released:
   Python 3.8.1, 3.7.6, 3.6.10 (CPython)
   Beta Release: Pypy 2.7 and 3.6, version 7.2.0

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -128,9 +128,10 @@ fi
 
 # Heroku uses the get-pip utility maintained by the Python community to vendor Pip.
 # https://github.com/pypa/get-pip
-GETPIP="https://lang-python.s3.amazonaws.com/etc/get-pip.py"
+GETPIP_URL="https://lang-python.s3.amazonaws.com/etc/get-pip.py"
+GETPIP_PY="${TMPDIR:-/tmp}/get-pip.py"
 
-if ! curl -s "${GETPIP}" -o "$ROOT_DIR/get-pip.py" &> /dev/null; then
+if ! curl -s "${GETPIP_URL}" -o "$GETPIP_PY" &> /dev/null; then
     mcount "failure.python.get-pip"
     echo "Failed to pull down get-pip"
     exit 1
@@ -145,7 +146,7 @@ if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
   rm -fr /app/.heroku/python/lib/python*/site-packages/pip-*
   rm -fr /app/.heroku/python/lib/python*/site-packages/setuptools-*
 
-  /app/.heroku/python/bin/python "$ROOT_DIR/get-pip.py" pip=="$PIP_UPDATE" &> /dev/null
+  /app/.heroku/python/bin/python "$GETPIP_PY" pip=="$PIP_UPDATE" &> /dev/null
   /app/.heroku/python/bin/pip install "$ROOT_DIR/vendor/setuptools-39.0.1-py2.py3-none-any.whl" &> /dev/null
 fi
 


### PR DESCRIPTION
In Cloud Native Buildpacks, the buildpack dir is read-only. This change fixes a failure on heroku/pack-images#65