### PR TITLE
Remove env vars used by legacy build systems

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,19 +73,13 @@ RECOMMENDED_PYTHON_VERSION=$DEFAULT_PYTHON_VERSION
 export PATH=$PATH:$ROOT_DIR/vendor/:$ROOT_DIR/vendor/pip-pop
 
 # Set environment variables if they weren't set by the platform.
-# Note: this is legacy, for a deprecated build system known as Anvil.
-# This can likely be removed, with caution.
-[ ! "$SLUG_ID" ] && SLUG_ID="defaultslug"
-[ ! "$REQUEST_ID" ] && REQUEST_ID=$SLUG_ID
 [ ! "$STACK" ] && STACK=$DEFAULT_PYTHON_STACK
 
 # Sanitize externally-provided environment variables:
 # The following environment variables are either problematic or simply unneccessary
 # for the buildpack to have knowledge of, so we unset them, to keep the environment
 # as clean and pristine as possible.
-unset GIT_DIR PYTHONHOME PYTHONPATH
-unset RECEIVE_DATA RUN_KEY BUILD_INFO DEPLOY LOG_TOKEN
-unset CYTOKINE_LOG_FILE GEM_PATH
+unset PYTHONHOME PYTHONPATH
 
 # Import the utils script, which contains helper functions used throughout the buildpack.
 # shellcheck source=bin/utils


### PR DESCRIPTION
These variables were used by Anvil and/or the legacy `slug_compiler` that predated cytokine.

I've not added a changelog entry since none were exported, so wouldn't have been available to subprocesses anyway.

Closes [W-8387606](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008VnOtIAK/view).

[skip changelog]