### PR TITLE
Release v192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v192 (2021-04-06)
+
 - Python 3.8.9 and 3.9.4 are now available (CPython) ([#1188](https://github.com/heroku/heroku-buildpack-python/pull/1188)).
 - Use Python 3.9 as the default Python version for new apps (previously Python 3.6) ([#1187](https://github.com/heroku/heroku-buildpack-python/pull/1187)).
 - Remove Airflow `SLUGIFY_USES_TEXT_UNIDECODE` workaround ([#1186](https://github.com/heroku/heroku-buildpack-python/pull/1186)).


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-python/compare/v191...04e615ce932cb229bbfd2b9f2e41faa3c8a62150

Closes GUS-W-9101676.