### PR TITLE
Binary build script: Create the `python` symlink as symbolic

### DIFF
--- a/builds/runtimes/python
+++ b/builds/runtimes/python
@@ -83,4 +83,8 @@ make install
 # https://bugs.python.org/issue45668
 find "${OUT_PREFIX}" -depth -type d -a \( -name 'test' -o -name 'tests' -o -name 'idle_test' \) -exec rm -rf '{}' +
 
-ln -vT python3 "${OUT_PREFIX}/bin/python"
+# Support using Python 3 via the version-less `python` command, for parity with virtualenvs,
+# the Python Docker images and to also ensure buildpack Python shadows any installed system
+# Python, should that provide a version-less alias too.
+# This symlink must be relative, to ensure that the Python install remains relocatable.
+ln -srvT "${OUT_PREFIX}/bin/python3" "${OUT_PREFIX}/bin/python"


### PR DESCRIPTION
Previously it was created as a hard-link, and whilst the target also happened to be a symlink (thus meaning it effectively became another symbolic symlink), if that ever changes in the future, we'll end up with a hard-linked Python binary and thus be affected by:
https://github.com/buildpacks/pack/issues/1286

The official Python Docker image also uses a symlink for this:
https://github.com/docker-library/python/blob/1cf43e70e45843c70909a5f914c3c6d0f85fc200/Dockerfile-linux.template#L284 

Before:

```
$ ls -al .heroku/python/bin/
...
lrwxrwxrwx 1 root root       10 Mar 24 11:44 python -> python3.10
lrwxrwxrwx 1 root root       10 Mar 24 11:44 python3 -> python3.10
-rwxr-xr-x 1 root root 24176128 Mar 24 11:43 python3.10
```

After:

```
$ ls -al .heroku/python/bin/
...
lrwxrwxrwx 1 root root        7 Apr 13 12:27 python -> python3
lrwxrwxrwx 1 root root       10 Apr 13 12:27 python3 -> python3.10
-rwxr-xr-x 1 root root 24179272 Apr 13 12:27 python3.10
```

GUS-W-8060029.