### PR TITLE
Clean up binary generation Dockerfiles

### DIFF
--- a/builds/cedar-14.Dockerfile
+++ b/builds/cedar-14.Dockerfile
@@ -1,15 +1,21 @@
 FROM heroku/cedar:14
 
-WORKDIR /app
 ENV WORKSPACE_DIR="/app/builds" \
     S3_BUCKET="lang-python" \
     S3_PREFIX="cedar-14/" \
-    DEBIAN_FRONTEND=noninteractive \
     STACK="cedar-14"
 
-RUN apt-get update && apt-get install -y python-pip libsqlite3-dev realpath && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        libsqlite3-dev \
+        python3-pip \
+        realpath \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 COPY requirements.txt /app/
-RUN pip install -r /app/requirements.txt
+# Can't use `--disable-pip-version-check --no-cache-dir` since not supported by Ubuntu 14.04's pip.
+RUN pip3 install -r /app/requirements.txt
 
 COPY . /app

--- a/builds/heroku-16.Dockerfile
+++ b/builds/heroku-16.Dockerfile
@@ -1,15 +1,20 @@
 FROM heroku/heroku:16-build
 
-WORKDIR /app
 ENV WORKSPACE_DIR="/app/builds" \
     S3_BUCKET="lang-python" \
     S3_PREFIX="heroku-16/" \
-    DEBIAN_FRONTEND=noninteractive \
     STACK="heroku-16"
 
-RUN apt-get update && apt-get install -y python-pip libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        libsqlite3-dev \
+        python3-pip \
+        python3-setuptools \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 COPY requirements.txt /app/
-RUN pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
+RUN pip3 install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 
 COPY . /app

--- a/builds/heroku-18.Dockerfile
+++ b/builds/heroku-18.Dockerfile
@@ -1,15 +1,20 @@
 FROM heroku/heroku:18-build
 
-WORKDIR /app
 ENV WORKSPACE_DIR="/app/builds" \
     S3_BUCKET="lang-python" \
     S3_PREFIX="heroku-18/" \
-    DEBIAN_FRONTEND=noninteractive \
     STACK="heroku-18"
 
-RUN apt-get update && apt-get install --no-install-recommends -y python-pip-whl=9.0.1-2 python-pip=9.0.1-2 python-setuptools python-wheel libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        libsqlite3-dev \
+        python3-pip \
+        python3-setuptools \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 COPY requirements.txt /app/
-RUN pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
+RUN pip3 install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 
 COPY . /app


### PR DESCRIPTION
* Switches from using Python 2 to Python 3 for `bob-builder`
* Adds `--no-install-recommends` to reduce unnecessary packages
* Removes unnecessary pinning of pip for Heroku-18 build
* Moves `DEBIAN_FRONTEND` to RUN level env var, given:
   https://serverfault.com/a/797318

Refs [W-8119717](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008frrNIAQ/view).

[skip changelog]