### PR TITLE
Tests: Delete redundant detect(), compile() and release()

### DIFF
--- a/test/utils
+++ b/test/utils
@@ -56,21 +56,6 @@ resetCapture()
   unset rtrn # deprecated
 }
 
-detect()
-{
-  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
-}
-
-compile()
-{
-  capture ${BUILDPACK_HOME}/bin/compile ${BUILD_DIR} ${CACHE_DIR}
-}
-
-release()
-{
-  capture ${BUILDPACK_HOME}/bin/release ${BUILD_DIR}
-}
-
 updateVersion()
 {
   echo "$2" > "test/fixtures/${1}/runtime.txt"


### PR DESCRIPTION
Since they are all shadowed by functions with the same name later in the file.

Fixes #1013.

[skip changelog]
