### PR TITLE
Rubocop: Disable autocorrect of RSpec/Focus

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,5 +13,10 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/Focus:
+  # Disable auto-correct otherwise format-on-save will remove the annotation
+  # whilst developing locally.
+  AutoCorrect: false
+
 RSpec/MultipleExpectations:
   Enabled: false


### PR DESCRIPTION
Since otherwise format-on-save will remove the focus annotations (that make rspec run just the specified test) whilst developing locally.

The rule is still enabled, so will prevent accidentally committing the annotations (which would disable part of the test suite in CI).

Closes GUS-W-9303487.

[skip changelog]