### PR TITLE
Update pipenv to 2020.11.15 and unpin pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update pipenv from `2018.5.18` to `2020.11.15` ([#1169](https://github.com/heroku/heroku-buildpack-python/pull/1169)).
+- Remove pinning of pip to `9.0.2` when using pipenv ([#1169](https://github.com/heroku/heroku-buildpack-python/pull/1169)).
 
 ## v188 (2020-12-21)
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -49,22 +49,22 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
         fi
 
-        export PIPENV_VERSION="2018.5.18"
+        PIPENV_VERSION='2020.11.15'
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip
         # to latest if only --upgrade is specified. Specify upgrade strategy to
         # avoid this eager behavior.
-        /app/.heroku/python/bin/pip install pipenv==$PIPENV_VERSION --upgrade --upgrade-strategy only-if-needed &> /dev/null
+        /app/.heroku/python/bin/pip install "pipenv==${PIPENV_VERSION}" --upgrade --upgrade-strategy only-if-needed &> /dev/null
 
         # Install the test dependencies, for CI.
         if [ "$INSTALL_TEST" ]; then
-            puts-step "Installing test dependencies…"
+            puts-step "Installing test dependencies"
             /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
 
         # Install the dependencies.
         elif [[ ! -f Pipfile.lock ]]; then
-            puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
+            puts-step "Installing dependencies with Pipenv ${PIPENV_VERSION}"
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
 
         else
@@ -72,7 +72,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             cp requirements.txt .heroku/python/requirements-declared.txt
             openssl dgst -sha256 Pipfile.lock > .heroku/python/Pipfile.lock.sha256
 
-            puts-step "Installing dependencies with Pipenv $PIPENV_VERSION…"
+            puts-step "Installing dependencies with Pipenv ${PIPENV_VERSION}"
             /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
         fi
     fi

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -158,6 +158,8 @@ elif [[ "${PYTHON_VERSION}" == ${PY27}* || "${PYTHON_VERSION}" == ${PYPY27}* ]];
   SETUPTOOLS_VERSION='44.1.1'
 fi
 
+puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"
+
 # We don't use get-pip.py, since:
 #  - it uses `--force-reinstall`, which is unnecessary here and slows down repeat builds
 #  - it means downloading pip twice (once embedded in get-pip.py, and again during
@@ -175,19 +177,7 @@ if ! curl -sSf "${PIP_WHEEL_URL}" -o "$PIP_WHEEL"; then
   exit 1
 fi
 
-if [[ -f "$BUILD_DIR/Pipfile" ]]; then
-  # The buildpack is pinned to old pipenv, which requires older pip.
-  # Pip 9.0.2 doesn't support installing itself from a wheel, so we have to use split
-  # versions here (ie: installer pip version different from target pip version).
-  PIP_VERSION='9.0.2'
-  PIP_TO_INSTALL="pip==${PIP_VERSION}"
-else
-  PIP_TO_INSTALL="${PIP_WHEEL}"
-fi
-
-puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"
-
 /app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --disable-pip-version-check --no-cache \
-  "${PIP_TO_INSTALL}" "setuptools==${SETUPTOOLS_VERSION}" "wheel==${WHEEL_VERSION}"
+  "${PIP_WHEEL}" "setuptools==${SETUPTOOLS_VERSION}" "wheel==${WHEEL_VERSION}"
 
 hash -r

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -10,9 +10,9 @@ RSpec.shared_examples 'builds using Pipenv with the requested Python version' do
         remote: -----> Python app detected
         remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
         remote: -----> Installing python-#{python_version}
-        remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-        remote: -----> Installing dependencies with Pipenv 2018.5.18…
-        remote:        Installing dependencies from Pipfile.lock \\(.*\\)…
+        remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+        remote: -----> Installing dependencies with Pipenv 2020.11.15
+        remote:        Installing dependencies from Pipfile.lock \\(.*\\)...
         remote: -----> Installing SQLite3
       REGEX
     end
@@ -30,9 +30,9 @@ RSpec.describe 'Pipenv support' do
           remote:  !     No 'Pipfile.lock' found! We recommend you commit this into your repository.
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-          remote: -----> Installing dependencies with Pipenv 2018.5.18…
-          remote:        Installing dependencies from Pipfile…
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing dependencies with Pipenv 2020.11.15
+          remote:        Installing dependencies from Pipfile...
           remote: -----> Installing SQLite3
         REGEX
       end
@@ -48,9 +48,9 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-          remote: -----> Installing dependencies with Pipenv 2018.5.18…
-          remote:        Installing dependencies from Pipfile.lock \\(aad8b1\\)…
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing dependencies with Pipenv 2020.11.15
+          remote:        Installing dependencies from Pipfile.lock \\(aad8b1\\)...
           remote: -----> Installing SQLite3
         REGEX
       end
@@ -70,9 +70,9 @@ RSpec.describe 'Pipenv support' do
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
             remote: -----> Installing python-#{LATEST_PYTHON_2_7}
-            remote: -----> Installing pip 9.0.2, setuptools 44.1.1 and wheel 0.34.2
-            remote: -----> Installing dependencies with Pipenv 2018.5.18…
-            remote:        Installing dependencies from Pipfile.lock \\(b8efa9\\)…
+            remote: -----> Installing pip 20.1.1, setuptools 44.1.1 and wheel 0.34.2
+            remote: -----> Installing dependencies with Pipenv 2020.11.15
+            remote:        Installing dependencies from Pipfile.lock \\(b8efa9\\)...
             remote: -----> Installing SQLite3
           REGEX
         end
@@ -172,9 +172,9 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
-          remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-          remote: -----> Installing dependencies with Pipenv 2018.5.18…
-          remote:        Installing dependencies from Pipfile.lock \\(75eae0\\)…
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing dependencies with Pipenv 2020.11.15
+          remote:        Installing dependencies from Pipfile.lock \\(75eae0\\)...
           remote: -----> Installing SQLite3
         REGEX
       end
@@ -189,9 +189,9 @@ RSpec.describe 'Pipenv support' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
-          remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-          remote: -----> Installing dependencies with Pipenv 2018.5.18…
-          remote:        Installing dependencies from Pipfile.lock (ef68d1)…
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing dependencies with Pipenv 2020.11.15
+          remote:        Installing dependencies from Pipfile.lock (ef68d1)...
           remote: -----> Installing SQLite3
         OUTPUT
       end
@@ -203,14 +203,15 @@ RSpec.describe 'Pipenv support' do
 
     it 'fails the build' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Python app detected
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 9.0.2, setuptools 47.1.1 and wheel 0.34.2
-          remote: -----> Installing dependencies with Pipenv 2018.5.18…
+          remote: -----> Installing pip 20.1.1, setuptools 47.1.1 and wheel 0.34.2
+          remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Your Pipfile.lock \\(aad8b1\\) is out of date. Expected: \\(ef68d1\\).
-          remote:        Aborting deploy.
+          remote:        \\[DeployException\\]: .*
+          remote:        ERROR:: Aborting deploy
         REGEX
       end
     end


### PR DESCRIPTION
Previously the buildpack used pipenv `2018.5.18`, which in addition to being out of date doesn't support newer pip, meaning that apps using pipenv had to be pinned to a much older version of pip.

For apps using pipenv, the buildpack now installs pipenv `2020.11.15` and no longer overrides the pip version compared to non-pipenv installs, meaning pip `20.1.1` is now used instead of pip `9.0.2`. (The pip version is still pinned, but to the reasonably new pip version used by all other non-pipenv builds.)

Changes:
https://github.com/pypa/pipenv/blob/master/CHANGELOG.rst#20201115-2020-11-15
https://github.com/pypa/pipenv/compare/v2018.05.18...v2020.11.15

This is particularly important since `cryptography` v3.4 ([released 2021-02-07](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#34---2021-02-07)) requires at least pip 19.x, otherwise pip is unable to use its newer style `abi3` wheels, and so falls back to building the source distribution. This causes the install to fail, since building `cryptography` from the sdist now requires Rust, which is not present in the Heroku stack image. As seen in:
- https://heroku.support/960104
- https://heroku.support/960598
- https://heroku.support/961123

For more info on the `cryptography` issue, see:
https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler
https://github.com/pyca/cryptography/issues/5771
https://github.com/pyca/cryptography/issues/5798

Fixes #979.
Fixes #987.
Fixes #1108.
Closes GUS-W-8054805.