### PR TITLE
Add Heroku-20 to deploy-runtimes default stacks list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: check test builder-image buildenv deploy-runtimes tools
 
 STACK ?= heroku-18
-STACKS ?= cedar-14 heroku-16 heroku-18
+STACKS ?= cedar-14 heroku-16 heroku-18 heroku-20
 TEST_CMD ?= test/run-versions && test/run-features && test/run-deps
 ENV_FILE ?= builds/dockerenv.default
 BUILDER_IMAGE_PREFIX := heroku-python-build


### PR DESCRIPTION
Now `make deploy-runtimes` will build binaries for Heroku-20 by default too, without the need to pass it in via an explicit `STACKS=...`list.

Closes [W-8233698](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008F6XlIAK/view).

[skip changelog]
