### PR TITLE
Release v191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v191 (2021-02-19)
+
 - Python 3.8.8 and 3.9.2 are now available (CPython) ([#1178](https://github.com/heroku/heroku-buildpack-python/pull/1178)).
 
 ## v190 (2021-02-16)


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-python/compare/v190...a1526d681929c70d26a80e6fe233ba6dacfaddae

Closes GUS-W-8911881.