### PR TITLE
Add support for Python 3.6.12 and 3.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Python 3.6.12 and 3.7.9 are now available (CPython) (#1054).
+- The default Python version for new apps is now 3.6.12 (previously 3.6.11) (#1054).
 
 ## v176 (2020-08-12)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ remote: Compressing source files... done.
 remote: Building source:
 remote:
 remote: -----> Python app detected
-remote: -----> Installing python-3.7.4
+remote: -----> Installing python
 remote: -----> Installing pip
 remote: -----> Installing SQLite3
 remote: -----> Installing requirements with pip
@@ -44,7 +44,7 @@ A `requirements.txt` must be present at the root of your application's repositor
 
 To specify your python version, you also need a `runtime.txt` file - unless you are using the default Python runtime version.
 
-Current default Python Runtime: Python 3.6.9
+Current default Python Runtime: Python 3.6.12
 
 Alternatively, you can provide a `setup.py` file, or a `Pipfile`.
 Using `pipenv` will generate `runtime.txt` at build time if one of the field `python_version` or `python_full_version` is specified in the `requires` section of your `Pipfile`.
@@ -63,8 +63,8 @@ Specify a Python Runtime
 Supported runtime options include:
 
 - `python-3.8.5`
-- `python-3.7.8`
-- `python-3.6.11`
+- `python-3.7.9`
+- `python-3.6.12`
 - `python-2.7.18`
 
 ## Tests

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -5,10 +5,10 @@
 # the env vars to subprocesses.
 # shellcheck disable=2034
 
-DEFAULT_PYTHON_VERSION="python-3.6.11"
+DEFAULT_PYTHON_VERSION="python-3.6.12"
 LATEST_38="python-3.8.5"
-LATEST_37="python-3.7.8"
-LATEST_36="python-3.6.11"
+LATEST_37="python-3.7.9"
+LATEST_36="python-3.6.12"
 LATEST_35="python-3.5.9"
 LATEST_34="python-3.4.10"
 LATEST_27="python-2.7.18"

--- a/builds/runtimes/python-3.6.12
+++ b/builds/runtimes/python-3.6.12
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3

--- a/builds/runtimes/python-3.7.9
+++ b/builds/runtimes/python-3.7.9
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3


### PR DESCRIPTION
Since they were released yesterday:
https://www.python.org/downloads/release/python-3612/
https://www.python.org/downloads/release/python-379/

Closes @W-7975179@.
Closes @W-7975181@.