### PR TITLE
Change default local development stack to Heroku-20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # These targets are not files
 .PHONY: check test compile builder-image buildenv deploy-runtimes tools
 
-STACK ?= heroku-18
+STACK ?= heroku-20
 STACKS ?= heroku-16 heroku-18 heroku-20
 TEST_CMD ?= test/run-versions && test/run-features && test/run-deps
 FIXTURE ?= test/fixtures/requirements-standard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'English'
 require 'rspec/core'
 require 'hatchet'
 
-DEFAULT_STACK = ENV['STACK'] || 'heroku-18'
+DEFAULT_STACK = ENV['STACK'] || 'heroku-20'
 
 LATEST_PYTHON_2_7 = '2.7.18'
 LATEST_PYTHON_3_5 = '3.5.10'


### PR DESCRIPTION
Since it's now the default stack on the platform:
https://devcenter.heroku.com/changelog-items/2005

Closes [W-8737134](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mqmxIAA/view).

[skip changelog]