### PR TITLE
Remove unnecessary date conditional for Python 2 EOL warning

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -52,11 +52,9 @@ if curl --output /dev/null --silent --head --fail "$VENDORED_PYTHON"; then
     fi
   fi
   if [[ "$PYTHON_VERSION" == $PY27* ]]; then
+    puts-warn "$PYTHON_2_EOL_UPDATE"
+    echo "       Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq"
     # security update note
-    if [[ "$(date "+%Y")" -gt "2019" ]]; then
-      puts-warn "$PYTHON_2_EOL_UPDATE"
-      echo "       Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq"
-    fi
     if [ "$PYTHON_VERSION" != "$LATEST_27" ]; then
       puts-warn "$ONLY_SUPPORTED_2_VERSION" "$LATEST_27"
       echo "       Learn More: https://devcenter.heroku.com/articles/python-runtimes"

--- a/test/run-versions
+++ b/test/run-versions
@@ -19,11 +19,7 @@ testPython2() {
     echo $LATEST_27 > "runtime.txt"
     compile "python2"
     assertCaptured $LATEST_27
-    if [[ $(date "+%Y") > "2019" ]]; then
-      assertCaptured "python-2-7-eol-faq";
-    else
-      assertNotCaptured "python-2-7-eol-faq";
-    fi
+    assertCaptured "python-2-7-eol-faq";
     assertNotCaptured "security update"
     assertCaptured "Installing pip 20.1.1, setuptools 44.1.1 and wheel 0.34.2"
     assertCaptured "Installing SQLite3"
@@ -33,11 +29,7 @@ testPython2() {
 testPython2_warn() {
     compile "python2_warn"
     assertCaptured "python-2.7.15"
-    if [[ $(date "+%Y") > "2019" ]]; then
-      assertCaptured "python-2-7-eol-faq";
-    else
-      assertNotCaptured "python-2-7-eol-faq";
-    fi
+    assertCaptured "python-2-7-eol-faq";
     assertCaptured "Only the latest version"
     assertCaptured "Installing SQLite3"
     assertCapturedSuccess


### PR DESCRIPTION
Since we're past the end of 2019, so the conditional is always true.

Closes @W-7952394@.

[skip changelog]