### PR TITLE
Making heroku-postgresql addon optional

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,6 +5,7 @@ BUILD_DIR=$1
 
 MANAGE_FILE=$(cd "$BUILD_DIR" && find . -maxdepth 3 -type f -name 'manage.py' | head -1)
 MANAGE_FILE=${MANAGE_FILE:2}
+PYTHON_BUILDPACK_NO_DEFAULT_ADDON=${PYTHON_BUILDPACK_NO_DEFAULT_ADDON:-}
 
 cat <<EOF
 ---
@@ -13,7 +14,7 @@ config_vars:
 EOF
 
 
-if [[ $MANAGE_FILE ]]; then
+if [[ $MANAGE_FILE && -z $PYTHON_BUILDPACK_NO_DEFAULT_ADDON ]]; then
 cat <<EOF
 
 addons:

--- a/bin/release
+++ b/bin/release
@@ -5,7 +5,7 @@ BUILD_DIR=$1
 
 MANAGE_FILE=$(cd "$BUILD_DIR" && find . -maxdepth 3 -type f -name 'manage.py' | head -1)
 MANAGE_FILE=${MANAGE_FILE:2}
-PYTHON_BUILDPACK_NO_DEFAULT_ADDON=${PYTHON_BUILDPACK_NO_DEFAULT_ADDON:-}
+PYTHON_BUILDPACK_NO_DEFAULT_ADDON="$BUILD_DIR/no_default_addons"
 
 cat <<EOF
 ---
@@ -14,7 +14,7 @@ config_vars:
 EOF
 
 
-if [[ $MANAGE_FILE && -z $PYTHON_BUILDPACK_NO_DEFAULT_ADDON ]]; then
+if [[ $MANAGE_FILE ]] && [[ ! -f $PYTHON_BUILDPACK_NO_DEFAULT_ADDON ]]; then
 cat <<EOF
 
 addons:


### PR DESCRIPTION
## Use Cases:
- We might not need any databases for some django apps.
- We might use a non-heroku database for a heroku app.

## Why is it important:
- We create dev environment heroku apps on demand. It can be confusing to the devs when they see the default heroku DB being created.
- It should work the same as before, the `heroku-postgresql` addon part will only be included if there is a file stamp `no_default_addons` in the `BUILD_DIR`

<!-- Hi and welcome to the Heroku Python buildpack repository!

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->

