### PR TITLE
ci(tests): add environments marker to python3.10 test

### DIFF
--- a/spec/fixtures/python_3.10/requirements.txt
+++ b/spec/fixtures/python_3.10/requirements.txt
@@ -1,1 +1,4 @@
 urllib3
+
+# Ensure setuptools minimal requirements works
+pep562; python_version < "3.7"


### PR DESCRIPTION
This pull request tries to reproduce the issue describe in #1248