### PR TITLE
Tests: Move Hatchet repos directory under '.hatchet/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ site
 .DS_Store
 
 /.envrc
-repos/*
+.hatchet/repos/
 
 #Venv
 buildpack/*

--- a/hatchet.json
+++ b/hatchet.json
@@ -1,6 +1,9 @@
 {
+  "hatchet": {
+    "directory": ".hatchet/"
+  },
   "python": [
-    "heroku/python-getting-started",
-    "sharpstone/python_default"
+    "https://github.com/heroku/python-getting-started",
+    "https://github.com/sharpstone/python_default"
   ]
 }

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,5 +1,5 @@
 ---
-- - "./repos/python/python-getting-started"
+- - ".hatchet/repos/python/python-getting-started"
   - main
-- - "./repos/python/python_default"
+- - ".hatchet/repos/python/python_default"
   - ca947f69027b2a30be5d26f9a42f25e54f4d7a1a


### PR DESCRIPTION
To make it clearer that it's a generated directory, and so Rubocop excludes it by default (since it excludes dot directories).

The repo URLs in `hatchet.json` have also been made to use the full URL, since explicit is better than implicit.

Closes [W-8633435](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008vU8jIAE/view).

[skip changelog]
