### PR TITLE
Tests: Replace stack change shunit2 test with Hatchet tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 STACK ?= heroku-20
 STACKS ?= heroku-16 heroku-18 heroku-20
 TEST_CMD ?= test/run-features && test/run-deps
-FIXTURE ?= test/fixtures/requirements-standard
+FIXTURE ?= spec/fixtures/python_version_unspecified
 ENV_FILE ?= builds/dockerenv.default
 BUILDER_IMAGE_PREFIX := heroku-python-build
 

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Python version support' do
           # so that users know why their app is on an older Python version.
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
-            remote:  !     Python has released a security update! Please consider upgrading to python-3.6.12
+            remote:  !     Python has released a security update! Please consider upgrading to python-#{LATEST_PYTHON_3_6}
             remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
           OUTPUT
           expect(app.run('python -V')).to include('Python 3.6.11')

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Stack changes' do
+  context 'when the stack is upgraded from Heroku-18 to Heroku-20', stacks: %w[heroku-18] do
+    # This test performs an initial build using an older buildpack version, followed
+    # by a build using the current version. This ensures that the current buildpack
+    # can successfully read the stack metadata written to the build cache in the past.
+    # The buildpack version chosen is one which had an older default Python version, so
+    # we can also prove that clearing the cache didn't lose the Python version metadata.
+    let(:buildpacks) { ['https://github.com/heroku/heroku-buildpack-python#v171'] }
+    let(:app) { new_app('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
+
+    it 'clears the cache before installing again whilst preserving the sticky Python version' do
+      app.deploy do |app|
+        expect(app.output).to include('Building on the Heroku-18 stack')
+        app.update_stack('heroku-20')
+        update_buildpacks(app, [:default])
+        app.commit!
+        app.push!
+        # TODO: The build log should explain that sticky-versioning has occurred,
+        # so that users know why their app is on an older Python version.
+        # TODO: The requirements output shouldn't say "installing from cache", since it's not.
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Python app detected
+          remote:  !     Python has released a security update! Please consider upgrading to python-#{LATEST_PYTHON_3_6}
+          remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
+          remote: -----> Stack has changed from heroku-18 to heroku-20, clearing cache
+          remote: -----> No change in requirements detected, installing from cache
+          remote: -----> Installing python-3.6.11
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing SQLite3
+          remote: -----> Installing requirements with pip
+          remote:        Collecting urllib3
+        OUTPUT
+      end
+    end
+  end
+
+  context 'when the stack is downgraded from Heroku-20 to Heroku-18', stacks: %w[heroku-20] do
+    let(:app) { new_app('spec/fixtures/python_version_unspecified') }
+
+    it 'clears the cache before installing again' do
+      app.deploy do |app|
+        expect(app.output).to include('Building on the Heroku-20 stack')
+        app.update_stack('heroku-18')
+        app.commit!
+        app.push!
+        # TODO: Stop using Python scripts before Python is installed (or else ensure system
+        # Python is always used) to avoid the glibc errors below.
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Python app detected
+          remote: python: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by python)
+          remote: python: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by python)
+          remote: -----> Stack has changed from heroku-20 to heroku-18, clearing cache
+          remote: -----> No change in requirements detected, installing from cache
+          remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing SQLite3
+          remote: -----> Installing requirements with pip
+          remote:        Collecting urllib3
+        OUTPUT
+      end
+    end
+  end
+end

--- a/test/fixtures/requirements-standard/requirements.txt
+++ b/test/fixtures/requirements-standard/requirements.txt
@@ -1,1 +1,0 @@
-requests

--- a/test/run-features
+++ b/test/run-features
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-testStackChange() {
-  local cache_dir="$(mktmpdir)"
-  mkdir -p "${cache_dir}/.heroku"
-  echo "different-stack" > "${cache_dir}/.heroku/python-stack"
-  compile "requirements-standard" "$cache_dir"
-  assertCaptured "clearing cache"
-  assertFile "$STACK" ".heroku/python-stack"
-  assertCapturedSuccess
-}
-
 testWarnOldDjango() {
   compile "old-django"
   assertCaptured "Your Django version is nearing the end of its community support."


### PR DESCRIPTION
Continues the shunit2 -> Hatchet test conversion.

This test was the last to use the `requirements-standard` fixture, so that fixture has been removed, which required switching to another in the default Makefile compile development target.

Closes [W-8780289](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000094TR8IAM/view).

[skip changelog]