### PR TITLE
Tests: Run Hatchet tests against all stacks in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,49 @@ script:
 
 jobs:
   include:
-  - name: Bash linting (shellcheck)
-    script: make lint-scripts
-  - name: Hatchet integration tests
+  - name: Linters (shellcheck and rubocop)
+    language: ruby
+    rvm:
+      - 2.7
+    script:
+      - make lint-scripts
+      - make lint-ruby
+
+  - name: Hatchet integration tests (Heroku-16)
     if: env(HEROKU_API_USER) IS present AND env(HEROKU_API_KEY) IS present
     language: ruby
     rvm:
       - 2.7
+    env:
+      - STACK=heroku-16
     before_script:
       - bundle exec hatchet ci:setup
     script:
-      - make lint-ruby
-      - PARALLEL_SPLIT_TEST_PROCESSES=11 bundle exec parallel_split_test spec/hatchet/
+      - bundle exec parallel_split_test spec/hatchet/
+
+  - name: Hatchet integration tests (Heroku-18)
+    if: env(HEROKU_API_USER) IS present AND env(HEROKU_API_KEY) IS present
+    language: ruby
+    rvm:
+      - 2.7
+    env:
+      - STACK=heroku-18
+    before_script:
+      - bundle exec hatchet ci:setup
+    script:
+      - bundle exec parallel_split_test spec/hatchet/
+
+  - name: Hatchet integration tests (Heroku-20)
+    if: env(HEROKU_API_USER) IS present AND env(HEROKU_API_KEY) IS present
+    language: ruby
+    rvm:
+      - 2.7
+    env:
+      - STACK=heroku-20
+    before_script:
+      - bundle exec hatchet ci:setup
+    script:
+      - bundle exec parallel_split_test spec/hatchet/
 
 env:
   jobs:
@@ -36,7 +67,7 @@ env:
     - STACK=heroku-20 TEST_CMD=test/run-versions
     - STACK=heroku-20 TEST_CMD=test/run-features
   global:
+    - HATCHET_APP_LIMIT=100
     - HATCHET_RETRIES=3
     - IS_RUNNING_ON_CI=true
-    - HATCHET_APP_LIMIT=80
-    - HATCHET_DEPLOY_STRATEGY=git
+    - PARALLEL_SPLIT_TEST_PROCESSES=11

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -22,7 +22,7 @@ describe 'Heroku CI' do
       run!('echo nose >> requirements.txt')
     end
 
-    Hatchet::Runner.new('python_default', before_deploy: before_deploy).run_ci do |test_run|
+    new_app('python_default', before_deploy: before_deploy).run_ci do |test_run|
       expect(test_run.output).to match('Downloading nose')
       expect(test_run.output).to match('OK')
 

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -5,7 +5,7 @@ require_relative '../spec_helper'
 describe 'Python' do
   describe 'cache' do
     it 'functions correctly' do
-      Hatchet::Runner.new('python_default').deploy do |app|
+      new_app('python_default').deploy do |app|
         expect(app.output).to match(/Installing pip/)
 
         expect(app.output).not_to match('Requirements file has been changed, clearing cached dependencies')
@@ -36,20 +36,18 @@ describe 'Python' do
   end
 
   describe 'python versions' do
-    let(:stack) { ENV['HEROKU_TEST_STACK'] || DEFAULT_STACK }
-
-    it 'works with 3.7.6' do
-      version = '3.7.6'
+    it 'works with 3.7.9' do
+      version = '3.7.9'
       before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
-      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack).deploy do |app|
+      new_app('python_default', before_deploy: before_deploy).deploy do |app|
         expect(app.run('python -V')).to match(version)
       end
     end
 
-    it 'works with 3.8.2' do
-      version = '3.8.2'
+    it 'works with 3.8.7' do
+      version = '3.8.7'
       before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
-      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack).deploy do |app|
+      new_app('python_default', before_deploy: before_deploy).deploy do |app|
         expect(app.run('python -V')).to match(version)
       end
     end
@@ -57,8 +55,7 @@ describe 'Python' do
     it 'fails with a bad version' do
       version = '3.8.2.lol'
       before_deploy = -> { run!(%(echo "python-#{version}" >> runtime.txt)) }
-      Hatchet::Runner.new('python_default', before_deploy: before_deploy, stack: stack,
-                                            allow_failure: true).deploy do |app|
+      new_app('python_default', before_deploy: before_deploy, allow_failure: true).deploy do |app|
         expect(app.output).to match('not available for this stack')
       end
     end
@@ -69,7 +66,7 @@ describe 'Python' do
       :default,
       'https://github.com/sharpstone/force_absolute_paths_buildpack'
     ]
-    Hatchet::Runner.new('python-getting-started', buildpacks: buildpacks).deploy do |app|
+    new_app('python-getting-started', buildpacks: buildpacks).deploy do |app|
       # Deploy works
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,14 @@ RSpec.configure do |config|
   end
 end
 
-DEFAULT_STACK = 'heroku-18'
+DEFAULT_STACK = ENV['STACK'] || 'heroku-18'
+
+def new_app(*args, **kwargs)
+  # Wrapping app creation to set the default stack, in lieu of being able to configure it globally:
+  # https://github.com/heroku/hatchet/issues/163
+  kwargs[:stack] ||= DEFAULT_STACK
+  Hatchet::Runner.new(*args, **kwargs)
+end
 
 def run!(cmd)
   out = `#{cmd}`


### PR DESCRIPTION
Before converting more shunit2 tests to Hatchet tests, we need to run the Hatchet tests against all stacks (and not just Heroku-18), for parity with the shunit2 tests.

The env var `HATCHET_DEPLOY_STRATEGY` has also been removed, since it's not been supported by Hatchet since v2.0.0:
https://github.com/heroku/hatchet/commit/427f90db0d82e816d1bd113fb294a8f61144bd75

Closes [W-8636282](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008vWnAIAU/view).

[skip changelog]