### PR TITLE
Evaluate symlinks when comparing $BUILD_DIR against /app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bugfix: handle build environments where `$BUILD_DIR` is set to a symlink of `/app`
 
 ## v192 (2021-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bugfix: handle build environments where `$BUILD_DIR` is set to a symlink of `/app`
+- Support build environments where `$BUILD_DIR` is set to a symlink of `/app` (#992).
 
 ## v192 (2021-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Support build environments where `$BUILD_DIR` is set to a symlink of `/app` (#992).
+- Support build environments where `$BUILD_DIR` is set to a symlink of `/app` ([#992](https://github.com/heroku/heroku-buildpack-python/pull/992)).
 
 ## v192 (2021-04-06)
 

--- a/bin/compile
+++ b/bin/compile
@@ -240,7 +240,8 @@ mkdir -p /app/.heroku/src
 # they occur in a temp directory. Beacuse Python is not portable, we must create
 # symlinks to emulate that we are operating in `/app` during the build process.
 # This is (hopefully obviously) because apps end up running from `/app` in production.
-if [[ $(realpath "$BUILD_DIR") != $(realpath /app) ]]; then
+# Realpath is used to support use-cases where one of the locations is a symlink to the other.
+if [[ "$(realpath "${BUILD_DIR}")" != "$(realpath /app)" ]]; then
     # python expects to reside in /app, so set up symlinks
     # we will not remove these later so subsequent buildpacks can still invoke it
     ln -nsf "$BUILD_DIR/.heroku/python" /app/.heroku/python

--- a/bin/compile
+++ b/bin/compile
@@ -240,7 +240,7 @@ mkdir -p /app/.heroku/src
 # they occur in a temp directory. Beacuse Python is not portable, we must create
 # symlinks to emulate that we are operating in `/app` during the build process.
 # This is (hopefully obviously) because apps end up running from `/app` in production.
-if [[ $BUILD_DIR != '/app' ]]; then
+if [[ $(realpath "$BUILD_DIR") != $(realpath /app) ]]; then
     # python expects to reside in /app, so set up symlinks
     # we will not remove these later so subsequent buildpacks can still invoke it
     ln -nsf "$BUILD_DIR/.heroku/python" /app/.heroku/python

--- a/bin/compile
+++ b/bin/compile
@@ -303,7 +303,8 @@ mtime "nltk.download.time" "${start}"
 # Support for editable installations. Here, we are copying pip–created src directory,
 # and copying it into the proper place (the logical place to do this was early, but it must be done here).
 # In CI, $BUILD_DIR is /app.
-if [[ ! "$BUILD_DIR" == "/app" ]]; then
+# Realpath is used to support use-cases where one of the locations is a symlink to the other.
+if [[ "$(realpath "${BUILD_DIR}")" != "$(realpath /app)" ]]; then
   rm -rf "$BUILD_DIR/.heroku/src"
   deep-cp /app/.heroku/src "$BUILD_DIR/.heroku/src"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -240,8 +240,8 @@ mkdir -p /app/.heroku/src
 # they occur in a temp directory. Beacuse Python is not portable, we must create
 # symlinks to emulate that we are operating in `/app` during the build process.
 # This is (hopefully obviously) because apps end up running from `/app` in production.
-# readlink is used to support use-cases where one of the locations is a symlink to the other.
-if [[ "$(readlink -e "${BUILD_DIR}")" != "$(readlink -e /app)" ]]; then
+# Realpath is used to support use-cases where one of the locations is a symlink to the other.
+if [[ "$(realpath "${BUILD_DIR}")" != "$(realpath /app)" ]]; then
     # python expects to reside in /app, so set up symlinks
     # we will not remove these later so subsequent buildpacks can still invoke it
     ln -nsf "$BUILD_DIR/.heroku/python" /app/.heroku/python

--- a/bin/compile
+++ b/bin/compile
@@ -240,8 +240,8 @@ mkdir -p /app/.heroku/src
 # they occur in a temp directory. Beacuse Python is not portable, we must create
 # symlinks to emulate that we are operating in `/app` during the build process.
 # This is (hopefully obviously) because apps end up running from `/app` in production.
-# Realpath is used to support use-cases where one of the locations is a symlink to the other.
-if [[ "$(realpath "${BUILD_DIR}")" != "$(realpath /app)" ]]; then
+# readlink is used to support use-cases where one of the locations is a symlink to the other.
+if [[ "$(readlink -e "${BUILD_DIR}")" != "$(readlink -e /app)" ]]; then
     # python expects to reside in /app, so set up symlinks
     # we will not remove these later so subsequent buildpacks can still invoke it
     ln -nsf "$BUILD_DIR/.heroku/python" /app/.heroku/python


### PR DESCRIPTION
This updates the `$BUILD_DIR` check to evaluate symlinks before comparing to `/app`.

In our build environment we have `/app` symlinked to `/workspace` to accommodate other buildpacks. `$BUILD_DIR` is set to `/workspace`. That causes this buildpack to fail to build because the paths aren't equal so the `.heroku/*` symlinks are created and in a later step the buildpack tries to install python over the symlink.

```
2020-07-08T15:36:14.47487514Z -----> Installing python-3.6.10
2020-07-08T15:36:14.493172053Z mkdir: cannot create directory â€˜.heroku/pythonâ€™: File exists
2020-07-08T15:36:31.569316508Z  !     Requested runtime (python-3.6.10) is not available for this stack (heroku-18).
2020-07-08T15:36:31.569494894Z  !     Aborting.  More info: 
```