### PR TITLE
Remove Git2GUS configuration

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,6 +1,0 @@
-{
-  "productTag": "a1aB0000000MR0RIAW",
-  "issueTypeLabels": { "gus: story": "USER STORY", "gus: bug": "BUG P3" },
-  "defaultBuild": "Heroku Unscheduled",
-  "statusWhenClosed": "CLOSED"
-}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,6 @@ name = "Python"
 [publish.Ignore]
 files = [
   ".circleci/",
-  ".git2gus/",
   ".github/",
   "builds/",
   "spec/",


### PR DESCRIPTION
Since the [Git2GUS](https://github.com/forcedotcom/git2gus) tool has a number of bugs/deficiencies which mean it's not usable for the time being. If that changes in the future we can add this configuration back and re-evaluate.

For example:
- https://github.com/forcedotcom/git2gus/issues/97
- https://github.com/forcedotcom/git2gus/issues/90
- https://github.com/forcedotcom/git2gus/issues/91
- https://github.com/forcedotcom/git2gus/issues/92
- https://github.com/forcedotcom/git2gus/issues/86
- https://github.com/forcedotcom/git2gus/issues/15

Closes [W-8825462](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000095LGKIA2/view).

[skip changelog]