### PR TITLE
Release v190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v190 (2021-02-16)
+
 - Python 3.6.13 and 3.7.10 are now available (CPython) ([#1174](https://github.com/heroku/heroku-buildpack-python/pull/1174)).
 - The default Python version for new apps is now 3.6.13 (previously 3.6.12) ([#1174](https://github.com/heroku/heroku-buildpack-python/pull/1174)).
 


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-python/compare/v189...57aee6f104872b04dc0f226dc3169fc59d827842

Closes GUS-W-8896689.