### PR TITLE
Buildpack release script usability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # These targets are not files
-.PHONY: lint lint-scripts lint-ruby compile builder-image buildenv deploy-runtimes
+.PHONY: lint lint-scripts lint-ruby compile builder-image buildenv deploy-runtimes publish
 
 STACK ?= heroku-20
 STACKS ?= heroku-16 heroku-18 heroku-20
@@ -57,3 +57,6 @@ endif
 			echo; \
 		done; \
 	done
+
+publish:
+	@etc/publish.sh


### PR DESCRIPTION
* The release script now runs `git fetch` prior to determining which commit to tag, preventing tagging a stale ref.
* `buildpacks:versions` is now run after publishing, to save having to do so manually each time to print the release time/status.
* The unused `{previous,latest}-version` tag feature has been removed.
* The script can now be run via `make publish` for consistency with other buildpack workflows.
* Miscellaneous output formatting/bash best practices fixes.

Closes GUS-W-8813922.

[skip changelog]