### PR TITLE
Fix for Pipenv not caching dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed `pipenv` not caching dependencies when `git` mentioned in package names.
+
 ## v187 (2020-12-08)
 
 - Python 3.9.1 is now available (CPython) (#1127).

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -10,7 +10,7 @@ if [[ -f Pipfile.lock ]]; then
     if [[ -f .heroku/python/Pipfile.lock.sha256 ]]; then
         if [[ $(openssl dgst -sha256 Pipfile.lock) == $(cat .heroku/python/Pipfile.lock.sha256) ]]; then
             # Don't skip installation if there are git deps.
-            if ! grep -q 'git' Pipfile.lock; then
+            if ! grep -q '\.git' Pipfile.lock; then
                 echo "Skipping installation, as Pipfile.lock hasn't changed since last deploy." | indent
 
                 mcount "tool.pipenv"


### PR DESCRIPTION
Having 'git' in one of your package names will prevent your deps from caching, resulting in painfully long build times. This is a simple fix.