### PR TITLE
Fix changelog after rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 # Master
 
-- Doc: fix runtime.txt generation when using pipenv
-- Update requirements.txt builds to use Pip 20.0.2
-- Download get-pip.py to tmpdir instead of root dir
-- Bugfix: Fix support for naive latest version declaration in Python 3.8
+- Docs: Fix explanation of runtime.txt generation when using pipenv
+- Bugfix: Correctly detect Python version when using a `python_version` of `3.8` in `Pipfile.lock`
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The merge of #910 added three lines to the changelog (rather than just one line):
https://github.com/heroku/heroku-buildpack-python/commit/932cd257c98e9f56e878134f84a09d7d972bc46e

The original commit before rebase, was:
https://github.com/heroku/heroku-buildpack-python/pull/910/commits/d57d26b2e0348199228312950e55b42bc9de8147

I've also clarified the wording of it and the other unreleased change, to reduce the chance for confusion as to what's changed, when customers debug issues.