### PR TITLE
Remove unused etc/ci-setup.sh

### DIFF
--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-sudo apt-get -qq update
-sudo apt-get install software-properties-common
-curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh


### PR DESCRIPTION
It stopped being used as of #781.

```
$ rg ci-setup.sh --stats
0 matches

$ git-content-search ci-setup.sh
e7da63f update to newer hatchet integration
M      .travis.yml
576def4 fix travis dependency blocker
M      .travis.yml

$ git show e7da63f | rg ci-setup.sh -C 1
-before_install:
- - sudo bash etc/ci-setup.sh
+ - bundle exec hatchet ci:setup
```

Hatchet embeds its own setup script, which is called via the rake task:
https://github.com/heroku/hatchet/blob/v6.0.0/etc/ci_setup.rb

Closes @W-7923930@.

[skip changelog]