### PR TITLE
Update hatchet tests to support latest version of Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Master
 
 - Bugfix: Caching on subsequent redeploys
+- Update tests to support latest version of Python
 
 --------------------------------------------------------------------------------
 

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -36,7 +36,7 @@ describe "Default Python Deploy" do
       expect(app.output).to_not match("Requirements file has been changed, updating cache")
       expect(app.output).to_not match("No dependencies found, preparing to install")
 
-      expect(app.run('python -V')).to match(/3.7.3/)
+      expect(app.run('python -V')).to match(/3.7.6/)
     end
   end
 end


### PR DESCRIPTION
Depends on https://github.com/heroku/python-getting-started/pull/99
