### PR TITLE
Move changelog entries to the correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
+- Vendor buildpack-stdlib instead of fetching from S3 (#1100).
+- Fix metric names for metrics emitted within `sub_env` (#1099).
 
 ## v183 (2020-10-12)
 
 - Add support for Heroku-20 (#968).
-- Vendor buildpack-stdlib instead of fetching from S3 (#1100).
-- Fix metric names for metrics emitted within `sub_env` (#1099).
 
 ## v182 (2020-10-06)
 


### PR DESCRIPTION
The changelog entries for #1099 and #1100 were added to the previous release section (rather than the "unreleased" section) by mistake.