### PR TITLE
Travis: Move hatchet ci:setup to before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
       - 2.6.6
     before_script:
       - gem install bundler -v 1.16.2
-    script:
       - bundle exec hatchet ci:setup
+    script:
       - PARALLEL_SPLIT_TEST_PROCESSES=11 bundle exec parallel_split_test spec/hatchet/
 
 env:


### PR DESCRIPTION
So that any failures during `hatchet ci:setup` cause the build to fail early, rather than try to proceed with running the Hatchet tests.

@W-7929878@

[skip changelog]