### PR TITLE
Warn about EOL for Django release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Master
 
 - Correct ftp to https in vendored file
+- Warn for Django 1.11 approaching EOL, provide link to roadmap
 
 --------------------------------------------------------------------------------
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -38,6 +38,12 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         mcount "failure.none-version"
     fi
 
+    if grep -q 'django==1.*' requirements.txt; then
+        puts-warn "Your Django version is nearing the end of its community support."
+        puts-warn "Upgrade to continue to receive security updates and for the best experience with Django."
+        puts-warn "For more information, check out https://www.djangoproject.com/weblog/2015/jun/25/roadmap/"
+    fi
+
     if [ ! -f "$BUILD_DIR/.heroku/python/bin/pip" ]; then
         exit 1
     fi


### PR DESCRIPTION
Django is nearing the end of its community support for 1.11, so let's let people know to start thinking about migrating