### PR TITLE
Add a Hatchet test for python 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Master
 
+- Add a Hatchet test for python 3.8.2
 - Set Code Owners to @heroku/langauges
 - Bugfix: Caching on subsequent redeploys
 - Update tests to support latest version of Python

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -16,45 +16,46 @@ describe "Default Python Deploy" do
     init_app(app)
   end
 
-["3.7.6", "3.8.2"].each do |version|
-  context "on python-#{version}" do
-    let(:app) { Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK) }
-    let(:python_version) { version }
-    it "🐍" do
-      app.deploy do |app|
-        # What should happen on first deploy
-        expect(app.output).to           match(/Installing pip/)
+  ["3.7.6", "3.8.2"].each do |version|
+    context "on python-#{version}" do
+      let(:app) { Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK) }
+      let(:python_version) { version }
+      it "🐍" do
+        app.deploy do |app|
+          # What should happen on first deploy
+          expect(app.output).to           match(/Installing pip/)
 
-        # What should not happen
-        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-        expect(app.output).to_not match("No change in requirements detected, installing from cache")
-        expect(app.output).to_not match("No such file or directory")
-        expect(app.output).to_not match("cp: cannot create regular file")
+          # What should not happen
+          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
+          expect(app.output).to_not match("No change in requirements detected, installing from cache")
+          expect(app.output).to_not match("No such file or directory")
+          expect(app.output).to_not match("cp: cannot create regular file")
 
-        # Redeploy with changed requirements file
-        run!(%Q{echo "" >> requirements.txt})
-        run!(%Q{echo "flask" >> requirements.txt})
-        run!(%Q{git add . ; git commit --allow-empty -m next})
-        app.push!
+          # Redeploy with changed requirements file
+          run!(%Q{echo "" >> requirements.txt})
+          run!(%Q{echo "flask" >> requirements.txt})
+          run!(%Q{git add . ; git commit --allow-empty -m next})
+          app.push!
 
-        # Check the cache to have cleared
-        expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
+          # Check the cache to have cleared
+          expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
 
-        # What should not happen when the requirements file is changed
-        expect(app.output).to_not match("No dependencies found, preparing to install")
-        expect(app.output).to_not match("No change in requirements detected, installing from cache")
+          # What should not happen when the requirements file is changed
+          expect(app.output).to_not match("No dependencies found, preparing to install")
+          expect(app.output).to_not match("No change in requirements detected, installing from cache")
 
-        run!(%Q{git commit --allow-empty -m next})
-        app.push!
+          run!(%Q{git commit --allow-empty -m next})
+          app.push!
 
-        # With no changes on redeploy, the cache should
-        expect(app.output).to match("No change in requirements detected, installing from cache")
+          # With no changes on redeploy, the cache should
+          expect(app.output).to match("No change in requirements detected, installing from cache")
 
-        # With no changes on redeploy, the cache should not
-        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-        expect(app.output).to_not match("No dependencies found, preparing to install")
+          # With no changes on redeploy, the cache should not
+          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
+          expect(app.output).to_not match("No dependencies found, preparing to install")
 
-        expect(app.run('python -V')).to match(version)
+          expect(app.run('python -V')).to match(version)
+        end
       end
     end
   end

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -16,45 +16,46 @@ describe "Default Python Deploy" do
     init_app(app)
   end
 
-  ["3.7.6", "3.8.2"].each do |version|
-    context "on python-#{version}" do
-      let(:app) { Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK) }
-      let(:python_version) { version }
-      it "🐍" do
-        app.deploy do |app|
-          # What should happen on first deploy
-          expect(app.output).to           match(/Installing pip/)
+["3.7.6", "3.8.2"].each do |version|
+  context "on python-#{version}" do
+    let(:app) { Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK) }
+    let(:python_version) { version }
+    it "🐍" do
+      app.deploy do |app|
+        # What should happen on first deploy
+        expect(app.output).to           match(/Installing pip/)
 
-          # What should not happen
-          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-          expect(app.output).to_not match("No change in requirements detected, installing from cache")
-          expect(app.output).to_not match("No such file or directory")
-          expect(app.output).to_not match("cp: cannot create regular file")
+        # What should not happen
+        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
+        expect(app.output).to_not match("No change in requirements detected, installing from cache")
+        expect(app.output).to_not match("No such file or directory")
+        expect(app.output).to_not match("cp: cannot create regular file")
 
-          # Redeploy with changed requirements file
-          run!(%Q{echo "" >> requirements.txt})
-          run!(%Q{echo "flask" >> requirements.txt})
-          run!(%Q{git add . ; git commit --allow-empty -m next})
-          app.push!
+        # Redeploy with changed requirements file
+        run!(%Q{echo "" >> requirements.txt})
+        run!(%Q{echo "flask" >> requirements.txt})
+        run!(%Q{git add . ; git commit --allow-empty -m next})
+        app.push!
 
-          # Check for the cache to have cleared
-          expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
+        # Check the cache to have cleared
+        expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
 
-          # What should not happen when the requirements file is changed
-          expect(app.output).to_not match("No dependencies found, preparing to install")
-          expect(app.output).to_not match("No change in requirements detected, installing from cache")
+        # What should not happen when the requirements file is changed
+        expect(app.output).to_not match("No dependencies found, preparing to install")
+        expect(app.output).to_not match("No change in requirements detected, installing from cache")
 
-          run!(%Q{git commit --allow-empty -m next})
-          app.push!
+        run!(%Q{git commit --allow-empty -m next})
+        app.push!
 
-          # With no changes on redeploy, the cache should
-          expect(app.output).to match("No change in requirements detected, installing from cache")
+        # With no changes on redeploy, the cache should
+        expect(app.output).to match("No change in requirements detected, installing from cache")
 
-          # With no changes on redeploy, the cache should not
-          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-          expect(app.output).to_not match("No dependencies found, preparing to install")
+        # With no changes on redeploy, the cache should not
+        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
+        expect(app.output).to_not match("No dependencies found, preparing to install")
 
-          expect(app.run('python -V')).to match(version)
-        end
+        expect(app.run('python -V')).to match(version)
+      end
+    end
   end
 end

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -1,42 +1,60 @@
 require_relative '../spec_helper'
 
 describe "Default Python Deploy" do
-  it "🐍" do
-    Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK).deploy do |app|
 
-      # What should happen on first deploy
-      expect(app.output).to           match(/Installing pip/)
-
-      # What should not happen
-      expect(app.output).to_not match("Requirements file has been changed, updating cache")
-      expect(app.output).to_not match("No change in requirements detected, installing from cache")
-      expect(app.output).to_not match("No such file or directory")
-      expect(app.output).to_not match("cp: cannot create regular file")
-
-      # Redeploy with changed requirements file
-      run!(%Q{echo "" >> requirements.txt})
-      run!(%Q{echo "flask" >> requirements.txt})
-      run!(%Q{git add . ; git commit --allow-empty -m next})
-      app.push!
-
-      # Check for the cache to have cleared
-      expect(app.output).to match("Requirements file has been changed, updating cache")
-
-      # What should not happen when the requirements file is changed
-      expect(app.output).to_not match("No dependencies found, preparing to install")
-      expect(app.output).to_not match("No change in requirements detected, installing from cache")
-
-      run!(%Q{git commit --allow-empty -m next})
-      app.push!
-
-      # With no changes on redeploy, the cache should
-      expect(app.output).to match("No change in requirements detected, installing from cache")
-
-      # With no changes on redeploy, the cache should not
-      expect(app.output).to_not match("Requirements file has been changed, updating cache")
-      expect(app.output).to_not match("No dependencies found, preparing to install")
-
-      expect(app.run('python -V')).to match(/3.7.6/)
+  def set_python_version(d, v)
+    Dir.chdir(d) do
+      File.open('runtime.txt', 'w') do |f|
+        f.puts "python-#{v}"
+      end
+      `git add runtime.txt && git commit -am "setting python version"`
     end
+  end
+
+  before(:each) do
+    set_python_version(app.directory, python_version)
+    init_app(app)
+  end
+
+  ["3.7.6", "3.8.2"].each do |version|
+    context "on python-#{version}" do
+      let(:app) { Hatchet::Runner.new('python-getting-started', stack: DEFAULT_STACK) }
+      let(:python_version) { version }
+      it "🐍" do
+        app.deploy do |app|
+          # What should happen on first deploy
+          expect(app.output).to           match(/Installing pip/)
+
+          # What should not happen
+          expect(app.output).to_not match("Requirements file has been changed, updating cache")
+          expect(app.output).to_not match("No change in requirements detected, installing from cache")
+          expect(app.output).to_not match("No such file or directory")
+          expect(app.output).to_not match("cp: cannot create regular file")
+
+          # Redeploy with changed requirements file
+          run!(%Q{echo "" >> requirements.txt})
+          run!(%Q{echo "flask" >> requirements.txt})
+          run!(%Q{git add . ; git commit --allow-empty -m next})
+          app.push!
+
+          # Check for the cache to have cleared
+          expect(app.output).to match("Requirements file has been changed, updating cache")
+
+          # What should not happen when the requirements file is changed
+          expect(app.output).to_not match("No dependencies found, preparing to install")
+          expect(app.output).to_not match("No change in requirements detected, installing from cache")
+
+          run!(%Q{git commit --allow-empty -m next})
+          app.push!
+
+          # With no changes on redeploy, the cache should
+          expect(app.output).to match("No change in requirements detected, installing from cache")
+
+          # With no changes on redeploy, the cache should not
+          expect(app.output).to_not match("Requirements file has been changed, updating cache")
+          expect(app.output).to_not match("No dependencies found, preparing to install")
+
+          expect(app.run('python -V')).to match(version)
+        end
   end
 end

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -26,7 +26,7 @@ describe "Default Python Deploy" do
           expect(app.output).to           match(/Installing pip/)
 
           # What should not happen
-          expect(app.output).to_not match("Requirements file has been changed, updating cache")
+          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
           expect(app.output).to_not match("No change in requirements detected, installing from cache")
           expect(app.output).to_not match("No such file or directory")
           expect(app.output).to_not match("cp: cannot create regular file")
@@ -38,7 +38,7 @@ describe "Default Python Deploy" do
           app.push!
 
           # Check for the cache to have cleared
-          expect(app.output).to match("Requirements file has been changed, updating cache")
+          expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
 
           # What should not happen when the requirements file is changed
           expect(app.output).to_not match("No dependencies found, preparing to install")
@@ -51,7 +51,7 @@ describe "Default Python Deploy" do
           expect(app.output).to match("No change in requirements detected, installing from cache")
 
           # With no changes on redeploy, the cache should not
-          expect(app.output).to_not match("Requirements file has been changed, updating cache")
+          expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
           expect(app.output).to_not match("No dependencies found, preparing to install")
 
           expect(app.run('python -V')).to match(version)


### PR DESCRIPTION
This uses a patterned borrowed from the [Java buildpack's tests](https://github.com/heroku/heroku-buildpack-java/blob/master/spec/java_spec.rb#L16) to test a matrix of runtime versions on the same app.