### PR TITLE
Remove duplicate pipenv metric event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove duplicate pipenv metric event (#1070).
 - Emit metrics for how the Python version was chosen for an app (#1069).
 - Emit Python version metric events for all builds, not just clean installs (#1066).
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -9,9 +9,6 @@ set -e
 if [[ -f Pipfile.lock ]]; then
     if [[ -f .heroku/python/Pipfile.lock.sha256 ]]; then
         if [[ $(openssl dgst -sha256 Pipfile.lock) == $(cat .heroku/python/Pipfile.lock.sha256) ]]; then
-            # Measure that we're using Pipenv.
-            mcount "tool.pipenv"
-
             # Don't skip installation of there are git deps.
             if ! grep -q 'git' Pipfile.lock; then
                 echo "Skipping installation, as Pipfile.lock hasn't changed since last deploy." | indent


### PR DESCRIPTION
Since the `tool.pipenv` event is being emitted twice per pipenv build, inflating its usage.

This whole file could do with a massive refactor (4 levels deep of conditionals is never a good sign), but that can wait until a later PR.

In the future it would also be great to have testing of metrics events.

Closes [W-8094963](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008dIsrIAE/view).