### PR TITLE
Tests: Remove redundant Hatchet cache test

### DIFF
--- a/spec/hatchet/python_spec.rb
+++ b/spec/hatchet/python_spec.rb
@@ -3,38 +3,6 @@
 require_relative '../spec_helper'
 
 RSpec.describe 'Python' do
-  describe 'cache' do
-    it 'functions correctly' do
-      new_app('python_default').deploy do |app|
-        expect(app.output).to match(/Installing pip/)
-
-        expect(app.output).not_to match('Requirements file has been changed, clearing cached dependencies')
-        expect(app.output).not_to match('No change in requirements detected, installing from cache')
-        expect(app.output).not_to match('No such file or directory')
-        expect(app.output).not_to match('cp: cannot create regular file')
-
-        # Redeploy with changed requirements file
-        run!(%(echo "" >> requirements.txt))
-        run!(%(echo "pygments" >> requirements.txt))
-        run!(%(git add . ; git commit --allow-empty -m next))
-        app.push!
-
-        # Check the cache to have cleared
-        expect(app.output).to match('Requirements file has been changed, clearing cached dependencies')
-        expect(app.output).not_to match('No dependencies found, preparing to install')
-        expect(app.output).not_to match('No change in requirements detected, installing from cache')
-
-        # With no changes on redeploy, the cache should be present
-        run!(%(git commit --allow-empty -m next))
-        app.push!
-
-        expect(app.output).to match('No change in requirements detected, installing from cache')
-        expect(app.output).not_to match('Requirements file has been changed, clearing cached dependencies')
-        expect(app.output).not_to match('No dependencies found, preparing to install')
-      end
-    end
-  end
-
   it 'getting started app has no relative paths' do
     buildpacks = [
       :default,


### PR DESCRIPTION
Since it was superseded by the pip cache test added in #1157, I just forgot to remove it in that PR.

Refs [W-8779835](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000094SrAIAU/view).

[skip changelog]