### PR TITLE
Update setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- Update setuptools from 39.0.1 to: (#1024)
+  - 44.1.1 for Python 2.7
+  - 43.0.0 for Python 3.4
+  - 47.1.1 for Python 3.5+
 - Switch the `heroku-buildpack-python` repository default branch from `master` to `main` (#1029).
 
 # 174 (2020-07-30)

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -138,13 +138,19 @@ fi
 set -e
 
 PIP_VERSION='20.0.2'
-SETUPTOOLS_VERSION='39.0.1'
+# Must use setuptools <47.2.0 until we fix:
+# https://github.com/heroku/heroku-buildpack-python/issues/1006
+SETUPTOOLS_VERSION='47.1.1'
 WHEEL_VERSION='0.34.2'
 
 if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then
-  # Python 3.4 support was dropped in pip 19.2+ and wheel 0.34.0+.
+  # Python 3.4 support was dropped in pip 19.2+, setuptools 44+ and wheel 0.34+.
   PIP_VERSION='19.1.1'
+  SETUPTOOLS_VERSION='43.0.0'
   WHEEL_VERSION='0.33.6'
+elif [[ "${PYTHON_VERSION}" == ${PY27}* || "${PYTHON_VERSION}" == ${PYPY27}* ]]; then
+  # Python 2.7 support was dropped in setuptools 45+.
+  SETUPTOOLS_VERSION='44.1.1'
 fi
 
 # We don't use get-pip.py, since:

--- a/test/run-features
+++ b/test/run-features
@@ -44,7 +44,7 @@ testStandardRequirements() {
 
 testPipenv() {
   compile "pipenv"
-  assertCaptured "Installing pip 9.0.2, setuptools 39.0.1 and wheel 0.34.2"
+  assertCaptured "Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2"
   assertCapturedSuccess
 }
 

--- a/test/run-versions
+++ b/test/run-versions
@@ -9,7 +9,7 @@ testPythonDefault() {
   compile "pythonDefault"
   assertCaptured $DEFAULT_PYTHON_VERSION
   assertNotCaptured "security update"
-  assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+  assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
   assertCaptured "Installing SQLite3"
   assertCapturedSuccess
 }
@@ -25,7 +25,7 @@ testPython2() {
       assertNotCaptured "python-2-7-eol-faq";
     fi
     assertNotCaptured "security update"
-    assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+    assertCaptured "Installing pip 20.0.2, setuptools 44.1.1 and wheel 0.34.2"
     assertCaptured "Installing SQLite3"
     assertCapturedSuccess
 }
@@ -53,7 +53,7 @@ testPython3_4() {
   compile "python3_4"
   assertCaptured $LATEST_34
   assertNotCaptured "security update"
-  assertCaptured "Installing pip 19.1.1, setuptools 39.0.1 and wheel 0.33.6"
+  assertCaptured "Installing pip 19.1.1, setuptools 43.0.0 and wheel 0.33.6"
   # if cedar 14 and legacy binaries, fail. if cedar 14 and staging, succeed.
   if [[ ! -n $USE_STAGING_BINARIES ]] && [[ $STACK == "cedar-14" ]]; then
       assertCapturedError
@@ -89,7 +89,7 @@ testPython3_5() {
   compile "python3_5"
   assertCaptured $LATEST_35
   assertNotCaptured "security update"
-  assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+  assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
   assertCaptured "Installing SQLite3"
   assertCapturedSuccess
 }
@@ -112,7 +112,7 @@ testPython3_6() {
   compile "python3_6"
   assertCaptured $LATEST_36
   assertNotCaptured "security update"
-  assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+  assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
   assertCaptured "Installing SQLite3"
   assertCapturedSuccess
 }
@@ -139,7 +139,7 @@ testPython3_7() {
   else
     assertNotCaptured "security update"
     assertCaptured $LATEST_37
-    assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+    assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
     assertCaptured "Installing SQLite3"
     assertCapturedSuccess
   fi
@@ -183,7 +183,7 @@ testPython3_8() {
   else
     assertNotCaptured "security update"
     assertCaptured $LATEST_38
-    assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+    assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
     assertCaptured "Installing SQLite3"
     assertCapturedSuccess
   fi
@@ -202,7 +202,7 @@ testPypy3_6() {
   else
     assertCaptured "Installing pypy"
     assertCaptured "$PYPY_36"
-    assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+    assertCaptured "Installing pip 20.0.2, setuptools 47.1.1 and wheel 0.34.2"
     assertCapturedSuccess
   fi
 }
@@ -214,7 +214,7 @@ testPypy2_7() {
   else
     assertCaptured "Installing pypy"
     assertCaptured "$PYPY_27"
-    assertCaptured "Installing pip 20.0.2, setuptools 39.0.1 and wheel 0.34.2"
+    assertCaptured "Installing pip 20.0.2, setuptools 44.1.1 and wheel 0.34.2"
     assertCapturedSuccess
   fi
 }


### PR DESCRIPTION
Upgrades setuptools from 39.0.1 to:
- 44.1.1 for Python 2.7 (since it's the last supported version)
- 43.0.0 for Python 3.4 (since it's the last supported version)
- 47.1.1 for Python 3.5+ (since we can't use 47.2.0+ until #1006 fixed)

https://setuptools.readthedocs.io/en/latest/history.html#v47-1-1

Fixes #949.
Closes #973.