### PR TITLE
Add support for Python 3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Python 3.9.1 is now available (CPython) (#1127).
 
 ## v186 (2020-11-18)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Specify a Python Runtime
 
 Supported runtime options include:
 
-- `python-3.9.0`
+- `python-3.9.1`
 - `python-3.8.6`
 - `python-3.7.9`
 - `python-3.6.12`

--- a/bin/default_pythons
+++ b/bin/default_pythons
@@ -6,7 +6,7 @@
 # shellcheck disable=2034
 
 DEFAULT_PYTHON_VERSION="python-3.6.12"
-LATEST_39="python-3.9.0"
+LATEST_39="python-3.9.1"
 LATEST_38="python-3.8.6"
 LATEST_37="python-3.7.9"
 LATEST_36="python-3.6.12"

--- a/builds/runtimes/python-3.9.1
+++ b/builds/runtimes/python-3.9.1
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/python/
+
+source $(dirname $0)/python3

--- a/test/fixtures/python3_9/runtime.txt
+++ b/test/fixtures/python3_9/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.0
+python-3.9.1

--- a/test/run-versions
+++ b/test/run-versions
@@ -155,10 +155,6 @@ testPython3_9() {
 }
 
 testPython3_9_warn() {
-  # Can't test the version warning until there is at least one old version of Python 3.9.
-  if [[ "${LATEST_39}" = "python-3.9.0" ]]; then
-    return
-  fi
   compile "python3_9_warn"
   assertCaptured "Installing python-3.9.0"
   assertCaptured "security update!"


### PR DESCRIPTION
https://pythoninsider.blogspot.com/2020/12/python-391-is-now-available-together.html
https://www.python.org/downloads/release/python-391/

Closes [W-8159183](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008gJUjIAM/view).