### PR TITLE
Tests: Prevent shadowing of the Python 3.7 version warning test

### DIFF
--- a/test/run-versions
+++ b/test/run-versions
@@ -140,18 +140,6 @@ testPython3_7_fail() {
   assertCapturedError
 }
 
-testPython3_7_warn() {
-  compile "python3_8_warn"
-  if [[ $STACK = "cedar-14" ]]; then
-    assertCapturedError
-  else
-    assertCaptured "python-3.8.0"
-    assertCaptured "security update!"
-    assertCaptured "Installing SQLite3"
-    assertCapturedSuccess
-  fi
-}
-
 testPython3_8() {
   updateVersion "python3_8" $LATEST_38
   compile "python3_8"
@@ -161,6 +149,18 @@ testPython3_8() {
     assertNotCaptured "security update"
     assertCaptured $LATEST_38
     assertCaptured "Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2"
+    assertCaptured "Installing SQLite3"
+    assertCapturedSuccess
+  fi
+}
+
+testPython3_8_warn() {
+  compile "python3_8_warn"
+  if [[ $STACK = "cedar-14" ]]; then
+    assertCapturedError
+  else
+    assertCaptured "python-3.8.0"
+    assertCaptured "security update!"
     assertCaptured "Installing SQLite3"
     assertCapturedSuccess
   fi


### PR DESCRIPTION
Previously the test for Python 3.8 version warnings was named the same as an earlier test for Python 3.7, meaning the earlier test definition was overwritten and so never run.

The later test has now been renamed to the correct version, and the test ordering adjusted for consistency with the rest of the file.

Closes [W-8110123](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008flL3IAI/view).

[skip changelog]