### PR TITLE
Update setuptools and wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update setuptools from 47.1.1 to: ([#1253](https://github.com/heroku/heroku-buildpack-python/pull/1254))
+  - 50.3.2 for Python 3.5
+  - 57.5.0 for Python 3.6+
+- Update wheel from 0.36.2 to 0.37.0 ([#1253](https://github.com/heroku/heroku-buildpack-python/pull/1254)).
 - Perform editable package `.pth` and `.egg-link` path rewriting at runtime ([#1252](https://github.com/heroku/heroku-buildpack-python/pull/1252)).
 
 ## v200 (2021-10-04)

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -151,10 +151,8 @@ fi
 set -e
 
 PIP_VERSION='20.2.4'
-# Must use setuptools <47.2.0 until we fix:
-# https://github.com/heroku/heroku-buildpack-python/issues/1006
-SETUPTOOLS_VERSION='47.1.1'
-WHEEL_VERSION='0.36.2'
+SETUPTOOLS_VERSION='57.5.0'
+WHEEL_VERSION='0.37.0'
 
 if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then
   # Python 3.4 support was dropped in pip 19.2+, setuptools 44+ and wheel 0.34+.
@@ -164,6 +162,9 @@ if [[ "${PYTHON_VERSION}" == ${PY34}* ]]; then
 elif [[ "${PYTHON_VERSION}" == ${PY27}* || "${PYTHON_VERSION}" == ${PYPY27}* ]]; then
   # Python 2.7 support was dropped in setuptools 45+.
   SETUPTOOLS_VERSION='44.1.1'
+elif [[ "${PYTHON_VERSION}" == ${PY35}* ]]; then
+  # Python 3.5 support was dropped in setuptools 51+.
+  SETUPTOOLS_VERSION='50.3.2'
 fi
 
 puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Pip support' do
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -38,7 +38,7 @@ RSpec.describe 'Pip support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Using cached install of python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote: -----> Discovering process types
@@ -61,7 +61,7 @@ RSpec.describe 'Pip support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Requirements file has been changed, clearing cached dependencies
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -103,6 +103,9 @@ RSpec.describe 'Pip support' do
           remote:          Running setup.py develop for local-package
           remote:        Successfully installed gunicorn local-package
           remote: -----> Running post-compile hook
+          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
+          remote: import os; var = 'SETUPTOOLS_USE_DISTUTILS'; enabled = os.environ.get\\(var, 'stdlib'\\) == 'local'; enabled and __import__\\('_distutils_hack'\\).add_shim\\(\\); 
+          remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/local_package
@@ -116,6 +119,9 @@ RSpec.describe 'Pip support' do
           remote: Running entrypoint for the local package: Hello!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
+          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
+          remote: import os; var = 'SETUPTOOLS_USE_DISTUTILS'; enabled = os.environ.get\\(var, 'stdlib'\\) == 'local'; enabled and __import__\\('_distutils_hack'\\).add_shim\\(\\); 
+          remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/local_package
@@ -132,6 +138,9 @@ RSpec.describe 'Pip support' do
 
         # Test rewritten paths work at runtime.
         expect(app.run('bin/test-entrypoints')).to match(Regexp.new(<<~REGEX))
+          ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
+          import os; var = 'SETUPTOOLS_USE_DISTUTILS'; enabled = os.environ.get\\(var, 'stdlib'\\) == 'local'; enabled and __import__\\('_distutils_hack'\\).add_shim\\(\\); 
+
           ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           /app/.heroku/src/gunicorn
           /app/local_package
@@ -152,7 +161,7 @@ RSpec.describe 'Pip support' do
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Using cached install of python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Obtaining file:///tmp/build_.*/local_package \\(from -r /tmp/build_.*/requirements.txt \\(line 1\\)\\)
@@ -163,6 +172,9 @@ RSpec.describe 'Pip support' do
           remote:          Running setup.py develop for local-package
           remote:        Successfully installed gunicorn local-package
           remote: -----> Running post-compile hook
+          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
+          remote: import os; var = 'SETUPTOOLS_USE_DISTUTILS'; enabled = os.environ.get\\(var, 'stdlib'\\) == 'local'; enabled and __import__\\('_distutils_hack'\\).add_shim\\(\\); 
+          remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/local_package
@@ -176,6 +188,9 @@ RSpec.describe 'Pip support' do
           remote: Running entrypoint for the local package: Hello!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
+          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
+          remote: import os; var = 'SETUPTOOLS_USE_DISTUTILS'; enabled = os.environ.get\\(var, 'stdlib'\\) == 'local'; enabled and __import__\\('_distutils_hack'\\).add_shim\\(\\); 
+          remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/local_package

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'builds using Pipenv with the requested Python version' do
         remote: -----> Using Python version specified in Pipfile.lock
         remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
         remote: -----> Installing python-#{python_version}
-        remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+        remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
         remote: -----> Installing dependencies with Pipenv 2020.11.15
         remote:        Installing dependencies from Pipfile.lock \\(.*\\)...
         remote: -----> Installing SQLite3
@@ -33,7 +33,7 @@ RSpec.describe 'Pipenv support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Installing dependencies from Pipfile...
           remote: -----> Installing SQLite3
@@ -53,7 +53,7 @@ RSpec.describe 'Pipenv support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Installing dependencies from Pipfile.lock \\(aad8b1\\)...
           remote: -----> Installing SQLite3
@@ -76,7 +76,7 @@ RSpec.describe 'Pipenv support' do
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
             remote: -----> Installing python-#{LATEST_PYTHON_2_7}
-            remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.36.2
+            remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.37.0
             remote: -----> Installing dependencies with Pipenv 2020.11.15
             remote:        Installing dependencies from Pipfile.lock \\(b8efa9\\)...
             remote: -----> Installing SQLite3
@@ -153,7 +153,7 @@ RSpec.describe 'Pipenv support' do
           remote:        Learn More: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-3.9.1
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Installing dependencies from Pipfile.lock \\(e13df1\\)...
           remote: -----> Installing SQLite3
@@ -203,7 +203,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Using Python version specified in runtime.txt
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Installing dependencies from Pipfile.lock \\(75eae0\\)...
           remote: -----> Installing SQLite3
@@ -221,7 +221,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Installing dependencies from Pipfile.lock (ef68d1)...
           remote: -----> Installing SQLite3
@@ -241,7 +241,7 @@ RSpec.describe 'Pipenv support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: cp: cannot stat '/tmp/build_.*/requirements.txt': No such file or directory
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing dependencies with Pipenv 2020.11.15
           remote:        Your Pipfile.lock \\(aad8b1\\) is out of date. Expected: \\(ef68d1\\).
           remote:        \\[DeployException\\]: .*

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'builds with the requested Python version' do |python_vers
         remote: -----> Python app detected
         remote: -----> Using Python version specified in runtime.txt
         remote: -----> Installing python-#{python_version}
-        remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+        remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
         remote: -----> Installing SQLite3
         remote: -----> Installing requirements with pip
         remote:        Collecting urllib3
@@ -89,7 +89,7 @@ RSpec.describe 'Python version support' do
             remote:  !     Python 2 has reached its community EOL. Upgrade your Python runtime to maintain a secure application as soon as possible.
             remote:        Learn More: https://devcenter.heroku.com/articles/python-2-7-eol-faq
             remote: -----> Installing python-#{LATEST_PYTHON_2_7}
-            remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.36.2
+            remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.37.0
             remote: -----> Installing SQLite3
             remote: -----> Installing requirements with pip
             remote:        Collecting urllib3
@@ -145,7 +145,20 @@ RSpec.describe 'Python version support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.5', allow_failure: allow_failure) }
 
     context 'when using Heroku-18', stacks: %w[heroku-18] do
-      include_examples 'builds with the requested Python version', LATEST_PYTHON_3_5
+      it 'builds with Python 3.5.10' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to include(<<~OUTPUT)
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
+            remote: -----> Installing python-#{LATEST_PYTHON_3_5}
+            remote: -----> Installing pip 20.2.4, setuptools 50.3.2 and wheel 0.37.0
+            remote: -----> Installing SQLite3
+            remote: -----> Installing requirements with pip
+            remote:        Collecting urllib3
+          OUTPUT
+          expect(app.run('python -V')).to include("Python #{LATEST_PYTHON_3_5}")
+        end
+      end
     end
 
     context 'when using Heroku-20', stacks: %w[heroku-20] do
@@ -195,7 +208,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing pypy2.7-#{LATEST_PYPY_2_7}
-          remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 44.1.1 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -214,7 +227,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing pypy3.6-#{LATEST_PYPY_3_6}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -257,7 +270,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Python version has changed from python-#{LATEST_PYTHON_3_6} to python-#{LATEST_PYTHON_3_9}, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-#{LATEST_PYTHON_3_9}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Stack has changed from heroku-18 to heroku-20, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-3.6.12
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -58,7 +58,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Stack has changed from heroku-20 to heroku-18, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 20.2.4, setuptools 47.1.1 and wheel 0.36.2
+          remote: -----> Installing pip 20.2.4, setuptools 57.5.0 and wheel 0.37.0
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3


### PR DESCRIPTION
Updates:
- setuptools from 47.1.1 to:
  - 50.3.2 for Python 3.5
  - 57.5.0 for Python 3.6+
- wheel from 0.36.2 to 0.37.0 for Python 2.7 and Python 3.5+.

Of note, the newer setuptools is fully compatible with Python 3.10, thereby fixing #1248. Updating to newer setuptools was blocked on #1006, but that's now been fixed by #1252.

The setuptools version hasn't been updated all the way to the latest (58.2.0), since v58 dropped support for 2to3, which caused breakage in a few packages, so I would rather hold off as long as possible (and there are no fixes that we need since then).

Release notes:
https://setuptools.pypa.io/en/latest/history.html#v57-5-0
https://wheel.readthedocs.io/en/stable/news.html

Full changelogs:
https://github.com/pypa/setuptools/compare/v47.1.1...v57.5.0
https://github.com/pypa/wheel/compare/0.36.2...0.37.0

Fixes #1248.
GUS-W-10052807.