### PR TITLE
Always output the Python version used and reason why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Always output the Python version used and reason why ([#1196](https://github.com/heroku/heroku-buildpack-python/pull/1196)).
 
 ## v193 (2021-04-13)
 

--- a/bin/compile
+++ b/bin/compile
@@ -222,11 +222,19 @@ fi
 source "$BIN_DIR/steps/pipenv-python-version"
 
 if [[ -f runtime.txt ]]; then
+  # PYTHON_VERSION_SOURCE may have already been set by the pipenv-python-version step.
+  # TODO: Refactor this and stop pipenv-python-version using runtime.txt as an API.
+  PYTHON_VERSION_SOURCE=${PYTHON_VERSION_SOURCE:-"runtime.txt"}
+  puts-step "Using Python version specified in ${PYTHON_VERSION_SOURCE}"
   mcount "version.reason.python.specified"
 elif [[ -n "${CACHED_PYTHON_VERSION:-}" ]]; then
+  puts-step "No Python version was specified. Using the same version as the last build: ${CACHED_PYTHON_VERSION}"
+  echo "       To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes"
   mcount "version.reason.python.cached"
   echo "${CACHED_PYTHON_VERSION}" > runtime.txt
 else
+  puts-step "No Python version was specified. Using the buildpack default: ${DEFAULT_PYTHON_VERSION}"
+  echo "       To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes"
   mcount "version.reason.python.default"
   echo "${DEFAULT_PYTHON_VERSION}" > runtime.txt
 fi

--- a/bin/steps/pipenv-python-version
+++ b/bin/steps/pipenv-python-version
@@ -9,6 +9,9 @@ if [[ -f $BUILD_DIR/Pipfile ]]; then
             puts-warn "No 'Pipfile.lock' found! We recommend you commit this into your repository."
         fi
         if [[ -f $BUILD_DIR/Pipfile.lock ]]; then
+            # Ignore unused env var warning since this is used by bin/compile.
+            # shellcheck disable=2034
+            PYTHON_VERSION_SOURCE='Pipfile.lock'
             set +e
             PYTHON=$(jq -r '._meta.requires.python_full_version' "$BUILD_DIR/Pipfile.lock")
             if [[ "$PYTHON" != "null" ]]; then

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -95,7 +95,7 @@ fi
 
 if [ -f .heroku/python-version ]; then
   if [ ! "$(cat .heroku/python-version)" = "$PYTHON_VERSION" ]; then
-      puts-step "Found $(cat .heroku/python-version), removing"
+      puts-step "Python version has changed from $(cat .heroku/python-version) to ${PYTHON_VERSION}, clearing cache"
       rm -rf .heroku/python
   else
     SKIP_INSTALL=1
@@ -121,17 +121,19 @@ else
   fi
 fi
 
-if [ ! "$SKIP_INSTALL" ]; then
-    puts-step "Installing $PYTHON_VERSION"
+if [[ -n "${SKIP_INSTALL}" ]]; then
+  puts-step "Using cached install of ${PYTHON_VERSION}"
+else
+  puts-step "Installing ${PYTHON_VERSION}"
 
-    # Prepare destination directory.
-    mkdir -p .heroku/python
+  # Prepare destination directory.
+  mkdir -p .heroku/python
 
-    if ! curl "${VENDORED_PYTHON}" -s | tar zxv -C .heroku/python &> /dev/null; then
-      puts-warn "Requested runtime ($PYTHON_VERSION) is not available for this stack ($STACK)."
-      puts-warn "Aborting.  More info: https://devcenter.heroku.com/articles/python-support"
-      exit 1
-    fi
+  if ! curl "${VENDORED_PYTHON}" -s | tar zxv -C .heroku/python &> /dev/null; then
+    puts-warn "Requested runtime ($PYTHON_VERSION) is not available for this stack ($STACK)."
+    puts-warn "Aborting.  More info: https://devcenter.heroku.com/articles/python-support"
+    exit 1
+  fi
 
   # Record for future reference.
   echo "$PYTHON_VERSION" > .heroku/python-version

--- a/spec/hatchet/hooks_spec.rb
+++ b/spec/hatchet/hooks_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Compile hooks' do
           remote: -----> Running pre-compile hook
           remote: pre_compile ran with env vars:
           remote: #{expected_env_vars.join("\nremote: ")}
-          remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
+          remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote: .*
           remote: -----> Installing requirements with pip
           remote: -----> Running post-compile hook

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Pip support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
           remote: -----> Installing SQLite3
@@ -32,7 +34,10 @@ RSpec.describe 'Pip support' do
         app.push!
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the same version as the last build: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> No change in requirements detected, installing from cache
+          remote: -----> Using cached install of python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
@@ -52,6 +57,8 @@ RSpec.describe 'Pip support' do
         app.push!
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the same version as the last build: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Requirements file has been changed, clearing cached dependencies
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -8,6 +8,7 @@ RSpec.shared_examples 'builds using Pipenv with the requested Python version' do
       # TODO: Fix the "cp: cannot stat" error here and in the other testcases below (W-7924941).
       expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
         remote: -----> Python app detected
+        remote: -----> Using Python version specified in Pipfile.lock
         remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
         remote: -----> Installing python-#{python_version}
         remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
@@ -28,6 +29,8 @@ RSpec.describe 'Pipenv support' do
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote:  !     No 'Pipfile.lock' found! We recommend you commit this into your repository.
+          remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
@@ -46,6 +49,8 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
@@ -66,6 +71,7 @@ RSpec.describe 'Pipenv support' do
         app.deploy do |app|
           expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
             remote: -----> Python app detected
+            remote: -----> Using Python version specified in Pipfile.lock
             remote:  !     Python 2 has reached its community EOL. Upgrade your Python runtime to maintain a secure application as soon as possible.
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
@@ -87,6 +93,7 @@ RSpec.describe 'Pipenv support' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
+            remote: -----> Using Python version specified in Pipfile.lock
             remote:  !     Requested runtime (python-#{LATEST_PYTHON_2_7}) is not available for this stack (#{app.stack}).
             remote:  !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
           OUTPUT
@@ -135,6 +142,7 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in Pipfile.lock
           remote:  !     Python has released a security update! Please consider upgrading to python-#{LATEST_PYTHON_3_9}
           remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
@@ -156,6 +164,7 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in Pipfile.lock
           remote:  !     Requested runtime (^3.9) is not available for this stack (#{app.stack}).
           remote:  !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
         OUTPUT
@@ -170,6 +179,7 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in Pipfile.lock
           remote:  !     Requested runtime (python-X.Y.Z) is not available for this stack (#{app.stack}).
           remote:  !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
         OUTPUT
@@ -184,6 +194,7 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in runtime.txt
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
@@ -202,6 +213,7 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
           remote: -----> Installing dependencies with Pipenv 2020.11.15
@@ -219,6 +231,8 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples 'warns there is a Python update available' do |requested_v
     app.deploy do |app|
       expect(clean_output(app.output)).to include(<<~OUTPUT)
         remote: -----> Python app detected
+        remote: -----> Using Python version specified in runtime.txt
         remote:  !     Python has released a security update! Please consider upgrading to python-#{latest_version}
         remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
         remote: -----> Installing python-#{requested_version}
@@ -20,6 +21,7 @@ RSpec.shared_examples 'aborts the build without showing an update warning' do |r
     app.deploy do |app|
       expect(clean_output(app.output)).to include(<<~OUTPUT)
         remote: -----> Python app detected
+        remote: -----> Using Python version specified in runtime.txt
         remote:  !     Requested runtime (python-#{requested_version}) is not available for this stack (#{app.stack}).
         remote:  !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
       OUTPUT
@@ -37,6 +39,7 @@ RSpec.describe 'Python update warnings' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
             remote:  !     Python 2 has reached its community EOL. Upgrade your Python runtime to maintain a secure application as soon as possible.
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote:  !     Only the latest version of Python 2 is supported on the platform. Please consider upgrading to python-#{LATEST_PYTHON_2_7}

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples 'builds with the requested Python version' do |python_vers
     app.deploy do |app|
       expect(clean_output(app.output)).to include(<<~OUTPUT)
         remote: -----> Python app detected
+        remote: -----> Using Python version specified in runtime.txt
         remote: -----> Installing python-#{python_version}
         remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
         remote: -----> Installing SQLite3
@@ -23,6 +24,7 @@ RSpec.shared_examples 'aborts the build with a runtime not available message' do
     app.deploy do |app|
       expect(clean_output(app.output)).to include(<<~OUTPUT)
         remote: -----> Python app detected
+        remote: -----> Using Python version specified in runtime.txt
         remote:  !     Requested runtime (python-#{requested_version}) is not available for this stack (#{app.stack}).
         remote:  !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
       OUTPUT
@@ -40,6 +42,8 @@ RSpec.describe 'Python version support' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
+            remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
+            remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
             remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           OUTPUT
         end
@@ -57,12 +61,14 @@ RSpec.describe 'Python version support' do
           update_buildpacks(app, [:default])
           app.commit!
           app.push!
-          # TODO: The build log should explain that sticky-versioning has occurred,
-          # so that users know why their app is on an older Python version.
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
+            remote: -----> No Python version was specified. Using the same version as the last build: python-3.6.12
+            remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
             remote:  !     Python has released a security update! Please consider upgrading to python-#{LATEST_PYTHON_3_6}
             remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
+            remote: -----> No change in requirements detected, installing from cache
+            remote: -----> Using cached install of python-3.6.12
           OUTPUT
           expect(app.run('python -V')).to include('Python 3.6.12')
         end
@@ -79,6 +85,7 @@ RSpec.describe 'Python version support' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
             remote:  !     Python 2 has reached its community EOL. Upgrade your Python runtime to maintain a secure application as soon as possible.
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote: -----> Installing python-#{LATEST_PYTHON_2_7}
@@ -111,6 +118,7 @@ RSpec.describe 'Python version support' do
           # not supporting the `PIP_NO_PYTHON_VERSION_WARNING` env var.
           expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
             remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
             remote: -----> Installing python-#{LATEST_PYTHON_3_4}
             remote: -----> Installing pip 19.1.1, setuptools 43.0.0 and wheel 0.33.6
             remote: DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 \\(cf PEP 429\\).
@@ -179,6 +187,7 @@ RSpec.describe 'Python version support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing pypy2.7-#{LATEST_PYPY_2_7}
           remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.36.2
           remote: -----> Installing SQLite3
@@ -197,6 +206,7 @@ RSpec.describe 'Python version support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing pypy3.6-#{LATEST_PYPY_3_6}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
           remote: -----> Installing SQLite3
@@ -237,7 +247,8 @@ RSpec.describe 'Python version support' do
         # TODO: The output shouldn't say "installing from cache", since it's not.
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
-          remote: -----> Found python-#{LATEST_PYTHON_3_6}, removing
+          remote: -----> Using Python version specified in runtime.txt
+          remote: -----> Python version has changed from python-#{LATEST_PYTHON_3_6} to python-#{LATEST_PYTHON_3_9}, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
           remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe 'Stack changes' do
         update_buildpacks(app, [:default])
         app.commit!
         app.push!
-        # TODO: The build log should explain that sticky-versioning has occurred,
-        # so that users know why their app is on an older Python version.
         # TODO: The requirements output shouldn't say "installing from cache", since it's not.
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the same version as the last build: python-3.6.12
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote:  !     Python has released a security update! Please consider upgrading to python-#{LATEST_PYTHON_3_6}
           remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Stack has changed from heroku-18 to heroku-20, clearing cache
@@ -51,6 +51,8 @@ RSpec.describe 'Stack changes' do
         # Python is always used) to avoid the glibc errors below.
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: -----> No Python version was specified. Using the same version as the last build: python-#{DEFAULT_PYTHON_VERSION}
+          remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: python: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by python)
           remote: python: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by python)
           remote: -----> Stack has changed from heroku-20 to heroku-18, clearing cache


### PR DESCRIPTION
Previously the Python version used for the build was only output to the log if Python was being installed for the first time, or if the cache had been invalidated due to stack/Python version/dependency changes.

This meant in the majority of app builds, the Python version was not shown. This makes debugging harder, as well as the "your Python version is out of date" warnings less useful, since they don't actually say what the current version is.

In addition, the reason a Python version was chosen was not explained, which could be particularly confusing given the "sticky"/cached version behaviour.

For example, if an existing app that doesn't specify a Python version is upgraded to a newer stack, the build can fail with a "runtime not available" error, but no indication as to why that version was chosen. eg:
https://heroku.support/955565
https://heroku.support/958240

Now, the Python version chosen and the reason for that choice is always output to the build log.

This is becoming particularly relevant given many apps are upgrading to Heroku-20, which being a newer stack, doesn't have all of the older runtime versions.

Closes GUS-W-8065925.