### PR TITLE
Binary build script: Enable `--with-system-expat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use the `expat` package from the stack image rather than CPython's vendored version, when building
+  Python binaries ([#1319](https://github.com/heroku/heroku-buildpack-python/pull/1319)).
 
 ## v210 (2022-04-14)
 

--- a/builds/runtimes/python
+++ b/builds/runtimes/python
@@ -60,6 +60,9 @@ CONFIGURE_OPTS=(
   # Skip running `ensurepip` as part of install, since the buildpack installs a curated
   # version of pip itself (which ensures it's consistent across Python patch releases).
   "--with-ensurepip=no"
+  # Build the `pyexpat` module using the `expat` library in the stack image (which will
+  # automatically receive security updates), rather than CPython's vendored version.
+  "--with-system-expat"
 )
 
 if [[ "${VERSION}" != 3.7.* ]]; then


### PR DESCRIPTION
Means the `pyexpat` module is now built using the `expat` library from the stack image (rather than CPython's vendored version), so that:
- any security fixes are automatically picked up from the stack image, without requiring a Python version update/new app build (the Python vendored version is also very rarely updated)
- our Python runtime more closely matches that of the official Python Docker image and other binary distributions
- (as a small added bonus) the Python runtime size in the slug is slightly smaller (eg 80% reduction in `pyexpat.*.so`, saving ~1.2MB)

See:
https://docs.python.org/3/using/configure.html#cmdoption-with-system-expat
https://github.com/docker-library/python/blob/1cf43e70e45843c70909a5f914c3c6d0f85fc200/Dockerfile-linux.template#L161

The current Python vendored expat version is `2.4.7` (that's only because it's just been bumped for the first time in a while, in general it's infrequently updated - eg [commit history](https://github.com/python/cpython/commits/3.10/Modules/expat/expat.h)).

The current expat versions in the stack images, are (but note these will have security backports, so the base version number doesn't quite tell the full story):
- Heroku-18: `2.2.5-3ubuntu0.7`
- Heroku-20: `2.2.9-1ubuntu0.4`
- Heroku-22 (upcoming): `2.4.7-1`

GUS-W-8060029.