### PR TITLE
Tests: Clean up rspec config and improve testing UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ builds/dockerenv.staging*
 builds/dockerenv.production
 
 test/scratch
+.rspec_status

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../spec_helper'
 
-describe 'Heroku CI' do
+RSpec.describe 'Heroku CI' do
   it 'works' do
     before_deploy = proc do
       File.open('app.json', 'w+') do |f|

--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../spec_helper'
 
-describe 'Python' do
+RSpec.describe 'Python' do
   describe 'cache' do
     it 'functions correctly' do
       new_app('python_default').deploy do |app|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,14 +7,17 @@ require 'English'
 require 'rspec/core'
 require 'hatchet'
 
-RSpec.configure do |config|
-  config.full_backtrace = true
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-end
-
 DEFAULT_STACK = ENV['STACK'] || 'heroku-18'
+
+RSpec.configure do |config|
+  # Disables the legacy rspec globals and monkey-patched `should` syntax.
+  config.disable_monkey_patching!
+  # Enable flags like --only-failures and --next-failure.
+  config.example_status_persistence_file_path = '.rspec_status'
+  # Allows limiting a spec run to individual examples or groups by tagging them
+  # with `:focus` metadata via the `fit`, `fcontext` and `fdescribe` aliases.
+  config.filter_run_when_matching :focus
+end
 
 def new_app(*args, **kwargs)
   # Wrapping app creation to set the default stack, in lieu of being able to configure it globally:


### PR DESCRIPTION
* Removes redundant/unwanted options.
* Enables use of `--only-failures` and `--next-failure`.
* Enables use of the `fit`, `fcontext` and `fdescribe` aliases, for focusing the test run on a specific test/group.
* Disables legacy rspec monkey-patching.

Closes [W-8658521](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008vsU6IAI/view).

[skip changelog]