### PR TITLE
Check Changelog improvements

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -5,12 +5,13 @@ on:
     types: [opened, reopened, edited, synchronize]
 
 jobs:
-  check:
+  check-changelog:
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
-      !contains(github.event.pull_request.body, '[skip ci]')
+      !contains(github.event.pull_request.body, '[skip ci]') &&
+      !contains(github.event.pull_request.labels.*.name, 'c: dependencies')
     steps:
       - uses: actions/checkout@v1
       - name: Check that CHANGELOG is touched


### PR DESCRIPTION
The Check Changelog GitHub action now:
* is skipped for dependabot PRs
* uses a more descriptive job name than `check`

See:
https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#name

Closes [W-8052460](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008coj3IAA/view).
Closes [W-8098931](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008dLgNIAU/view).

[skip changelog]