### PR TITLE
manual override of pip version for pipenv users (PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add support for Heroku-20 (#968).
-- allow pipenv users to specify pip version via `PIP_VERSION_OVERRIDE` variable (#1094)
+- Allow pipenv users to specify pip version via `PIP_VERSION_OVERRIDE` variable (#1094)
 
 ## v182 (2020-10-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for Heroku-20 (#968).
+- allow pipenv users to specify pip version via `PIP_VERSION_OVERRIDE` variable (#1094)
 
 ## v182 (2020-10-06)
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -179,7 +179,12 @@ if [[ -f "$BUILD_DIR/Pipfile" ]]; then
   # The buildpack is pinned to old pipenv, which requires older pip.
   # Pip 9.0.2 doesn't support installing itself from a wheel, so we have to use split
   # versions here (ie: installer pip version different from target pip version).
-  PIP_VERSION='9.0.2'
+  if [ -z "$PIP_VERSION_OVERRIDE" ]
+    then
+      PIP_VERSION='9.0.2'
+    else
+      PIP_VERSION=PIP_VERSION_OVERRIDE
+  fi
   PIP_TO_INSTALL="pip==${PIP_VERSION}"
 else
   PIP_TO_INSTALL="${PIP_WHEEL}"


### PR DESCRIPTION
Allow for a manual override of pip version for pipenv users (PR)
https://github.com/heroku/heroku-buildpack-python/issues/1093

<!-- Hi and welcome to the Heroku Python buildpack repository!

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
