### PR TITLE
Update the Python 3.4.10 build script to use the correct Python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Rebuild the Python 3.4.10 archives with the correct version of Python (#1048).
 - Fix the security update version check message for apps using PyPy (#1040).
 - Remove `vendor/test-utils` (#1043).
 

--- a/builds/runtimes/python-3.4.10
+++ b/builds/runtimes/python-3.4.10
@@ -1,32 +1,4 @@
 #!/usr/bin/env bash
 # Build Path: /app/.heroku/python/
 
-OUT_PREFIX=$1
-BIN_DIR="$(cd "$(dirname "$0")"/../.. || exit; pwd)/bin"
-export BIN_DIR
-
-# shellcheck source=bin/utils
-source "$BIN_DIR/steps/sqlite3"
-
-sqlite3_version
-echo "Setting up SQLite3 Headers for $SQLITE3_VERSION"
-sqlite3_install "$OUT_PREFIX" "$SQLITE3_VERSION" 1
-
-echo "Building Python…"
-SOURCE_TARBALL='https://python.org/ftp/python/3.7.2/Python-3.7.2.tgz'
-curl -L $SOURCE_TARBALL | tar xz
-mv Python-3.7.2 src
-cd src
-
-./configure --prefix=$OUT_PREFIX --with-ensurepip=no
-make
-make install
-
-# Remove unneeded test directories, similar to the official Docker Python images:
-# https://github.com/docker-library/python
-find "${OUT_PREFIX}" \( -type d -a \( -name test -o -name tests \) \) -exec rm -rf '{}' +
-
-# Remove spare /
-LOCATION=${OUT_PREFIX%?}
-
-ln $LOCATION/bin/python3 $LOCATION/bin/python
+source $(dirname $0)/python3

--- a/test/run-versions
+++ b/test/run-versions
@@ -54,29 +54,14 @@ testPython3_4() {
   assertCaptured $LATEST_34
   assertNotCaptured "security update"
   assertCaptured "Installing pip 19.1.1, setuptools 43.0.0 and wheel 0.33.6"
-  # if cedar 14 and legacy binaries, fail. if cedar 14 and staging, succeed.
-  if [[ ! -n $USE_STAGING_BINARIES ]] && [[ $STACK == "cedar-14" ]]; then
-      assertCapturedError
-# if heroku 18 and legacy binaries, succeed. if heroku 18 and staging, fail.
-  elif [[ -n $USE_STAGING_BINARIES ]] && [[ $STACK == "heroku-18" ]]; then
-      assertCapturedError
-  else
-#   all else succeed
-    assertCapturedSuccess
-  fi
+  assertCapturedSuccess
 }
 
 testPython3_4_warn() {
   compile "python3_4_warn"
   assertCaptured "python-3.4.9"
   assertCaptured "security update!"
-# if heroku 18 and legacy binaries, succeed. if heroku 18 and staging, fail.
-  if [[ -n $USE_STAGING_BINARIES ]] && [[ $STACK == "heroku-18" ]]; then
-      assertCapturedError
-  else
-#   all else succeed
-    assertCapturedSuccess
-  fi
+  assertCapturedSuccess
 }
 
 testPython3_4_fail() {


### PR DESCRIPTION
The existing Python 3.4.10 archive actually contained Python 3.7.2, since the version in the source URL was not updated when the file was created in #813.

The build formula now uses the shared build script approach like all of the other build scripts, which ensures the version can never get out of sync (since it's extracted from the formula filename).

The build for Heroku-18 failed to compile `_ssl` properly (even though the build exited zero) since Python 3.4.10 is old enough it doesn't work well with libssl1.1. Installing `libssl1.0-dev` in the build image locally resolved the issue - however we don't want to use that in the future for newer Python, so I've not updated the `heroku-18.Dockerfile`.

In addition, with the rebuilt archives the tests now pass on Cedar-14, so no longer need to be marked as failing.

(There are a few other build scripts that need to be switched to the shared script approach, but they are being handled in the separate #1049, since those versions don't need anything to be rebuilt.)

Closes @W-7947035@.
