### PR TITLE
Improve the Check Changelog GitHub action

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,14 +1,17 @@
 name: Check Changelog
 
 on:
- pull_request:
-  types: [opened, reopened, edited, synchronize]
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
- build:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: actions/checkout@v1
-   - name: Check that CHANGELOG is touched
-     run: |
-       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+  check:
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.body, '[skip changelog]') &&
+      !contains(github.event.pull_request.body, '[changelog skip]') &&
+      !contains(github.event.pull_request.body, '[skip ci]')
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check that CHANGELOG is touched
+        run: git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
It now:
* uses the PR body rather than title for controlling whether to skip the check, to reduce PR title noise
* supports `[skip changelog]` in addition to `[changelog skip]`, since I could never remember which way around the words should go
* uses the GitHub `if` syntax with the `github` event context, which simplifies the implementation, means the action doesn't run steps like git checkout when it's going to be skipped anyway, and gives the status check the grey icon when skipped instead of the green check
* renames the inner job from `build` to `check`

The file has also been style-formatted using Prettier.

See:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request

Example failing (since no skip syntax used):
https://github.com/heroku/heroku-buildpack-python/pull/1009/checks?check_run_id=906015118

Example skipped (since skip syntax used):
https://github.com/heroku/heroku-buildpack-python/pull/1009/checks?check_run_id=906022522