### PR TITLE
Add support for Python 3.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Python 3.8.7 is now available (CPython) (#1125).
+
 ## v187 (2020-12-08)
 
 - Python 3.9.1 is now available (CPython) (#1127).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Specify a Python Runtime
 Supported runtime options include:
 
 - `python-3.9.1`
-- `python-3.8.6`
+- `python-3.8.7`
 - `python-3.7.9`
 - `python-3.6.12`
 - `python-2.7.18`

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -7,7 +7,7 @@
 
 DEFAULT_PYTHON_VERSION="python-3.6.12"
 LATEST_39="python-3.9.1"
-LATEST_38="python-3.8.6"
+LATEST_38="python-3.8.7"
 LATEST_37="python-3.7.9"
 LATEST_36="python-3.6.12"
 LATEST_35="python-3.5.10"

--- a/builds/runtimes/python-3.8.7
+++ b/builds/runtimes/python-3.8.7
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3

--- a/test/fixtures/python3_8/runtime.txt
+++ b/test/fixtures/python3_8/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.6
+python-3.8.7


### PR DESCRIPTION
https://pythoninsider.blogspot.com/2020/12/python-387-is-now-available.html
https://www.python.org/downloads/release/python-387/

Closes [W-7791264](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008SjjqIAC/view).
