### PR TITLE
Remove confusing diff output for cache check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Master
 
 - update Code Owners to include the Heroku Buildpack Maintainers team
+- Clean up build log output
 
 - Add failcase for cache busting
 - Bugfix: Clearing pip dependencies

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -110,7 +110,7 @@ if [[ ! -f "$CACHE_DIR/.heroku/requirements.txt" ]]; then
   fi
 else
   # IF there IS a cached directory, check for differences with the new one
-  if ! diff "$BUILD_DIR/requirements.txt" "$CACHE_DIR/.heroku/requirements.txt"; then
+  if ! diff "$BUILD_DIR/requirements.txt" "$CACHE_DIR/.heroku/requirements.txt" &> /dev/null; then
     puts-step "Clearing cached dependencies"
     # if there are any differences, clear the Python cache
     # Installing Python over again does not take noticably more time


### PR DESCRIPTION
Thanks to @jkutner's son for being the very first reporter 🎉 

Fixes #942 confusing output from `diff` command. Note, "Clearing cache" output will be addressed in a separate test-expanding PR confirming the clear-cache behavior.
