### PR TITLE
Travis: Correctly skip Hatchet on PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   - name: Bash linting (shellcheck)
     script: make check
   - name: Hatchet integration tests
-    if: env(TRAVIS_PULL_REQUEST_SLUG) = env(TRAVIS_REPO_SLUG)
+    if: env(HEROKU_API_USER) IS present AND env(HEROKU_API_KEY) IS present
     language: ruby
     rvm:
       - 2.7


### PR DESCRIPTION
The Hatchet run requires a valid Heroku login, the credentials for which are set via Travis secure environment variables, which by design are not revealed to PRs from forks.

The previous conditional wasn't working as intended - the Hatchet job was still being triggered for forks from PRs.

The new conditional fixes this, and also means that forks could set their own credentials via Travis environment variables if they wanted a way to run the tests in CI on their own repo.

See:
https://docs.travis-ci.com/user/conditions-v1

Fixes #1019.
Closes @W-7918482@.

[skip changelog]