### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,12 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-    labels:
-      - "c: dependencies"
-
+      interval: "daily"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
-    labels:
-      - "c: dependencies"
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates#supported-repositories-and-ecosystems

I've also changed the frequency to daily (so we don't have to wait as long), and removed the custom label, so we get the automatic per lang labels.

Refs GUS-W-9678950.

[skip changelog]