### PR TITLE
Make Check Changelog compatible with actions/checkout v2

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -11,8 +11,11 @@ jobs:
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
       !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'c: dependencies')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Check that CHANGELOG is touched
-        run: git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
The GitHub action `actions/checkout` now only shallow clones the Git repo as of v2+, meaning the Check Changelog action fails with:
`fatal: ambiguous argument 'remotes/origin/main': unknown revision or path not in the working tree.`

To fix, an explicit `git fetch` has been added of the HEAD of the default branch.

Refs GUS-W-9728468.

[skip changelog]