### PR TITLE
Binary build script: Strip Python binary/libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use shared builds + LTO when building Python 3.10 binaries ([#1320](https://github.com/heroku/heroku-buildpack-python/pull/1320)).
   Note: This and the other Python binary changes below will only take effect for future Python
   version releases (or future Heroku stacks) - existing Python binaries are not being recompiled.
+- Strip debugging symbols from the Python binary and libraries ([#1321](https://github.com/heroku/heroku-buildpack-python/pull/1321)).
 - Use the `expat` package from the stack image rather than CPython's vendored version, when building
   Python binaries ([#1319](https://github.com/heroku/heroku-buildpack-python/pull/1319)).
 

--- a/builds/runtimes/python
+++ b/builds/runtimes/python
@@ -100,14 +100,33 @@ fi
 
 ./configure "${CONFIGURE_OPTS[@]}"
 
-make -j "$(nproc)"
+# Using LDFLAGS we instruct the linker to omit all symbol information from the final binary
+# and shared libraries, to reduce the size of the build. We have to use `--strip-all` and
+# not `--strip-unneeded` since `ld` only understands the former (unlike the `strip` command),
+# however it's safe to use since these options don't apply to static libraries.
+make -j "$(nproc)" LDFLAGS='-Wl,--strip-all'
 make install
+
+if [[ "${VERSION}" == 3.[7-9].* ]]; then
+  # On older versions of Python we're still building the static library, which has to be
+  # manually stripped since the linker stripping enabled in LDFLAGS doesn't cover them.
+  # We're using `--strip-unneeded` since `--strip-all` would remove the `.symtab` section
+  # that is required for static libraries to be able to be linked.
+  # `find` is used since there are multiple copies of the static library in version-specific
+  # locations, eg:
+  #   - `lib/libpython3.9.a`
+  #   - `lib/python3.9/config-3.9-x86_64-linux-gnu/libpython3.9.a`
+  find "${OUT_PREFIX}" -type f -name '*.a' -print -exec strip --strip-unneeded '{}' +
+elif ! find "${OUT_PREFIX}" -type f -name '*.a' -print -exec false '{}' +; then
+  echo "Unexpected static libraries found!" >&2
+  exit 1
+fi
 
 # Remove unneeded test directories, similar to the official Docker Python images:
 # https://github.com/docker-library/python
 # TODO: Explore using --disable-test-modules once the PGO fix is in a released Python version:
 # https://bugs.python.org/issue45668
-find "${OUT_PREFIX}" -depth -type d -a \( -name 'test' -o -name 'tests' -o -name 'idle_test' \) -exec rm -rf '{}' +
+find "${OUT_PREFIX}" -depth -type d -a \( -name 'test' -o -name 'tests' -o -name 'idle_test' \) -print -exec rm -rf '{}' +
 
 # Support using Python 3 via the version-less `python` command, for parity with virtualenvs,
 # the Python Docker images and to also ensure buildpack Python shadows any installed system


### PR DESCRIPTION
The debug symbols in the Python binaries are as good as unused, and add substantially to the size of the build. Stripping frees up slug space for use by dependencies/the app itself, and also reduces the download/extraction/re-archiving times for both the classic buildpack and CNB.

This also matches the approach used by several of our other languages, as well as that for the slim official Python docker image:
https://github.com/docker-library/python/blob/1cf43e70e45843c70909a5f914c3c6d0f85fc200/Dockerfile-linux.template#L171-L172

For Python 3.10 (which uses a shared lib), this reduces the build size **from 90MB to 55MB**.

For Python 3.9 (which uses a static lib, and so suffers from the double static lib issue, see: https://bugs.python.org/issue43103) the build size is reduced **from 195MB to 69 MB**.

Figures for Python 3.7/3.8 were not generated, but they will see similar reductions to that for Python 3.9, since they also use the static lib.

Python 3.10 diff:

```
$ diff -U0 <(cd shared-lto && du -Sh) <(cd shared-lto-strip/ && du -Sh)
--- /dev/fd/63
+++ /dev/fd/62
@@ -1 +1 @@
-56K    ./bin
+36K    ./bin
@@ -81 +81 @@
-18M    ./lib/python3.10/lib-dynload
+5.5M   ./lib/python3.10/lib-dynload
@@ -103 +103 @@
-26M    ./lib
+4.1M   ./lib

$ diff -U0 <(cd shared-lto && du -sh) <(cd shared-lto-strip/ && du -sh)
--- /dev/fd/63
+++ /dev/fd/62
@@ -1 +1 @@
-90M    .
+55M    .
```

Python 3.9 diff:

```
$ diff -U0 <(cd 39-orig/ && du -Sh) <(cd 39-strip/ && du -Sh)
--- /dev/fd/63
+++ /dev/fd/62
@@ -2 +2 @@
-19M    ./lib/python3.9/lib-dynload
+5.6M   ./lib/python3.9/lib-dynload
@@ -91 +91 @@
-56M    ./lib/python3.9/config-3.9-x86_64-linux-gnu
+7.6M   ./lib/python3.9/config-3.9-x86_64-linux-gnu
@@ -93,2 +93,2 @@
-56M    ./lib
-22M    ./bin
+7.4M   ./lib
+3.8M   ./bin

$ diff -U0 <(cd 39-orig/ && du -sh) <(cd 39-strip/ && du -sh)
--- /dev/fd/63
+++ /dev/fd/62
@@ -1 +1 @@
-195M   .
+69M    .
```

See also:
https://www.technovelty.org/linux/stripping-shared-libraries.html

GUS-W-10989125.