### PR TITLE
README: Remove broken link to Dev Center article

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This is the official [Heroku buildpack](https://devcenter.heroku.com/articles/bu
 
 Recommended web frameworks include **Django** and **Flask**, among others. The recommended webserver is **Gunicorn**. There are no restrictions around what software can be used (as long as it's pip-installable). Web processes must bind to `$PORT`, and only the HTTP protocol is permitted for incoming connections.
 
-Python packages with C dependencies that are not [available on the stack image](https://devcenter.heroku.com/articles/stack-packages) are generally not supported, unless `manylinux` wheels are provided by the package maintainers (common). For recommended solutions, check out [this article](https://devcenter.heroku.com/articles/python-c-deps) for more information.
-
 See it in Action
 ----------------
 ```


### PR DESCRIPTION
The article no longer exists (the solution it recommended was out of date), and the README also isn't really the best place for this kind of content.

Closes GUS-W-8884544.

[skip changelog]