### PR TITLE
Release v202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v202 (2021-11-01)
+
 - Update pip from 20.2.4 to: ([#1259](https://github.com/heroku/heroku-buildpack-python/pull/1259))
   - 20.3.4 for Python 2.7 and 3.5
   - 21.3.1 for Python 3.6+


### PR DESCRIPTION
To pick up #1259.

https://github.com/heroku/heroku-buildpack-python/compare/v201...b82ddba7346caeabcf38d215a0c9bffc83d5e9f4

GUS-W-10113918.