### PR TITLE
fix small typo re: install of python packages from git

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -9,7 +9,7 @@ set -e
 if [[ -f Pipfile.lock ]]; then
     if [[ -f .heroku/python/Pipfile.lock.sha256 ]]; then
         if [[ $(openssl dgst -sha256 Pipfile.lock) == $(cat .heroku/python/Pipfile.lock.sha256) ]]; then
-            # Don't skip installation of there are git deps.
+            # Don't skip installation if there are git deps.
             if ! grep -q 'git' Pipfile.lock; then
                 echo "Skipping installation, as Pipfile.lock hasn't changed since last deploy." | indent
 


### PR DESCRIPTION
simple typo fix, found when I was checking into how caching works!