### PR TITLE
Tests: Add additional log output to the editable package tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,12 @@ require:
 AllCops:
   NewCops: enable
 
+Layout/TrailingWhitespace:
+  # Required since we use heredocs to assert against Hatchet output, and sometimes that output
+  # contains trailing newlines which we must match against. The alternative is to end the lines
+  # with the unsightly `#{' '}` workaround.
+  AllowInHeredoc: true
+
 Metrics/BlockLength:
   Enabled: false
 

--- a/spec/fixtures/requirements_editable/bin/compile
+++ b/spec/fixtures/requirements_editable/bin/compile
@@ -7,4 +7,6 @@ set -euo pipefail
 
 BUILD_DIR="${1}"
 
-exec "${BUILD_DIR}/bin/test-entrypoints"
+cd "${BUILD_DIR}"
+
+exec bin/test-entrypoints

--- a/spec/fixtures/requirements_editable/bin/test-entrypoints
+++ b/spec/fixtures/requirements_editable/bin/test-entrypoints
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# List the filenames and contents of all .egg-link and .pth files in site-packages.
+find .heroku/python/lib*/*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' \) | sort | xargs -exec tail -n +1
+echo
+
 echo -n "Running entrypoint for the local package: "
 local_package
 

--- a/spec/hatchet/django_spec.rb
+++ b/spec/hatchet/django_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Django support' do
             remote:        Traceback \\(most recent call last\\):
             remote:        .*
             remote:        ModuleNotFoundError: No module named 'gettingstarted'
-            remote:#{' '}
+            remote: 
             remote:  !     Error while running '\\$ python manage.py collectstatic --noinput'.
           REGEX
         end


### PR DESCRIPTION
This expands on the editable package tests added in #1251, making them now output the contents of all of the `.pth` and `.egg-link` files in `site-packages` to aid debugging, as well as help demonstrate the changes that will be taking place in #1252.

GUS-W-10047026.

[skip changelog]