### PR TITLE
Tests: Make assertCapturedSuccess check stderr is empty again

### DIFF
--- a/test/run-deps
+++ b/test/run-deps
@@ -43,7 +43,9 @@ testNLTK() {
   echo 'ignore::RuntimeWarning' > "${env_dir}/PYTHONWARNINGS"
   compile 'nltk' '' "${env_dir}"
   assertCaptured "[nltk_data] Downloading package city_database" "STD_ERR"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since the NLTK downloader outputs all
+  # progress/status messages to stderr (W-8146040).
+  assertCapturedSuccessWithStdErr
 }
 
 testPsycopg2() {

--- a/test/run-features
+++ b/test/run-features
@@ -33,7 +33,9 @@ testStackChange() {
 testSetupPy() {
   compile "setup-py"
   assertCaptured "maya"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 
 testStandardRequirements() {
@@ -45,29 +47,39 @@ testStandardRequirements() {
 testPipenv() {
   compile "pipenv"
   assertCaptured "Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 
 testPipenvLock() {
   compile "pipenv-lock"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 
 testPipenvVersion() {
   compile "pipenv-version"
   assertCaptured $DEFAULT_PYTHON_VERSION
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 
 testPipenvVersion2() {
   compile "pipenv-version2"
   assertCaptured $LATEST_27
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 testPipenvFullVersion() {
   compile "pipenv-full-version"
   assertCaptured "3.6.3"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since stderr contains:
+  # "cp: cannot stat '/tmp/build_*/requirements.txt': No such file or directory" (W-7924941)
+  assertCapturedSuccessWithStdErr
 }
 
 testNoRequirements() {

--- a/test/run-versions
+++ b/test/run-versions
@@ -40,14 +40,18 @@ testPython3_4() {
   assertCaptured $LATEST_34
   assertNotCaptured "security update"
   assertCaptured "Installing pip 19.1.1, setuptools 43.0.0 and wheel 0.33.6"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since Pip outputs a Python 3.4 EOL warning to stderr,
+  # and the newest Pip that works on Python 3.4 doesn't support `PIP_NO_PYTHON_VERSION_WARNING`.
+  assertCapturedSuccessWithStdErr
 }
 
 testPython3_4_warn() {
   compile "python3_4_warn"
   assertCaptured "python-3.4.9"
   assertCaptured "security update!"
-  assertCapturedSuccess
+  # Can't use `assertCapturedSuccess` since Pip outputs a Python 3.4 EOL warning to stderr,
+  # and the newest Pip that works on Python 3.4 doesn't support `PIP_NO_PYTHON_VERSION_WARNING`.
+  assertCapturedSuccessWithStdErr
 }
 
 testPython3_5() {

--- a/test/utils
+++ b/test/utils
@@ -85,12 +85,20 @@ assertNotCaptured()
 assertCapturedSuccess()
 {
   assertEquals "Captured exit code -" "0" "${RETURN}"
-  # assertEquals "STD_ERR -" "" "$(cat ${STD_ERR})"
+  assertEquals "STD_ERR -" "" "$(cat ${STD_ERR})"
 
-  if [ $RETURN -ne 0 -a -z "$(cat ${STD_ERR})" ]; then
-    # Failing exit code but stderr was empty. Display stdout to help debugging.
-    cat $STD_OUT
-    echo
+  if [ $RETURN -ne 0 -o -n "$(cat ${STD_ERR})" ]; then
+    debug
+  fi
+}
+
+assertCapturedSuccessWithStdErr()
+{
+  assertEquals "Captured exit code -" "0" "${RETURN}"
+  assertNotEquals "STD_ERR -" "" "$(cat ${STD_ERR})"
+
+  if [ ${RETURN} -ne 0 ]; then
+    debug
   fi
 }
 
@@ -151,9 +159,14 @@ _assertContains()
 
 debug()
 {
-  cat $STD_OUT
-  echo '^^^^^^'
-  cat $STD_ERR
+  echo
+  echo '### STD_OUT ###'
+  cat "${STD_OUT}"
+  echo
+  echo '### STD_ERR ###'
+  cat "${STD_ERR}"
+  echo
+  echo
 }
 
 assertContains()


### PR DESCRIPTION
`assertCapturedSuccess` used to check that `stderr` was empty, until:
https://github.com/heroku/heroku-buildpack-python/commit/797652a75d69a1fece96a26bf4514fe9e9e1c020#diff-65c067a6f0a3aef292fb54ec21a1fe8cR98

Adding back the assertion exposes some new bugs, which I'll fix in later PRs. In the meantime affected tests have been adjusted to use a new `assertCapturedSuccessWithStdErr`.

The test harness output for the failing case has also been improved, to ease debugging.

Closes [W-7918492](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008WooEIAS/view).
Closes #1025.

[skip changelog]