### PR TITLE
Symlink staticfiles option

### DIFF
--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -9,6 +9,7 @@
 # Runtime arguments:
 #   - $DISABLE_COLLECTSTATIC: disables this functionality.
 #   - $DEBUG_COLLECTSTATIC: upon failure, print out environment variables.
+#   - $SYMLINK_COLLECTSTATIC: symlink static files where possible.
 
 # shellcheck source=bin/utils
 source "$BIN_DIR/utils"
@@ -36,7 +37,11 @@ if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALL
     # Create a temporary file for collecting the collectstaic logs.
     COLLECTSTATIC_LOG=$(mktemp)
 
-    python "$MANAGE_FILE" collectstatic --noinput --traceback 2>&1 | tee "$COLLECTSTATIC_LOG" | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
+    if [ "$SYMLINK_COLLECTSTATIC" ]; then
+      python "$MANAGE_FILE" collectstatic --link --noinput --traceback 2>&1 | tee "$COLLECTSTATIC_LOG"
+    else
+      python "$MANAGE_FILE" collectstatic --noinput --traceback 2>&1 | tee "$COLLECTSTATIC_LOG" | sed '/^Post-processed/d;/^Copying/d;/^$/d' | indent
+    fi
     COLLECTSTATIC_STATUS="${PIPESTATUS[0]}"
 
     set -e

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -28,7 +28,7 @@ sp-grep -s django && DJANGO_INSTALLED=1
 if [ ! "$DISABLE_COLLECTSTATIC" ] && [ -f "$MANAGE_FILE" ] && [ "$DJANGO_INSTALLED" ]; then
     set +e
 
-    puts-step "$ python $MANAGE_FILE collectstatic --noinput"
+    puts-step "$ python $MANAGE_FILE collectstatic"
 
     # Run collectstatic, cleanup some of the noisy output.
     PYTHONPATH=${PYTHONPATH:-.}


### PR DESCRIPTION
Django's `collectstatic` command has a `--link` option (https://docs.djangoproject.com/en/2.2/ref/contrib/staticfiles/#cmdoption-collectstatic-link) which symlinks files where possible instead of creating copies of them.

I've seen this reduce the size of `collected-static` directories by up to 40% so this should have a positive impact on slug sizes!

As far as I can tell this is also compatible with Whitenoise and doesn't interfere with how it generates gzipped versions of files as those remain as actual files.