### PR TITLE
Remove unused .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace


### PR DESCRIPTION
Since we don't use that tool (<https://pre-commit.com>), and there are better alternatives should we want to expand coverage of these kind of things.

Closes @W-7923935@.

[skip changelog]