### PR TITLE
Add config file for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "c: dependencies"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "c: dependencies"


### PR DESCRIPTION
GitHub are gradually integrating Dependabot into GitHub as a native feature. The native integration now supports updating not only security updates, but all dependencies - however this must be explicitly enabled by adding a config file:
https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates

The config options are described here:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

Closes @W-7937066@.

[skip changelog]