### PR TITLE
Tests: Run detect/compile/release in a clean environment

### DIFF
--- a/test/run-deps
+++ b/test/run-deps
@@ -5,8 +5,9 @@
 source "bin/default_pythons"
 
 testAirflow() {
-  export SLUGIFY_USES_TEXT_UNIDECODE="yes"
-  compile "airflow"
+  local env_dir="$(mktmpdir)"
+  echo 'yes' > "${env_dir}/SLUGIFY_USES_TEXT_UNIDECODE"
+  compile 'airflow' '' "${env_dir}"
   assertCaptured "apache-airflow==1.10.2"
   assertCapturedSuccess
 }
@@ -17,27 +18,30 @@ testCollectstatic() {
 }
 
 testGEOS() {
-  export BUILD_WITH_GEO_LIBRARIES=1
-  compile "geos"
+  local env_dir="$(mktmpdir)"
+  echo '1' > "${env_dir}/BUILD_WITH_GEO_LIBRARIES"
+  compile 'geos' '' "${env_dir}"
   assertCaptured "geos"
   assertCapturedSuccess
 }
 
 testGEOSDeprecation() {
-  export BUILD_WITH_GEO_LIBRARIES=1
-  compile "geos"
+  local env_dir="$(mktmpdir)"
+  echo '1' > "${env_dir}/BUILD_WITH_GEO_LIBRARIES"
+  compile 'geos' '' "${env_dir}"
   assertCaptured " !     The GDAL, GEOS and PROJ binaries and BUILD_WITH_GEO_LIBRARIES functonality are now deprecated.
  !     An alternative buildpack to enable GDAL, GEOS and PROJ use is available here - https://github.com/heroku/heroku-geo-buildpack"
   assertCapturedSuccess
 }
 
 testNLTK() {
+  local env_dir="$(mktmpdir)"
   # NOTE: This is a RuntimeWarning emitted by Python 3's runpy.py script
   # which is what is used when you call `python -m <module>`. This is due to
   # how nltk imports things. It's not actually an error, but it would probably
   # be bad to silence in Production.
-  export PYTHONWARNINGS="ignore::RuntimeWarning"
-  compile "nltk"
+  echo 'ignore::RuntimeWarning' > "${env_dir}/PYTHONWARNINGS"
+  compile 'nltk' '' "${env_dir}"
   assertCaptured "[nltk_data] Downloading package city_database" "STD_ERR"
   assertCapturedSuccess
 }

--- a/test/utils
+++ b/test/utils
@@ -234,13 +234,18 @@ default_process_types_cleanup() {
   fi
 }
 
+run_in_clean_env() {
+  # Prevent stray environment variables from outside the test runner being exposed to tests.
+  env -i HOME="${HOME}" LANG="${LANG}" PATH="${PATH}" STACK="${STACK}" "$@"
+}
+
 compile() {
   default_process_types_cleanup
   bp_dir=$(mktmpdir)
   compile_dir=$(mktmpdir)
   cp -a $(pwd)/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
-  capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+  capture run_in_clean_env ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
 }
 
 compileDir() {
@@ -252,13 +257,13 @@ compileDir() {
   local env_dir=$3
 
   cp -a $(pwd)/* ${bp_dir}
-  capture ${bp_dir}/bin/compile ${compile_dir} ${cache_dir} ${env_dir}
+  capture run_in_clean_env ${bp_dir}/bin/compile ${compile_dir} ${cache_dir} ${env_dir}
 }
 
 release() {
   bp_dir=$(mktmpdir)
   cp -a $(pwd)/* ${bp_dir}
-  capture ${bp_dir}/bin/release ${bp_dir}/test/fixtures/$1
+  capture run_in_clean_env ${bp_dir}/bin/release ${bp_dir}/test/fixtures/$1
 }
 
 assertFile() {


### PR DESCRIPTION
To prevent external environment variables from leaking into the tests, which otherwise causes problems trying to write tests for #1011.

Several tests which were relying on this leak had to be fixed, so that the env vars they were using are set using `ENV_DIR`, as happens in production.

Fixes #1014.
Fixes #1015.

[skip changelog]