### PR TITLE
Tests: Switch to branch 'main' of python-getting-started repo

### DIFF
--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,5 +1,5 @@
 ---
 - - "./repos/python/python-getting-started"
-  - master
+  - main
 - - "./repos/python/python_default"
   - ca947f69027b2a30be5d26f9a42f25e54f4d7a1a


### PR DESCRIPTION
Since the default branch for that repository has been changed from `master` to `main` in [W-7903771](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Tig9IAC/view).

Closes [W-8047331](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008cldWIAQ/view).

[skip changelog]