### PR TITLE
Add a configuration file for Git2Gus

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,0 +1,6 @@
+{
+  "productTag": "a1aB0000000MR0RIAW",
+  "issueTypeLabels": { "gus: story": "USER STORY", "gus: bug": "BUG P3" },
+  "defaultBuild": "Heroku Unscheduled",
+  "statusWhenClosed": "CLOSED"
+}


### PR DESCRIPTION
This will allow for one-way sync of GitHub issues in this repository into our internal issues tracker, GUS. Issues are only synced when the specified GitHub label is added.

In the future I may switch the chosen label to just be the standard `t: bug` type labels, but for now I'm choosing a separate label so that we have more control over what is synced.

See:
https://lwc-gus-bot.herokuapp.com/#getting-started

@W-7918433@

[skip changelog]