### PR TITLE
Move Gemfile dependencies inside a test/development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem "rspec"
-gem "heroku_hatchet"
-gem "rspec-retry"
-gem "parallel_split_test"
+group :test, :development do
+  gem "heroku_hatchet"
+  gem "parallel_split_test"
+  gem "rspec"
+  gem "rspec-retry"
+end


### PR DESCRIPTION
To make it clearer that they aren't used in production.
The gems list has also been sorted alphabetically.

https://bundler.io/guides/groups.html

Closes [W-8619625](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mEcHIAU/view).

[skip changelog]