### PR TITLE
Travis: Reduce end to end testing time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,40 @@
-language: ruby
+language: minimal
 dist: bionic
-sudo: required
 branches:
   only:
   - master
 
-rvm:
-- 2.6.6
-before_script:
-  - gem install bundler -v 1.16.2
-
 script:
-  - make test STACK="cedar-14" TEST_CMD="${TESTFOLDER}"
-  - make test STACK="heroku-16" TEST_CMD="${TESTFOLDER}"
-  - make test STACK="heroku-18" TEST_CMD="${TESTFOLDER}"
+  - make test STACK="${STACK}" TEST_CMD="${TEST_CMD}"
 
 jobs:
   include:
-  - stage: Bash linting (shellcheck)
-    sudo: false
+  - name: Bash linting (shellcheck)
     script: make check
-  - stage: Hatchet Integration
+  - name: Hatchet integration tests
     if: env(TRAVIS_PULL_REQUEST_SLUG) = env(TRAVIS_REPO_SLUG)
-    name: Run Hatchet
+    language: ruby
+    rvm:
+      - 2.6.6
+    before_script:
+      - gem install bundler -v 1.16.2
     script:
       - bundle exec hatchet ci:setup
       - PARALLEL_SPLIT_TEST_PROCESSES=11 bundle exec parallel_split_test spec/hatchet/
 
 env:
-  matrix:
-    - TESTFOLDER=test/run-deps
-    - TESTFOLDER=test/run-versions
-    - TESTFOLDER=test/run-features
+  jobs:
+    - STACK=cedar-14 TEST_CMD=test/run-deps
+    - STACK=cedar-14 TEST_CMD=test/run-versions
+    - STACK=cedar-14 TEST_CMD=test/run-features
+
+    - STACK=heroku-16 TEST_CMD=test/run-deps
+    - STACK=heroku-16 TEST_CMD=test/run-versions
+    - STACK=heroku-16 TEST_CMD=test/run-features
+
+    - STACK=heroku-18 TEST_CMD=test/run-deps
+    - STACK=heroku-18 TEST_CMD=test/run-versions
+    - STACK=heroku-18 TEST_CMD=test/run-features
   global:
     - HATCHET_RETRIES=3
     - IS_RUNNING_ON_CI=true


### PR DESCRIPTION
This change (along with #1021, which skips an unnecessary docker build) reduces the wall clock time from ~22 minutes to ~6 minutes. Even with the additional Travis setup overhead from the larger job matrix, the combined job duration (~50 minutes) has not increased due to the other time savings.

Changes:

- for the unit tests, each stack is now tested in its own job and so tested in parallel
- the use of Travis stages has been removed, since by design it blocks later tasks on earlier stages having completed - reducing parallelism unnecessarily for this use case
- all jobs except for the Hatchet job now use Travis' `minimal` image, and no longer install redundant Ruby + bundler
- the `sudo: {required,false}` references have been removed, since Travis no longer supports its non-sudo container infrastructure so ignores that option

Fixes #1018.

[skip changelog]