### PR TITLE
Simplify binary build process and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 # These targets are not files
-.PHONY: check test buildenv-heroku-16 buildenv-heroku-18 tools
+.PHONY: check test builder-image buildenv deploy-runtimes tools
 
 STACK ?= heroku-18
+STACKS ?= cedar-14 heroku-16 heroku-18
 TEST_CMD ?= test/run-versions && test/run-features && test/run-deps
+ENV_FILE ?= builds/dockerenv.default
+BUILDER_IMAGE_PREFIX := heroku-python-build
 
 ifeq ($(STACK),cedar-14)
 	# Cedar-14 doesn't have a build image varient.
-	IMAGE_TAG := heroku/cedar:14
+	STACK_IMAGE_TAG := heroku/cedar:14
 else
 	# Converts a stack name of `heroku-NN` to its build Docker image tag of `heroku/heroku:NN-build`.
-	IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
+	STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
 endif
 
 check:
@@ -19,35 +22,40 @@ check:
 
 test:
 	@echo "Running tests using: STACK=$(STACK) TEST_CMD='$(TEST_CMD)'"
-	@echo ""
-	@docker run --rm -it -v $(PWD):/buildpack:ro -e "STACK=$(STACK)" "$(IMAGE_TAG)" bash -c 'cp -r /buildpack /buildpack_test && cd /buildpack_test && $(TEST_CMD)'
-	@echo ""
-
-buildenv-heroku-16:
-	@echo "Creating build environment (heroku-16)..."
 	@echo
-	@docker build --pull -f $(shell pwd)/builds/heroku-16.Dockerfile -t python-buildenv-heroku-16 .
+	@docker run --rm -it -v $(PWD):/buildpack:ro -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" bash -c 'cp -r /buildpack /buildpack_test && cd /buildpack_test && $(TEST_CMD)'
+	@echo
+
+builder-image:
+	@echo "Generating binary builder image for $(STACK)..."
+	@echo
+	@docker build --pull -f builds/$(STACK).Dockerfile -t "$(BUILDER_IMAGE_PREFIX)-$(STACK)" .
+	@echo
+
+buildenv: builder-image
+	@echo "Starting build environment for $(STACK)..."
 	@echo
 	@echo "Usage..."
 	@echo
-	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
-	@echo "  $$ bob build runtimes/python-2.7.13"
-	@echo "  $$ bob deploy runtimes/python-2.7.13"
+	@echo "  $$ bob build runtimes/python-X.Y.Z"
 	@echo
-	@docker run -it --rm python-buildenv-heroku-16
+	@docker run --rm -it --env-file="$(ENV_FILE)" -v $(PWD)/builds:/app/builds "$(BUILDER_IMAGE_PREFIX)-$(STACK)" bash
 
-buildenv-heroku-18:
-	@echo "Creating build environment (heroku-18)..."
+deploy-runtimes:
+ifndef RUNTIMES
+	$(error No runtimes specified! Use: "make deploy-runtimes RUNTIMES='python-X.Y.Z ...' [STACKS='heroku-18 ...'] [ENV_FILE=...]")
+endif
+	@echo "Using: RUNTIMES='$(RUNTIMES)' STACKS='$(STACKS)' ENV_FILE='$(ENV_FILE)'"
 	@echo
-	@docker build --pull -f $(shell pwd)/builds/heroku-18.Dockerfile -t python-buildenv-heroku-18 .
-	@echo
-	@echo "Usage..."
-	@echo
-	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
-	@echo "  $$ bob build runtimes/python-2.7.13"
-	@echo "  $$ bob deploy runtimes/python-2.7.13"
-	@echo
-	@docker run -it --rm python-buildenv-heroku-18
+	@set -eu; for stack in $(STACKS); do \
+		$(MAKE) builder-image STACK=$${stack}; \
+		for runtime in $(RUNTIMES); do \
+			echo "Generating/deploying $${runtime} for $${stack}..."; \
+			echo; \
+			docker run --rm -it --env-file="$(ENV_FILE)" "$(BUILDER_IMAGE_PREFIX)-$${stack}" bob deploy "runtimes/$${runtime}"; \
+			echo; \
+		done; \
+	done
 
 tools:
 	git clone https://github.com/kennethreitz/pip-pop.git

--- a/builds/dockerenv.default
+++ b/builds/dockerenv.default
@@ -1,5 +1,8 @@
+# Since no values are specified here, these variables will be read from the environment at run time:
+# https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
-S3_BUCKET
-S3_PREFIX
-S3_REGION
+
+# Uncomment these if you need to override the default S3 bucket and/or path prefixes.
+# S3_BUCKET
+# S3_PREFIX

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-docopt==0.6.2
+# Dependencies for generating/publishing Python binaries.
 bob-builder==0.0.18
+
+# Sub-dependencies of bob-builder.
 boto==2.49.0
+docopt==0.6.2


### PR DESCRIPTION
* Moves all manual build steps to make targets, to simplify the commands run, and reduce chance for error.
* Removes the need to remember to rebuild the builder image by building it automatically prior to launching.
* Adds a new make target for deploying multiple runtimes at once to speed up the common case.
* Reduces repetition/superfluous content in documentation.
* Removes unused `S3_REGION` from `dockerenv.default` (the contents of S3 buckets inherit the region of the bucket).
* Documents build dependencies in `requirements.txt`.

Closes [W-8119717](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008frrNIAQ/view).

[skip changelog]