### PR TITLE
Use Rubocop to lint tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+require:
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable
+
+Metrics/BlockLength:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 jobs:
   include:
   - name: Bash linting (shellcheck)
-    script: make check
+    script: make lint-scripts
   - name: Hatchet integration tests
     if: env(HEROKU_API_USER) IS present AND env(HEROKU_API_KEY) IS present
     language: ruby
@@ -19,6 +19,7 @@ jobs:
     before_script:
       - bundle exec hatchet ci:setup
     script:
+      - make lint-ruby
       - PARALLEL_SPLIT_TEST_PROCESSES=11 bundle exec parallel_split_test spec/hatchet/
 
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+ruby '~> 2.7.0'
 
 group :test, :development do
-  gem "heroku_hatchet"
-  gem "parallel_split_test"
-  gem "rspec"
-  gem "rspec-retry"
+  gem 'heroku_hatchet'
+  gem 'parallel_split_test'
+  gem 'rspec'
+  gem 'rspec-retry'
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.1)
     diff-lcs (1.4.4)
     erubis (2.7.0)
     excon (0.78.1)
@@ -21,11 +22,16 @@ GEM
     parallel_split_test (0.8.0)
       parallel (>= 0.5.13)
       rspec (>= 3.1.0)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     platform-api (3.2.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
+    rainbow (3.0.0)
     rate_throttle_client (0.1.2)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
     rrrretry (1.0.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -42,8 +48,24 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.10.1)
+    rubocop (1.7.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.4.0)
+      parser (>= 2.7.1.5)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
     thor (1.0.1)
     threaded (0.0.4)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -53,6 +75,11 @@ DEPENDENCIES
   parallel_split_test
   rspec
   rspec-retry
+  rubocop
+  rubocop-rspec
+
+RUBY VERSION
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,15 @@ BUILDER_IMAGE_PREFIX := heroku-python-build
 # Converts a stack name of `heroku-NN` to its build Docker image tag of `heroku/heroku:NN-build`.
 STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
 
-check:
+lint: lint-scripts lint-ruby
+
+lint-scripts:
 	@shellcheck -x bin/compile bin/detect bin/release bin/test-compile bin/utils bin/warnings bin/default_pythons
 	@shellcheck -x bin/steps/collectstatic bin/steps/eggpath-fix  bin/steps/eggpath-fix2 bin/steps/nltk bin/steps/pip-install bin/steps/pipenv bin/steps/pipenv-python-version bin/steps/python
 	@shellcheck -x bin/steps/hooks/*
+
+lint-ruby:
+	@bundle exec rubocop
 
 test:
 	@echo "Running tests using: STACK=$(STACK) TEST_CMD='$(TEST_CMD)'"

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
-describe "Heroku CI" do
-  it "works" do
-    before_deploy = Proc.new do
-      File.open("app.json", "w+") do |f|
-        f.puts <<~EOM
+describe 'Heroku CI' do
+  it 'works' do
+    before_deploy = proc do
+      File.open('app.json', 'w+') do |f|
+        f.puts <<~MANIFEST
           {
             "environments": {
               "test": {
@@ -14,20 +16,20 @@ describe "Heroku CI" do
               }
             }
           }
-        EOM
+        MANIFEST
       end
 
-      run!("echo nose >> requirements.txt")
+      run!('echo nose >> requirements.txt')
     end
 
-    Hatchet::Runner.new("python_default", before_deploy: before_deploy).run_ci do |test_run|
-      expect(test_run.output).to match("Downloading nose")
-      expect(test_run.output).to match("OK")
+    Hatchet::Runner.new('python_default', before_deploy: before_deploy).run_ci do |test_run|
+      expect(test_run.output).to match('Downloading nose')
+      expect(test_run.output).to match('OK')
 
       test_run.run_again
 
-      expect(test_run.output).to match("installing from cache")
-      expect(test_run.output).to_not match("Downloading nose")
+      expect(test_run.output).to match('installing from cache')
+      expect(test_run.output).not_to match('Downloading nose')
     end
   end
 end

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -1,71 +1,75 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
-describe "Python" do
-  describe "cache" do
-    it "functions correctly" do
-      Hatchet::Runner.new("python_default").deploy do |app|
+describe 'Python' do
+  describe 'cache' do
+    it 'functions correctly' do
+      Hatchet::Runner.new('python_default').deploy do |app|
         expect(app.output).to match(/Installing pip/)
 
-        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-        expect(app.output).to_not match("No change in requirements detected, installing from cache")
-        expect(app.output).to_not match("No such file or directory")
-        expect(app.output).to_not match("cp: cannot create regular file")
+        expect(app.output).not_to match('Requirements file has been changed, clearing cached dependencies')
+        expect(app.output).not_to match('No change in requirements detected, installing from cache')
+        expect(app.output).not_to match('No such file or directory')
+        expect(app.output).not_to match('cp: cannot create regular file')
 
         # Redeploy with changed requirements file
-        run!(%Q{echo "" >> requirements.txt})
-        run!(%Q{echo "pygments" >> requirements.txt})
-        run!(%Q{git add . ; git commit --allow-empty -m next})
+        run!(%(echo "" >> requirements.txt))
+        run!(%(echo "pygments" >> requirements.txt))
+        run!(%(git add . ; git commit --allow-empty -m next))
         app.push!
 
         # Check the cache to have cleared
-        expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
-        expect(app.output).to_not match("No dependencies found, preparing to install")
-        expect(app.output).to_not match("No change in requirements detected, installing from cache")
+        expect(app.output).to match('Requirements file has been changed, clearing cached dependencies')
+        expect(app.output).not_to match('No dependencies found, preparing to install')
+        expect(app.output).not_to match('No change in requirements detected, installing from cache')
 
         # With no changes on redeploy, the cache should be present
-        run!(%Q{git commit --allow-empty -m next})
+        run!(%(git commit --allow-empty -m next))
         app.push!
 
-        expect(app.output).to match("No change in requirements detected, installing from cache")
-        expect(app.output).to_not match("Requirements file has been changed, clearing cached dependencies")
-        expect(app.output).to_not match("No dependencies found, preparing to install")
+        expect(app.output).to match('No change in requirements detected, installing from cache')
+        expect(app.output).not_to match('Requirements file has been changed, clearing cached dependencies')
+        expect(app.output).not_to match('No dependencies found, preparing to install')
       end
     end
   end
 
-  describe "python versions" do
-    let(:stack) { ENV["HEROKU_TEST_STACK"] || DEFAULT_STACK }
-    it "works with 3.7.6" do
-      version = "3.7.6"
-      before_deploy = -> { run!(%Q{echo "python-#{version}" >> runtime.txt}) }
-      Hatchet::Runner.new("python_default", before_deploy: before_deploy, stack: stack).deploy do |app|
+  describe 'python versions' do
+    let(:stack) { ENV['HEROKU_TEST_STACK'] || DEFAULT_STACK }
+
+    it 'works with 3.7.6' do
+      version = '3.7.6'
+      before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
+      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack).deploy do |app|
         expect(app.run('python -V')).to match(version)
       end
     end
 
-    it "works with 3.8.2" do
-      version = "3.8.2"
-      before_deploy = -> { run!(%Q{echo "python-#{version}" >> runtime.txt}) }
-      Hatchet::Runner.new("python_default", before_deploy: before_deploy, stack: stack).deploy do |app|
+    it 'works with 3.8.2' do
+      version = '3.8.2'
+      before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
+      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack).deploy do |app|
         expect(app.run('python -V')).to match(version)
       end
     end
 
-    it "fails with a bad version" do
-      version = "3.8.2.lol"
-      before_deploy = -> { run!(%Q{echo "python-#{version}" >> runtime.txt}) }
-      Hatchet::Runner.new("python_default", before_deploy: before_deploy, stack: stack, allow_failure: true).deploy do |app|
-        expect(app.output).to match("not available for this stack")
+    it 'fails with a bad version' do
+      version = '3.8.2.lol'
+      before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
+      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack,
+                                            allow_failure: true).deploy do |app|
+        expect(app.output).to match('not available for this stack')
       end
     end
   end
 
-  it "getting started app has no relative paths" do
+  it 'getting started app has no relative paths' do
     buildpacks = [
       :default,
-      "https://github.com/sharpstone/force_absolute_paths_buildpack"
+      'https://github.com/sharpstone/force_absolute_paths_buildpack'
     ]
-    Hatchet::Runner.new("python-getting-started", buildpacks: buildpacks).deploy do |app|
+    Hatchet::Runner.new('python-getting-started', buildpacks: buildpacks).deploy do |app|
       # Deploy works
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 ENV['HATCHET_BUILDPACK_BASE'] = 'https://github.com/heroku/heroku-buildpack-python.git'
+
+require 'English'
 
 require 'rspec/core'
 require 'rspec/retry'
 require 'hatchet'
-
-require 'date'
 
 RSpec.configure do |config|
   config.full_backtrace      = true
@@ -19,6 +21,7 @@ DEFAULT_STACK = 'heroku-18'
 
 def run!(cmd)
   out = `#{cmd}`
-  raise "Error running command #{cmd} with output: #{out}" unless $?.success?
-  return out
+  raise "Error running command #{cmd} with output: #{out}" unless $CHILD_STATUS.success?
+
+  out
 end


### PR DESCRIPTION
Added to the project using the steps here:
https://docs.rubocop.org/rubocop/1.7/installation.html

Then fixes applied using Rubocop's auto-correct feature, followed by one or two manual fixes, and then disabling the remaining less helpful rules.

The required Ruby version has been added to `Gemfile` since rubocop can use it to determine whether to enable rules about more modern Ruby features.

Closes [W-8620478](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mFdVIAU/view).

[skip changelog]