### PR TITLE
Remove Airflow SLUGIFY_USES_TEXT_UNIDECODE workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove Airflow `SLUGIFY_USES_TEXT_UNIDECODE` workaround ([#1186](https://github.com/heroku/heroku-buildpack-python/pull/1186)).
 - Fix grammar in the Python 2 EOL message ([#1182](https://github.com/heroku/heroku-buildpack-python/pull/1182)).
 
 ## v191 (2021-02-19)

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -21,18 +21,6 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
     set +e
 
-    # Set SLUGIFY_USES_TEXT_UNIDECODE, required for Airflow versions 1.10.0 to 1.10.2,
-    # in order to acknowledge a GPL package issue:
-    # https://github.com/apache/airflow/blob/master/UPDATING.md#airflow-110
-    # TODO: Remove this functionality since newer versions of Airflow do not need this.
-    if [[ -r "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE" ]]; then
-        SLUGIFY_USES_TEXT_UNIDECODE="$(cat "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE")"
-        export SLUGIFY_USES_TEXT_UNIDECODE
-        mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
-    fi
-
-    set +e
-
     # Measure that we're using pip.
     mcount "tool.pip"
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -42,13 +42,6 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
-        # Set SLUGIFY_USES_TEXT_UNIDECODE, required for Airflow versions >=1.10
-        if [[ -r "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE" ]]; then
-            SLUGIFY_USES_TEXT_UNIDECODE="$(cat "$ENV_DIR/SLUGIFY_USES_TEXT_UNIDECODE")"
-            export SLUGIFY_USES_TEXT_UNIDECODE
-            mcount "buildvar.SLUGIFY_USES_TEXT_UNIDECODE"
-        fi
-
         PIPENV_VERSION='2020.11.15'
 
         # Install pipenv.

--- a/spec/fixtures/requirements_airflow_1.10.2/requirements.txt
+++ b/spec/fixtures/requirements_airflow_1.10.2/requirements.txt
@@ -1,1 +1,0 @@
-apache-airflow==1.10.2

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -123,13 +123,6 @@ RSpec.describe 'Pip support' do
     include_examples 'installs successfully using pip'
   end
 
-  context 'when using Airflow 1.10.2 with SLUGIFY_USES_TEXT_UNIDECODE set' do
-    let(:config) { { 'SLUGIFY_USES_TEXT_UNIDECODE' => 'yes' } }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_airflow_1.10.2', config: config) }
-
-    include_examples 'installs successfully using pip'
-  end
-
   context 'when requirements.txt contains GDAL but the GDAL C++ library is missing' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_gdal', allow_failure: true) }
 


### PR DESCRIPTION
Airflow versions 1.10.0 to 1.10.2 required that the environment variable `SLUGIFY_USES_TEXT_UNIDECODE` was set during pip installation, in order to acknowledge a GPL licencing issue:
https://github.com/apache/airflow/blob/master/UPDATING.md#airflow-110

Since this buildpack doesn't expose all app env vars to the `pip install` command by default, this meant the env var `SLUGIFY_USES_TEXT_UNIDECODE` had to be special-cased.

However Airflow 1.10.3 and newer no longer require this:
https://github.com/apache/airflow/blob/master/UPDATING.md#airflow-1103

Removing this workaround also means we can remove the test, which:
* is the longest running test in the Hatchet suite, due to the sheer size of Airflow and its dependencies
* saves having to make the test compatible with Python 3.9, when the default Python version changes shortly.

Usage of this env var is extremely low (and the metrics overstate usage, since the metrics don't exclude apps using newer Airflow):
https://metrics.librato.com/s/metrics/buildpack.python.buildvar.SLUGIFY_USES_TEXT_UNIDECODE?duration=2419200

Apps using the affected Airflow versions should update either to a newer Airflow 1.10.x release (the most recent being 1.10.15), or else Airflow 2.

Closes GUS-W-9084752.