### PR TITLE
support python 3.6.11 and 3.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Python Buildpack Changelog
 
+# Master
+- Python 3.6.11 and 3.7.8 are now available (CPython)
+
 # 170 (2020-05-19)
 
 - Python 2.7.18, 3.5.9, 3.7.7 and 3.8.3 are now available (CPython).

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Specify a Python Runtime
 Supported runtime options include:
 
 - `python-3.8.3`
-- `python-3.7.7`
-- `python-3.6.10`
+- `python-3.7.8`
+- `python-3.6.11`
 - `python-2.7.18`
 
 ## Tests

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-DEFAULT_PYTHON_VERSION="python-3.6.10"
+DEFAULT_PYTHON_VERSION="python-3.6.11"
 LATEST_38="python-3.8.3"
-LATEST_37="python-3.7.7"
-LATEST_36="python-3.6.10"
+LATEST_37="python-3.7.8"
+LATEST_36="python-3.6.11"
 LATEST_35="python-3.5.9"
 LATEST_34="python-3.4.10"
 LATEST_27="python-2.7.18"

--- a/builds/runtimes/python-3.6.11
+++ b/builds/runtimes/python-3.6.11
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3

--- a/builds/runtimes/python-3.7.8
+++ b/builds/runtimes/python-3.7.8
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3


### PR DESCRIPTION
This should include support for CPython `3.6.11` and `3.7.8`, following the pattern in https://github.com/heroku/heroku-buildpack-python/pull/977 . 

I'm happy to apply fixes where needed. 