### PR TITLE
Fix old Django version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Master
 
 - Correct ftp to https in vendored file
-- Warn for Django 1.11 approaching EOL, provide link to roadmap
+- Warn for Django 1.11 approaching EOL, provide link to roadmap [fixed detection]
 
 --------------------------------------------------------------------------------
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -38,10 +38,10 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         mcount "failure.none-version"
     fi
 
-    if grep -q 'django==1.*' requirements.txt; then
+    if grep -qi '^django==1.*' requirements.txt; then
         puts-warn "Your Django version is nearing the end of its community support."
         puts-warn "Upgrade to continue to receive security updates and for the best experience with Django."
-        puts-warn "For more information, check out https://www.djangoproject.com/weblog/2015/jun/25/roadmap/"
+        puts-warn "For more information, check out https://www.djangoproject.com/download/#supported-versions"
     fi
 
     if [ ! -f "$BUILD_DIR/.heroku/python/bin/pip" ]; then


### PR DESCRIPTION
There are three changes in this PR, all affecting the "Your Django version is nearing the end of its community support" warning (documented in https://devcenter.heroku.com/changelog-items/1745).

The original line to detect the EOL condition was:

`grep -q 'django==1.*' requirements.txt`

The changes are:

1) Add the `^` prefix to the regex in order to not false-positive on e.g. `pwned-passwords-django==1.4` - *most* third-party Django packages follow the `django-foo` convention, but it's not universal (and `pwned-passwords-django` itself is a reasonably popular package, which under present conditions throws that warning even if you're on e.g. Django 2.2).

2) Add the `-i` flag to `grep` in order to catch the case of "Django==1.11" (which is totally valid and in fact is the likely result of following Django's own "how to install" guide, which currently reads: `pip install Django==...`)

3) Adjust the "more info" link to point to the more permanent page: https://www.djangoproject.com/download/#supported-versions

As a sidenote, technically Django 2.0 and 2.1 are out of support as well (after 1.11 the LTS releases are 2.2, 3.2, etc), and currently *don't* throw a warning, but I didn't want to overcomplicate this PR - the first fix especially is pretty important, since it's throwing false positives.
