### PR TITLE
Check Changelog: Listen to 'labeled' and 'unlabeled' events

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
 
 jobs:
   check-changelog:


### PR DESCRIPTION
Adding and removing labels doesn't trigger an `edited` event, so previously the check would not be skipped when the `c: dependencies` label was added automatically shortly after Dependabot PRs were opened.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request

Closes [W-8737039](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mqfNIAQ/view).

[skip changelog]