### PR TITLE
Release v198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v198 (2021-08-30)
+
 - Python 3.8.12 and 3.9.7 are now available (CPython) ([#1236](https://github.com/heroku/heroku-buildpack-python/pull/1236)).
 - The default Python version for new apps is now 3.9.7 (previously 3.9.6) ([#1236](https://github.com/heroku/heroku-buildpack-python/pull/1236)).
 


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-python/compare/v197...9982aa36cb58c9b4fdd4ed7f1efd517ad19ceeeb

GUS-W-9833138.