### PR TITLE
Migrate to a new S3 bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Migrate from the `lang-python` S3 bucket to `heroku-buildpack-python` (#1089).
 - Remove `vendor/shunit2` (#1086).
 - Replace `BUILDPACK_VENDOR_URL` and `USE_STAGING_BINARIES` with `BUILDPACK_S3_BASE_URL` (#1085).
 

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,12 @@ export BUILD_DIR CACHE_DIR ENV_DIR
 # The user can provide BUILDPACK_S3_BASE_URL to specify a custom target.
 # Note: this is designed for non-Heroku use, as it does not use the user-provided
 # environment variable mechanism (the ENV_DIR).
-DEFAULT_S3_BASE_URL='https://lang-python.s3.amazonaws.com'
+if [[ "${STACK}" == "cedar-14" ]]; then
+  # Since Cedar-14 is EOL on 2020-11-02 it's not worth migrating it to the new bucket.
+  DEFAULT_S3_BASE_URL='https://lang-python.s3.amazonaws.com'
+else
+  DEFAULT_S3_BASE_URL='https://heroku-buildpack-python.s3.amazonaws.com'
+fi
 S3_BASE_URL="${BUILDPACK_S3_BASE_URL:-${DEFAULT_S3_BASE_URL}}"
 # This has to be exported since it's used by the geo-libs step which is run in a subshell.
 # TODO: Stop exporting once the geo-libs step is removed or no longer uses `sub_env`.

--- a/builds/heroku-16.Dockerfile
+++ b/builds/heroku-16.Dockerfile
@@ -1,7 +1,7 @@
 FROM heroku/heroku:16-build
 
 ENV WORKSPACE_DIR="/app/builds" \
-    S3_BUCKET="lang-python" \
+    S3_BUCKET="heroku-buildpack-python" \
     S3_PREFIX="heroku-16/" \
     STACK="heroku-16"
 

--- a/builds/heroku-18.Dockerfile
+++ b/builds/heroku-18.Dockerfile
@@ -1,7 +1,7 @@
 FROM heroku/heroku:18-build
 
 ENV WORKSPACE_DIR="/app/builds" \
-    S3_BUCKET="lang-python" \
+    S3_BUCKET="heroku-buildpack-python" \
     S3_PREFIX="heroku-18/" \
     STACK="heroku-18"
 


### PR DESCRIPTION
Since:
* We want the S3 bucket to be owned by a different AWS account and it's not possible to transfer ownership of an existing bucket.
* In the future we want to rebuild some of the Python runtime archives (for example to improve the sqlite3 handling, or to tweak the compile flags used), and it will be easier to reason about the change if we can guarantee only recent buildpack versions are using the assets rather than several year old unmaintained forks.

The assets were synced from the old bucket using (minus the `--dryrun`):

```
aws s3 sync s3://lang-python s3://heroku-buildpack-python \
  --dryrun \
  --metadata-directive REPLACE \
  --exclude "*" \
  --include 'common/*' \
  --include 'heroku-*/runtimes/*' \
  --include 'heroku-*/libraries/vendor/gdal.tar.gz' \
  --include 'heroku-*/libraries/vendor/geos.tar.gz' \
  --include 'heroku-*/libraries/vendor/proj.tar.gz' \
  --exclude 'common/pip-20.0.2-py2.py3-none-any.whl' \
  --exclude '*/runtimes/*-opt.tar.gz' \
  --exclude '*/runtimes/sqlite-free/*'
```

The files that were `--exclude`d are those that are no longer used, or test assets that were not officially released.

The Cedar-14 assets were not migrated since it's EOL next month.

The old S3 bucket will be left untouched for the foreseeable future (ie: we won't be deleting it), since builds using older versions of this buildpack (either due to pinning to a tag or via a fork) will still be using assets from it.

Closes [W-8060097](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008cuLpIAI/view).