### PR TITLE
Tests: Add additional coverage of editable package installation

### DIFF
--- a/spec/fixtures/requirements_editable/bin/compile
+++ b/spec/fixtures/requirements_editable/bin/compile
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This file is run by the inline buildpack, and tests that editable reqirements are
+# usable by buildpacks that run after the Python buildpack during the build.
+
+set -euo pipefail
+
+BUILD_DIR="${1}"
+
+exec "${BUILD_DIR}/bin/test-entrypoints"

--- a/spec/fixtures/requirements_editable/bin/detect
+++ b/spec/fixtures/requirements_editable/bin/detect
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# This file is run by the inline buildpack.
+
+set -euo pipefail
+
+echo "Inline"

--- a/spec/fixtures/requirements_editable/bin/post_compile
+++ b/spec/fixtures/requirements_editable/bin/post_compile
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+exec bin/test-entrypoints

--- a/spec/fixtures/requirements_editable/bin/test-entrypoints
+++ b/spec/fixtures/requirements_editable/bin/test-entrypoints
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo -n "Running entrypoint for the local package: "
+local_package
+
+echo -n "Running entrypoint for the VCS package: "
+gunicorn --version

--- a/spec/fixtures/requirements_editable/local_package/local_package/__init__.py
+++ b/spec/fixtures/requirements_editable/local_package/local_package/__init__.py
@@ -1,0 +1,2 @@
+def hello():
+    print("Hello!")

--- a/spec/fixtures/requirements_editable/local_package/setup.cfg
+++ b/spec/fixtures/requirements_editable/local_package/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = local_package
+version = 0.0.1
+
+[options]
+packages = local_package
+
+[options.entry_points]
+console_scripts =
+    local_package = local_package:hello

--- a/spec/fixtures/requirements_editable/local_package/setup.py
+++ b/spec/fixtures/requirements_editable/local_package/setup.py
@@ -1,5 +1,3 @@
 from setuptools import setup
 
-setup(
-  name='test',
-)
+setup()

--- a/spec/fixtures/requirements_editable/requirements.txt
+++ b/spec/fixtures/requirements_editable/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/certifi/python-certifi#egg=certifi
--e .
+-e ./local_package
+-e git+https://github.com/benoitc/gunicorn@20.1.0#egg=gunicorn


### PR DESCRIPTION
Previously the editable installation mode test only checked whether the build completed successfully, not whether the installed editable packages worked.

Now the packages are tested via their entrypoints in the following scenarios:
1. During the `bin/post_compile` hook
2. By a later buildpack in the build
3. At runtime

In particular, (2) catches the issue described in #1006 when setuptools is upgraded ([example failure](https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-python/221/workflows/5ba7fb0e-663b-4d76-ad34-ed7e1b37ba3b/jobs/946)), and (1) + (3) will be useful to verify the solution to #1006 hasn't broken the other cases.

GUS-W-10047026.

[skip changelog]