### PR TITLE
Pass detection if a runtime.txt is present

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -15,7 +15,7 @@
 BUILD_DIR=$1
 
 # Exit early if app is clearly not Python.
-if [ ! -f "$BUILD_DIR/requirements.txt" ] && [ ! -f "$BUILD_DIR/setup.py" ] && [ ! -f "$BUILD_DIR/Pipfile" ]; then
+if [ ! -f "$BUILD_DIR/requirements.txt" ] && [ ! -f "$BUILD_DIR/setup.py" ] && [ ! -f "$BUILD_DIR/Pipfile" ] && [ ! -f "$BUILD_DIR/runtime.txt" ]; then
   exit 1
 fi
 


### PR DESCRIPTION
This would be useful for apps that only need a Python runtime, and don't depend on any packages.

For example https://github.com/jkutner/web-tty-buildpack
