### PR TITLE
Remove redundant Mercurial install step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove redundant Mercurial install step (#1111).
 - Remove support for the Cedar-14 stack (#1110).
 
 ## v184 (2020-10-21)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
 
 check:
 	@shellcheck -x bin/compile bin/detect bin/release bin/test-compile bin/utils bin/warnings bin/default_pythons
-	@shellcheck -x bin/steps/collectstatic bin/steps/eggpath-fix  bin/steps/eggpath-fix2 bin/steps/gdal bin/steps/geo-libs bin/steps/mercurial bin/steps/nltk bin/steps/pip-install bin/steps/pip-uninstall bin/steps/pipenv bin/steps/pipenv-python-version bin/steps/python
+	@shellcheck -x bin/steps/collectstatic bin/steps/eggpath-fix  bin/steps/eggpath-fix2 bin/steps/gdal bin/steps/geo-libs bin/steps/nltk bin/steps/pip-install bin/steps/pip-uninstall bin/steps/pipenv bin/steps/pipenv-python-version bin/steps/python
 	@shellcheck -x bin/steps/hooks/*
 
 test:

--- a/bin/compile
+++ b/bin/compile
@@ -263,12 +263,6 @@ fi
 # shellcheck source=bin/steps/eggpath-fix
 source "$BIN_DIR/steps/eggpath-fix"
 
-# Mercurial support.
-# If a customer appears to be using mercurial for dependency resolution, we install it first.
-# Note: this only applies to pip, not pipenv. This can likely be removed, over time. Measure it first.
-# shellcheck source=bin/steps/mercurial
-source "$BIN_DIR/steps/mercurial"
-
 # Support for Geo libraries. This is deprecated functionality.
 # It is undocumented.
 # shellcheck source=bin/steps/geo-libs

--- a/bin/steps/mercurial
+++ b/bin/steps/mercurial
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# Install Mercurial if it appears to be required.
-if [[ -f "requirements.txt" ]]; then
-	if (grep -Fiq "hg+" requirements.txt) then
-		/app/.heroku/python/bin/pip install  mercurial | cleanup | indent
-		mcount "steps.mercurial"
-	fi
-fi

--- a/test/fixtures/requirements-mercurial/requirements.txt
+++ b/test/fixtures/requirements-mercurial/requirements.txt
@@ -1,0 +1,1 @@
+hg+https://www.mercurial-scm.org/repo/python-hglib/#egg=python-hglib

--- a/test/run-deps
+++ b/test/run-deps
@@ -74,6 +74,12 @@ testPylibmc() {
   assertCapturedSuccess
 }
 
+testMercurial() {
+  compile "requirements-mercurial"
+  assertCaptured "Cloning hg"
+  assertCapturedSuccess
+}
+
 pushd $(dirname 0) >/dev/null
 popd >/dev/null
 


### PR DESCRIPTION
Mercurial is installed in the stack image for all stacks, so the pip install of packages from Mercurial VCS URLs works without the need for the buildpack to install Mercurial itself.

See:
https://github.com/heroku/stack-images/pull/141
https://github.com/heroku/stack-images/search?q=mercurial

Closes [W-7906950](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008TjrpIAC/view).