### PR TITLE
Emit Python version metric events for all builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Emit Python version metric events for all builds, not just clean installs (#1066).
 
 ## v178 (2020-09-07)
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -80,6 +80,8 @@ else
   exit 1
 fi
 
+mcount "version.python.${PYTHON_VERSION}"
+
 if [[ "$STACK" != "$CACHED_PYTHON_STACK" ]]; then
     puts-step "Stack has changed from $CACHED_PYTHON_STACK to $STACK, clearing cache"
     rm -fr .heroku/python-stack .heroku/python-version .heroku/python .heroku/vendor .heroku/python .heroku/python-sqlite3-version
@@ -118,8 +120,6 @@ if [ ! "$SKIP_INSTALL" ]; then
 
     # Prepare destination directory.
     mkdir -p .heroku/python
-
-    mcount "version.python.$PYTHON_VERSION"
 
     if ! curl "${VENDORED_PYTHON}" -s | tar zxv -C .heroku/python &> /dev/null; then
       puts-warn "Requested runtime ($PYTHON_VERSION) is not available for this stack ($STACK)."


### PR DESCRIPTION
Previously the metric events describing the chosen Python version were only emitted when that Python version was installed, and not when it was being used from the build cache (the common case).

Now the version is emitted for all builds, improving visibility into the distribution of Python usage, and helping determine the priority of features like opt-in automatic Python patch updates.

Closes [W-8059668](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008ctxiIAA/view).