### PR TITLE
Travis: Switch to Ubuntu 20.04 base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: minimal
-dist: bionic
+dist: focal
 branches:
   only:
   - main


### PR DESCRIPTION
Since it's a smaller, more up to date image, with fewer services starting at boot, improving start times:
https://blog.travis-ci.com/2020-08-10-focal-build-environment
https://docs.travis-ci.com/user/reference/focal/

Closes @W-7951908@.

[skip changelog]