### PR TITLE
Exclude more files when publishing the buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,13 +1,21 @@
 [buildpack]
 name = "Python"
 
-  [publish.Ignore]
-  files = [
-    "test/",
-    ".gitignore",
-    ".dockerignore",
-    ".github/",
-    "Dockerfile",
-    "Pipfile",
-    "Pipfile.lock"
-  ]
+[publish.Ignore]
+files = [
+  ".git2gus/",
+  ".github/",
+  "builds/",
+  "spec/",
+  "test/",
+  ".dockerignore",
+  ".gitignore",
+  ".travis.yml",
+  "Gemfile",
+  "Gemfile.lock",
+  "hatchet.json",
+  "hatchet.lock",
+  "Makefile",
+  "Rakefile",
+  "requirements.txt",
+]


### PR DESCRIPTION
Since these files are not required at compile time.

The incorrect indentation has also been corrected.

Closes [W-8065952](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008cyG2IAI/view).

[skip changelog]