### PR TITLE
Tests: Replace compile hooks shunit2 test with a Hatchet test

### DIFF
--- a/spec/fixtures/hooks/bin/post_compile
+++ b/spec/fixtures/hooks/bin/post_compile
@@ -1,0 +1,4 @@
+set -euo pipefail
+
+echo 'post_compile ran with env vars:'
+printenv | cut -d '=' -f 1 | sort

--- a/spec/fixtures/hooks/bin/pre_compile
+++ b/spec/fixtures/hooks/bin/pre_compile
@@ -1,0 +1,4 @@
+set -euo pipefail
+
+echo 'pre_compile ran with env vars:'
+printenv | cut -d '=' -f 1 | sort

--- a/spec/hatchet/hooks_spec.rb
+++ b/spec/hatchet/hooks_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Compile hooks' do
+  context 'when an app has bin/pre_compile and bin/post_compile scripts' do
+    let(:app) { new_app('spec/fixtures/hooks', config: { 'SOME_APP_CONFIG_VAR' => '1' }) }
+
+    it 'runs the hooks with the correct environment' do
+      expected_env_vars = %w[
+        _
+        BIN_DIR
+        BPLOG_PREFIX
+        BUILD_DIR
+        BUILDPACK_LOG_FILE
+        CACHE_DIR
+        C_INCLUDE_PATH
+        CPLUS_INCLUDE_PATH
+        DYNO
+        ENV_DIR
+        EXPORT_PATH
+        HOME
+        LANG
+        LD_LIBRARY_PATH
+        LIBRARY_PATH
+        OLDPWD
+        PATH
+        PIP_NO_PYTHON_VERSION_WARNING
+        PKG_CONFIG_PATH
+        PROFILE_PATH
+        PWD
+        PYTHONUNBUFFERED
+        REQUEST_ID
+        SHLVL
+        SOME_APP_CONFIG_VAR
+        SOURCE_VERSION
+        STACK
+      ]
+      # On Heroku-16 'OLDPWD' will not be set, since for bash <4.4 it's not exported to subshells:
+      # https://github.com/heroku/heroku-buildpack-python/pull/1011#issuecomment-665117835
+      expected_env_vars.delete('OLDPWD') if app.stack == 'heroku-16'
+
+      app.deploy do |app|
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+          remote: -----> Python app detected
+          remote: -----> Running pre-compile hook
+          remote: pre_compile ran with env vars:
+          remote: #{expected_env_vars.join("\nremote: ")}
+          remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
+          remote: .*
+          remote: -----> Installing requirements with pip
+          remote: -----> Running post-compile hook
+          remote: post_compile ran with env vars:
+          remote: #{expected_env_vars.join("\nremote: ")}
+        REGEX
+      end
+    end
+  end
+end

--- a/test/fixtures/hooks/bin/post_compile
+++ b/test/fixtures/hooks/bin/post_compile
@@ -1,4 +1,0 @@
-set -euo pipefail
-
-echo "post_compile ran!"
-echo "post_compile env: $(printenv | cut -d '=' -f 1 | sort | xargs)."

--- a/test/fixtures/hooks/bin/pre_compile
+++ b/test/fixtures/hooks/bin/pre_compile
@@ -1,4 +1,0 @@
-set -euo pipefail
-
-echo "pre_compile ran!"
-echo "pre_compile env: $(printenv | cut -d '=' -f 1 | sort | xargs)."

--- a/test/run-features
+++ b/test/run-features
@@ -56,50 +56,6 @@ testDontWarnOldDjango() {
   assertCapturedSuccess
 }
 
-testHooks() {
-  # Test that the hooks are called correctly, and that the environment contains
-  # the app's config vars but no unexpected env vars from the buildpack.
-  local env_dir="$(mktmpdir)"
-  echo 'test' > "${env_dir}/SOME_APP_CONFIG_VAR"
-  local expected_env_vars=(
-    _
-    BIN_DIR
-    BPLOG_PREFIX
-    BUILD_DIR
-    BUILDPACK_LOG_FILE
-    CACHE_DIR
-    C_INCLUDE_PATH
-    CPLUS_INCLUDE_PATH
-    ENV_DIR
-    EXPORT_PATH
-    HOME
-    LANG
-    LD_LIBRARY_PATH
-    LIBRARY_PATH
-    OLDPWD
-    PATH
-    PIP_NO_PYTHON_VERSION_WARNING
-    PKG_CONFIG_PATH
-    PROFILE_PATH
-    PWD
-    PYTHONUNBUFFERED
-    SHLVL
-    SOME_APP_CONFIG_VAR
-    STACK
-  )
-  if [[ "${STACK}" == "heroku-16" ]]; then
-    # Remove "OLDPWD" from expected_env_vars since for bash <4.4 it's not exported to subshells:
-    # https://github.com/heroku/heroku-buildpack-python/pull/1011#issuecomment-665117835
-    read -ra expected_env_vars <<< "${expected_env_vars[@]/OLDPWD/}"
-  fi
-  compile 'hooks' '' "${env_dir}"
-  assertCaptured "pre_compile ran!"
-  assertCaptured "pre_compile env: ${expected_env_vars[*]}."
-  assertCaptured "post_compile ran!"
-  assertCaptured "post_compile env: ${expected_env_vars[*]}."
-  assertCapturedSuccess
-}
-
 pushd $(dirname 0) >/dev/null
 popd >/dev/null
 


### PR DESCRIPTION
Continues the shunit2 -> Hatchet test conversion (see #1146 for reasoning).

Closes [W-8737289](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mqzSIAQ/view).

[skip changelog]