### PR TITLE
Tests: Cleanup after update to Hatchet 7.3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,10 @@ jobs:
     working_directory: /mnt/ramdisk/project
     environment:
       HATCHET_APP_LIMIT: 200
+      HATCHET_DEFAULT_STACK: << parameters.stack >>
       HATCHET_RETRIES: 3
       HEROKU_DISABLE_AUTOUPDATE: 1
       PARALLEL_SPLIT_TEST_PROCESSES: 60
-      STACK: << parameters.stack >>
       # Make Hatchet create the temporary Git repos on the faster ramdisk.
       TMPDIR: /mnt/ramdisk
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,6 @@ jobs:
       - checkout
       - install-ruby-dependencies
       - run:
-          # This step can be removed once we have a newer Hatchet release that includes:
-          # https://github.com/heroku/hatchet/pull/171
-          name: Install Heroku CLI
-          command: curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install.sh | sh
-      - run:
           name: Hatchet setup
           command: bundle exec hatchet ci:setup
       - run:

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 RSpec.describe 'Heroku CI' do
   it 'works' do
-    new_app('spec/fixtures/ci_nose').run_ci do |test_run|
+    Hatchet::Runner.new('spec/fixtures/ci_nose').run_ci do |test_run|
       expect(test_run.output).to match('Downloading nose')
       expect(test_run.output).to match('OK')
 

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Buildpack detection' do
   # are already tested in the specs for general buildpack functionality.
 
   context 'when there are no recognised Python project files' do
-    let(:app) { new_app('spec/fixtures/no_python_project_files', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/no_python_project_files', allow_failure: true) }
 
     it 'fails detection' do
       app.deploy do |app|

--- a/spec/hatchet/django_spec.rb
+++ b/spec/hatchet/django_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 RSpec.describe 'Django support' do
   context 'when requirements.txt contains Django==1.11' do
-    let(:app) { new_app('spec/fixtures/requirements_django_1.11') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_django_1.11') }
 
     it 'warns about Django end of support' do
       app.deploy do |app|
@@ -19,7 +19,7 @@ RSpec.describe 'Django support' do
   end
 
   context 'when requirements.txt contains Django==2.1' do
-    let(:app) { new_app('spec/fixtures/requirements_django_2.1') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_django_2.1') }
 
     it 'does not warn about Django end of support' do
       app.deploy do |app|
@@ -30,7 +30,7 @@ RSpec.describe 'Django support' do
 
   # TODO: Add tests for disabling collectstatic, failure cases etc.
   context 'when building a Django project' do
-    let(:app) { new_app('python-getting-started') }
+    let(:app) { Hatchet::Runner.new('python-getting-started') }
 
     it 'collectstatic is run automatically' do
       app.deploy do |app|

--- a/spec/hatchet/getting_started_spec.rb
+++ b/spec/hatchet/getting_started_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Python getting started project' do
       :default,
       'https://github.com/sharpstone/force_absolute_paths_buildpack'
     ]
-    new_app('python-getting-started', buildpacks: buildpacks).deploy do |app|
+    Hatchet::Runner.new('python-getting-started', buildpacks: buildpacks).deploy do |app|
       # Deploy works
     end
   end

--- a/spec/hatchet/hooks_spec.rb
+++ b/spec/hatchet/hooks_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 RSpec.describe 'Compile hooks' do
   context 'when an app has bin/pre_compile and bin/post_compile scripts' do
-    let(:app) { new_app('spec/fixtures/hooks', config: { 'SOME_APP_CONFIG_VAR' => '1' }) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/hooks', config: { 'SOME_APP_CONFIG_VAR' => '1' }) }
 
     it 'runs the hooks with the correct environment' do
       expected_env_vars = %w[

--- a/spec/hatchet/nltk_spec.rb
+++ b/spec/hatchet/nltk_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 RSpec.describe 'NLTK corpora support' do
   context 'when the NLTK package is installed and nltk.txt is present' do
-    let(:app) { new_app('spec/fixtures/nltk_dependency_and_nltk_txt') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/nltk_dependency_and_nltk_txt') }
 
     it 'installs the specified NLTK corpora' do
       app.deploy do |app|
@@ -25,7 +25,7 @@ RSpec.describe 'NLTK corpora support' do
   end
 
   context 'when the NLTK package is installed but there is no nltk.txt' do
-    let(:app) { new_app('spec/fixtures/nltk_dependency_only') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/nltk_dependency_only') }
 
     it 'warns that nltk.txt was not found' do
       app.deploy do |app|
@@ -39,7 +39,7 @@ RSpec.describe 'NLTK corpora support' do
   end
 
   context 'when only nltk.txt is present' do
-    let(:app) { new_app('spec/fixtures/nltk_txt_but_no_dependency') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/nltk_txt_but_no_dependency') }
 
     it 'does not try to install the specified NLTK corpora' do
       app.deploy do |app|

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -13,7 +13,7 @@ end
 
 RSpec.describe 'Pip support' do
   context 'when requirements.txt is unchanged since the last build' do
-    let(:app) { new_app('spec/fixtures/python_version_unspecified') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified') }
 
     it 're-uses packages from the cache' do
       app.deploy do |app|
@@ -43,7 +43,7 @@ RSpec.describe 'Pip support' do
   end
 
   context 'when requirements.txt has changed since the last build' do
-    let(:app) { new_app('spec/fixtures/python_version_unspecified') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified') }
 
     it 'clears the cache before installing the packages again' do
       app.deploy do |app|
@@ -69,19 +69,19 @@ RSpec.describe 'Pip support' do
   end
 
   context 'when requirements.txt contains popular compiled packages' do
-    let(:app) { new_app('spec/fixtures/requirements_compiled') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_compiled') }
 
     include_examples 'installs successfully using pip'
   end
 
   context 'when requirements.txt contains Git/Mercurial requirements URLs' do
-    let(:app) { new_app('spec/fixtures/requirements_vcs') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_vcs') }
 
     include_examples 'installs successfully using pip'
   end
 
   context 'when requirements.txt contains editable requirements' do
-    let(:app) { new_app('spec/fixtures/requirements_editable') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_editable') }
 
     # TODO: Make this test the path rewriting, and --src directory handling,
     # and that the packages work during all of hooks, later buildpacks, runtime,
@@ -90,7 +90,7 @@ RSpec.describe 'Pip support' do
   end
 
   context 'when there is only a setup.py' do
-    let(:app) { new_app('spec/fixtures/setup_py_only') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/setup_py_only') }
 
     it 'installs packages from setup.py' do
       app.deploy do |app|
@@ -101,7 +101,7 @@ RSpec.describe 'Pip support' do
   end
 
   context 'when there is both a requirements.txt and setup.py' do
-    let(:app) { new_app('spec/fixtures/requirements_txt_and_setup_py') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_txt_and_setup_py') }
 
     it 'installs packages only from requirements.txt' do
       app.deploy do |app|
@@ -118,20 +118,20 @@ RSpec.describe 'Pip support' do
     # This is split out from the requirements_compiled fixture, since the original
     # pysqlite package (as opposed to the newer pysqlite3) only supports Python 2.
     # This test has to be skipped on newer stacks where Python 2 is not available.
-    let(:app) { new_app('spec/fixtures/requirements_pysqlite_python_2') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_pysqlite_python_2') }
 
     include_examples 'installs successfully using pip'
   end
 
   context 'when using Airflow 1.10.2 with SLUGIFY_USES_TEXT_UNIDECODE set' do
     let(:config) { { 'SLUGIFY_USES_TEXT_UNIDECODE' => 'yes' } }
-    let(:app) { new_app('spec/fixtures/requirements_airflow_1.10.2', config: config) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_airflow_1.10.2', config: config) }
 
     include_examples 'installs successfully using pip'
   end
 
   context 'when requirements.txt contains GDAL but the GDAL C++ library is missing' do
-    let(:app) { new_app('spec/fixtures/requirements_gdal', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_gdal', allow_failure: true) }
 
     it 'outputs instructions for how to resolve the build failure' do
       app.deploy do |app|
@@ -147,7 +147,7 @@ RSpec.describe 'Pip support' do
 
   context 'when the legacy BUILD_WITH_GEO_LIBRARIES env var is set' do
     let(:config) { { 'BUILD_WITH_GEO_LIBRARIES' => '' } }
-    let(:app) { new_app('spec/fixtures/python_version_unspecified', config: config, allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', config: config, allow_failure: true) }
 
     it 'aborts the build with an unsupported error message' do
       app.deploy do |app|

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -21,7 +21,7 @@ end
 
 RSpec.describe 'Pipenv support' do
   context 'without a Pipfile.lock' do
-    let(:app) { new_app('spec/fixtures/pipenv_no_lockfile') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_no_lockfile') }
 
     it 'builds with the default Python version using just the Pipfile' do
       app.deploy do |app|
@@ -40,7 +40,7 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'with a Pipfile.lock but no Python version specified' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_version_unspecified') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_version_unspecified') }
 
     it 'builds with the default Python version' do
       app.deploy do |app|
@@ -59,7 +59,7 @@ RSpec.describe 'Pipenv support' do
 
   context 'with a Pipfile.lock containing python_version 2.7' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/pipenv_python_2.7', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_2.7', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       it 'builds with the latest Python 2.7' do
@@ -99,44 +99,44 @@ RSpec.describe 'Pipenv support' do
   # Python version to be used instead, due to W-8104668.
   context 'with a Pipfile.lock containing python_version 3.5',
           skip: 'python_version mapping does not currently support 3.5' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_3.5') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.5') }
 
     include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_5
   end
 
   context 'with a Pipfile.lock containing python_version 3.6' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_3.6') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.6') }
 
     include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_6
   end
 
   context 'with a Pipfile.lock containing python_version 3.7' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_3.7') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.7') }
 
     include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_7
   end
 
   context 'with a Pipfile.lock containing python_version 3.8' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_3.8') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.8') }
 
     include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_8
   end
 
   context 'with a Pipfile.lock containing python_version 3.9' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_3.9') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.9') }
 
     include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'with a Pipfile.lock containing python_full_version 3.9.1' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_full_version') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_full_version') }
 
     include_examples 'builds using Pipenv with the requested Python version', '3.9.1'
   end
 
   context 'with a Pipfile.lock containing an invalid python_version',
           skip: 'unknown python_version values are currently ignored (W-8104668)' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_version_invalid', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_version_invalid', allow_failure: true) }
 
     it 'fails the build' do
       app.deploy do |app|
@@ -150,7 +150,7 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'with a Pipfile.lock containing an invalid python_full_version' do
-    let(:app) { new_app('spec/fixtures/pipenv_python_full_version_invalid', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_full_version_invalid', allow_failure: true) }
 
     it 'fails the build' do
       app.deploy do |app|
@@ -164,7 +164,7 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'when there is a both a Pipfile.lock python_version and a runtime.txt' do
-    let(:app) { new_app('spec/fixtures/pipenv_and_runtime_txt') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_and_runtime_txt') }
 
     it 'builds with the Python version from runtime.txt' do
       app.deploy do |app|
@@ -182,7 +182,7 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'when there is both a Pipfile.lock and a requirements.txt' do
-    let(:app) { new_app('spec/fixtures/pipenv_and_requirements_txt') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_and_requirements_txt') }
 
     it 'builds with Pipenv rather than pip' do
       app.deploy do |app|
@@ -199,7 +199,7 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'when the Pipfile.lock is out of sync with Pipfile' do
-    let(:app) { new_app('spec/fixtures/pipenv_lockfile_out_of_sync', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_lockfile_out_of_sync', allow_failure: true) }
 
     it 'fails the build' do
       app.deploy do |app|

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -30,7 +30,7 @@ end
 RSpec.describe 'Python update warnings' do
   context 'with a runtime.txt containing python-2.7.17' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_2.7_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_2.7_outdated', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       it 'warns that Python 2.7.17 is both EOL and not the latest patch release' do
@@ -56,7 +56,7 @@ RSpec.describe 'Python update warnings' do
 
   context 'with a runtime.txt containing python-3.4.9' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_3.4_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.4_outdated', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       include_examples 'warns there is a Python update available', '3.4.9', LATEST_PYTHON_3_4
@@ -71,7 +71,7 @@ RSpec.describe 'Python update warnings' do
 
   context 'with a runtime.txt containing python-3.5.9' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_3.5_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.5_outdated', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       include_examples 'warns there is a Python update available', '3.5.9', LATEST_PYTHON_3_5
@@ -85,31 +85,31 @@ RSpec.describe 'Python update warnings' do
   end
 
   context 'with a runtime.txt containing python-3.6.11' do
-    let(:app) { new_app('spec/fixtures/python_3.6_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.6_outdated') }
 
     include_examples 'warns there is a Python update available', '3.6.11', LATEST_PYTHON_3_6
   end
 
   context 'with a runtime.txt containing python-3.7.8' do
-    let(:app) { new_app('spec/fixtures/python_3.7_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7_outdated') }
 
     include_examples 'warns there is a Python update available', '3.7.8', LATEST_PYTHON_3_7
   end
 
   context 'with a runtime.txt containing python-3.8.6' do
-    let(:app) { new_app('spec/fixtures/python_3.8_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8_outdated') }
 
     include_examples 'warns there is a Python update available', '3.8.6', LATEST_PYTHON_3_8
   end
 
   context 'with a runtime.txt containing python-3.9.0' do
-    let(:app) { new_app('spec/fixtures/python_3.9_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9_outdated') }
 
     include_examples 'warns there is a Python update available', '3.9.0', LATEST_PYTHON_3_9
   end
 
   context 'with a runtime.txt containing pypy2.7-7.3.1' do
-    let(:app) { new_app('spec/fixtures/pypy_2.7_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pypy_2.7_outdated') }
 
     it 'warns there is a PyPy update available' do
       app.deploy do |app|
@@ -123,7 +123,7 @@ RSpec.describe 'Python update warnings' do
   end
 
   context 'with a runtime.txt containing pypy3.6-7.3.1' do
-    let(:app) { new_app('spec/fixtures/pypy_3.6_outdated') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pypy_3.6_outdated') }
 
     it 'warns there is a PyPy update available' do
       app.deploy do |app|

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -33,7 +33,7 @@ end
 RSpec.describe 'Python version support' do
   context 'when no Python version is specified' do
     let(:buildpacks) { [:default] }
-    let(:app) { new_app('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
 
     context 'with a new app' do
       it 'builds with the default Python version' do
@@ -72,7 +72,7 @@ RSpec.describe 'Python version support' do
 
   context 'when runtime.txt contains python-2.7.18' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_2.7', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_2.7', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       it 'builds with Python 2.7.18' do
@@ -102,7 +102,7 @@ RSpec.describe 'Python version support' do
 
   context 'when runtime.txt contains python-3.4.10' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_3.4', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.4', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       it 'builds with Python 3.4.10' do
@@ -134,7 +134,7 @@ RSpec.describe 'Python version support' do
 
   context 'when runtime.txt contains python-3.5.10' do
     let(:allow_failure) { false }
-    let(:app) { new_app('spec/fixtures/python_3.5', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.5', allow_failure: allow_failure) }
 
     context 'when using Heroku-16 or Heroku-18', stacks: %w[heroku-16 heroku-18] do
       include_examples 'builds with the requested Python version', LATEST_PYTHON_3_5
@@ -149,31 +149,31 @@ RSpec.describe 'Python version support' do
   end
 
   context 'when runtime.txt contains python-3.6.13' do
-    let(:app) { new_app('spec/fixtures/python_3.6') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.6') }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_6
   end
 
   context 'when runtime.txt contains python-3.7.10' do
-    let(:app) { new_app('spec/fixtures/python_3.7') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7') }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_7
   end
 
   context 'when runtime.txt contains python-3.8.7' do
-    let(:app) { new_app('spec/fixtures/python_3.8') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8') }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_8
   end
 
   context 'when runtime.txt contains python-3.9.1' do
-    let(:app) { new_app('spec/fixtures/python_3.9') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9') }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'when runtime.txt contains pypy2.7-7.3.2' do
-    let(:app) { new_app('spec/fixtures/pypy_2.7') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pypy_2.7') }
 
     it 'builds with PyPy2.7 v7.3.2' do
       app.deploy do |app|
@@ -191,7 +191,7 @@ RSpec.describe 'Python version support' do
   end
 
   context 'when runtime.txt contains pypy3.6-7.3.2' do
-    let(:app) { new_app('spec/fixtures/pypy_3.6') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pypy_3.6') }
 
     it 'builds with PyPy3.6 v7.3.2' do
       app.deploy do |app|
@@ -209,25 +209,25 @@ RSpec.describe 'Python version support' do
   end
 
   context 'when runtime.txt contains an invalid python version string' do
-    let(:app) { new_app('spec/fixtures/python_version_invalid', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_invalid', allow_failure: true) }
 
     include_examples 'aborts the build with a runtime not available message', 'X.Y.Z'
   end
 
   context 'when runtime.txt contains stray whitespace' do
-    let(:app) { new_app('spec/fixtures/runtime_txt_with_stray_whitespace') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/runtime_txt_with_stray_whitespace') }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'when there is only a runtime.txt and no requirements.txt', skip: 'not currently supported (W-8720280)' do
-    let(:app) { new_app('spec/fixtures/runtime_txt_only', allow_failure: true) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/runtime_txt_only', allow_failure: true) }
 
     include_examples 'builds with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'when the requested Python version has changed since the last build' do
-    let(:app) { new_app('spec/fixtures/python_3.6') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.6') }
 
     it 'builds with the new Python version after removing the old install' do
       app.deploy do |app|

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Stack changes' do
     # The buildpack version chosen is one which had an older default Python version, so
     # we can also prove that clearing the cache didn't lose the Python version metadata.
     let(:buildpacks) { ['https://github.com/heroku/heroku-buildpack-python#v189'] }
-    let(:app) { new_app('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
 
     it 'clears the cache before installing again whilst preserving the sticky Python version' do
       app.deploy do |app|
@@ -39,7 +39,7 @@ RSpec.describe 'Stack changes' do
   end
 
   context 'when the stack is downgraded from Heroku-20 to Heroku-18', stacks: %w[heroku-20] do
-    let(:app) { new_app('spec/fixtures/python_version_unspecified') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified') }
 
     it 'clears the cache before installing again' do
       app.deploy do |app|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,10 +37,6 @@ RSpec.configure do |config|
   config.filter_run_excluding stacks: ->(stacks) { !stacks.include?(ENV['HATCHET_DEFAULT_STACK']) }
 end
 
-def new_app(*args, **kwargs)
-  Hatchet::Runner.new(*args, **kwargs)
-end
-
 def clean_output(output)
   # Remove trailing whitespace characters added by Git:
   # https://github.com/heroku/hatchet/issues/162

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-ENV['HATCHET_BUILDPACK_BASE'] = 'https://github.com/heroku/heroku-buildpack-python.git'
+ENV['HATCHET_BUILDPACK_BASE'] ||= 'https://github.com/heroku/heroku-buildpack-python.git'
+ENV['HATCHET_DEFAULT_STACK'] ||= 'heroku-20'
 
 require 'English'
 
 require 'rspec/core'
 require 'hatchet'
-
-DEFAULT_STACK = ENV['STACK'] || 'heroku-20'
 
 LATEST_PYTHON_2_7 = '2.7.18'
 LATEST_PYTHON_3_4 = '3.4.10'
@@ -35,13 +34,10 @@ RSpec.configure do |config|
   # with `:focus` metadata via the `fit`, `fcontext` and `fdescribe` aliases.
   config.filter_run_when_matching :focus
   # Allows declaring on which stacks a test/group should run by tagging it with `stacks`.
-  config.filter_run_excluding stacks: ->(stacks) { !stacks.include?(DEFAULT_STACK) }
+  config.filter_run_excluding stacks: ->(stacks) { !stacks.include?(ENV['HATCHET_DEFAULT_STACK']) }
 end
 
 def new_app(*args, **kwargs)
-  # Wrapping app creation to set the default stack, in lieu of being able to configure it globally:
-  # https://github.com/heroku/hatchet/issues/163
-  kwargs[:stack] ||= DEFAULT_STACK
   Hatchet::Runner.new(*args, **kwargs)
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@
 ENV['HATCHET_BUILDPACK_BASE'] ||= 'https://github.com/heroku/heroku-buildpack-python.git'
 ENV['HATCHET_DEFAULT_STACK'] ||= 'heroku-20'
 
-require 'English'
-
 require 'rspec/core'
 require 'hatchet'
 
@@ -48,11 +46,4 @@ def update_buildpacks(app, buildpacks)
   # https://github.com/heroku/hatchet/issues/166
   buildpack_list = buildpacks.map { |b| { buildpack: (b == :default ? DEFAULT_BUILDPACK_URL : b) } }
   app.api_rate_limit.call.buildpack_installation.update(app.name, updates: buildpack_list)
-end
-
-def run!(cmd)
-  out = `#{cmd}`
-  raise "Error running command #{cmd} with output: #{out}" unless $CHILD_STATUS.success?
-
-  out
 end


### PR DESCRIPTION
Now that we've updated to Hatchet 7.3.4 in #1173, we can remove the workarounds for issues resolved/features added in that version:
https://github.com/heroku/hatchet/blob/main/CHANGELOG.md#734

See individual commit messages for more details.

Closes GUS-W-8900415.

[skip changelog]