### PR TITLE
Update the BUILD_WITH_GEO_LIBRARIES error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update the `BUILD_WITH_GEO_LIBRARIES` error message (#1121).
 - Switch NLTK feature detection away from `sp-grep` (#1119).
 - Switch Django collectstatic feature detection away from `sp-grep` (#1119).
 - Remove vendored `sp-grep` script (#1119).

--- a/bin/compile
+++ b/bin/compile
@@ -104,13 +104,15 @@ fi
 
 if [[ -f "${ENV_DIR}/BUILD_WITH_GEO_LIBRARIES" ]]; then
   mcount "failure.unsupported.BUILD_WITH_GEO_LIBRARIES"
-  puts-warn "The Python buildpack's BUILD_WITH_GEO_LIBRARIES functonality is no longer supported:"
-  puts-warn "https://help.heroku.com/D5INLB1A/python-s-build_with_geo_libraries-legacy-feature-is-now-deprecated"
+  puts-warn "The Python buildpack's legacy BUILD_WITH_GEO_LIBRARIES functonality is"
+  puts-warn "no longer supported:"
+  puts-warn "https://devcenter.heroku.com/changelog-items/1947"
   puts-warn
-  puts-warn "For GDAL, GEOS and PROJ support, use the Geo buildpack alongside the Python buildpack:"
-  puts-warn "https://github.com/heroku/heroku-geo-buildpack"
+  puts-warn "To continue to use GDAL, GEOS or PROJ support, see the migration guide:"
+  puts-warn "https://help.heroku.com/D5INLB1A/python-s-build_with_geo_libraries-legacy-feature-is-no-longer-supported"
   puts-warn
-  puts-warn "To remove this error message, unset the BUILD_WITH_GEO_LIBRARIES variable using:"
+  puts-warn "Or if you no longer need those libraries, this message can be hidden by"
+  puts-warn "unsetting the BUILD_WITH_GEO_LIBRARIES environment variable, using:"
   puts-warn "heroku config:unset BUILD_WITH_GEO_LIBRARIES"
   exit 1
 fi

--- a/test/run-deps
+++ b/test/run-deps
@@ -21,7 +21,7 @@ testBuildWithGeoLibrariesWarning() {
   local env_dir="$(mktmpdir)"
   echo '1' > "${env_dir}/BUILD_WITH_GEO_LIBRARIES"
   compile 'gdal' '' "${env_dir}"
-  assertCaptured " !     The Python buildpack's BUILD_WITH_GEO_LIBRARIES functonality is no longer supported"
+  assertCaptured " !     The Python buildpack's legacy BUILD_WITH_GEO_LIBRARIES functonality"
   assertCapturedError
 }
 


### PR DESCRIPTION
So that it links to the changelog post now that it exists:
https://devcenter.heroku.com/changelog-items/1947

And to adjust the emphasis towards the migration guide over the Geo buildpack repository link.

Closes [W-8391415](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008J3uIIAS/view).