### PR TITLE
Report/pipversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Master
 
+- Report version of pip used to build log
 - Add failcase for cache busting
 - Bugfix: Clearing pip dependencies
 - Correct ftp to https in vendored file

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -152,10 +152,13 @@ if ! curl -s "${GETPIP_URL}" -o "$GETPIP_PY" &> /dev/null; then
     exit 1
 fi
 
-# If a new Python has been installed or Pip isn't up to date:
-if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
+# If Pip isn't up to date:
+CURRENT_PIP_VERSION="$(pip --version)"
 
-  puts-step "Installing pip"
+
+if [ "$FRESH_PYTHON" ] || [[ ! "$CURRENT_PIP_VERSION" == *$PIP_UPDATE* ]]; then
+
+  puts-step "Installing pip $PIP_UPDATE"
 
   # Remove old installations.
   rm -fr /app/.heroku/python/lib/python*/site-packages/pip-*
@@ -163,6 +166,8 @@ if [ "$FRESH_PYTHON" ] || [[ ! $(pip --version) == *$PIP_UPDATE* ]]; then
 
   /app/.heroku/python/bin/python "$GETPIP_PY" pip=="$PIP_UPDATE" &> /dev/null
   /app/.heroku/python/bin/pip install "$ROOT_DIR/vendor/setuptools-39.0.1-py2.py3-none-any.whl" &> /dev/null
+else
+  puts-step "pip version $CURRENT_PIP_VERSION is already installed"
 fi
 
 set -e


### PR DESCRIPTION
Superceding #792, running from privileged account (which I didn't know I had to do back in 2018 😉).

Adds a print statement to report in build log which pip version we're using - this is especially valuable as we update pip more regularly.

In progress:

- [ ]  Add tests confirming expected behavior
