### PR TITLE
More recent changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@
 - Doc: Update Readme with version numbers
 - update Code Owners to include the Heroku Buildpack Maintainers team
 - Clean up build log output
-
-- Add failcase for cache busting
-- Bugfix: Clearing pip dependencies
-- Correct ftp to https in vendored file
-- Warn for Django 1.11 approaching EOL, provide link to roadmap
 - Update Python versions in README to match docs
 
 --------------------------------------------------------------------------------
+
+# 167 (2020-03-26)
+
+- Add failcase for cache busting
+- Bugfix: Clearing pip dependencies
+
+# 166 (2020-03-05)
+
+- Correct ftp to https in vendored file
+- Warn for Django 1.11 approaching EOL, provide link to roadmap
 
 # 165 (2020-02-27)
 


### PR DESCRIPTION
Supersedes #937. 

Automerge for change logs can cause serious errors in a file where line number is related to chronological order, so made a fresh clean slate to make sure everything's right where it should be.
