### PR TITLE
Binary build script: Switch from timestamp to hash based .pyc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   Note: This and the other Python binary changes below will only take effect for future Python
   version releases (or future Heroku stacks) - existing Python binaries are not being recompiled.
 - Strip debugging symbols from the Python binary and libraries ([#1321](https://github.com/heroku/heroku-buildpack-python/pull/1321)).
+- Switch the pre-generated `.pyc` files for the Python stdlib from `timestamp` to `unchecked-hash` validation mode, for improved compatibility with Cloud Native Buildpacks ([#1322](https://github.com/heroku/heroku-buildpack-python/pull/1322)).
+- Stop shipping optimisation level one and two `.pyc` files with the Python stdlib ([#1322](https://github.com/heroku/heroku-buildpack-python/pull/1322)).
 - Use the `expat` package from the stack image rather than CPython's vendored version, when building
   Python binaries ([#1319](https://github.com/heroku/heroku-buildpack-python/pull/1319)).
 

--- a/builds/runtimes/python
+++ b/builds/runtimes/python
@@ -128,6 +128,31 @@ fi
 # https://bugs.python.org/issue45668
 find "${OUT_PREFIX}" -depth -type d -a \( -name 'test' -o -name 'tests' -o -name 'idle_test' \) -print -exec rm -rf '{}' +
 
+# The `make install` step automatically generates `.pyc` files for the stdlib, however:
+# - It generates these using the default `timestamp` invalidation mode, which does
+#   not work well with the CNB file timestamp normalisation behaviour. As such, we
+#   must use one of the hash-based invalidation modes to prevent the `.pyc`s from
+#   always being treated as outdated and so being regenerated at application boot.
+# - It generates `.pyc`s for all three optimisation levels (standard, -O and -OO),
+#   when the vast majority of apps only use the standard mode. As such, we can skip
+#   regenerating/shipping those `.opt-{1,2}.pyc` files, reducing build output by 18MB.
+#
+# We use the `unchecked-hash` mode rather than `checked-hash` since it improves app startup
+# times by ~5%, and is only an issue if manual edits are made to the stdlib, which is not
+# something we support.
+#
+# See:
+# https://docs.python.org/3/reference/import.html#cached-bytecode-invalidation
+# https://docs.python.org/3/library/compileall.html
+# https://peps.python.org/pep-0488/
+# https://peps.python.org/pep-0552/
+find "${OUT_PREFIX}" -depth -type f -name "*.pyc" -delete
+# We use the Python binary from the original build output in the source directory,
+# rather than the installed binary in `$OUT_PREFIX`, for parity with the automatic
+# `.pyc` generation run by `make install`:
+# https://github.com/python/cpython/blob/v3.10.4/Makefile.pre.in#L1603-L1629
+LD_LIBRARY_PATH="${PWD}" ./python -m compileall -f --invalidation-mode unchecked-hash --workers 0 "${OUT_PREFIX}"
+
 # Support using Python 3 via the version-less `python` command, for parity with virtualenvs,
 # the Python Docker images and to also ensure buildpack Python shadows any installed system
 # Python, should that provide a version-less alias too.


### PR DESCRIPTION
When we build Python binaries, the `make install` step automatically generates `.pyc` files for the Python stdlib, however:
- It generates these using the default `timestamp` invalidation mode, which does not work well with the CNB file timestamp normalisation behaviour.
- It generates `.pyc`s for all three optimisation levels (standard, `-O` and `-OO`), when the vast majority of apps only use the standard mode.

As such, this changes our builds to:
- Use one of the hash-based pyc invalidation modes to prevent the `.pyc`s from always being treated as outdated and so being regenerated at application boot.
- Ship only the standard optimisation level pycs (and not the `.opt-{1,2}.pyc` files), reducing build output by 18MB.

We use the `unchecked-hash` mode rather than `checked-hash` since it improves app startup times by ~5%, and is only an issue if manual edits are made to the stdlib, which is not something we support.

See:
https://docs.python.org/3/reference/import.html#cached-bytecode-invalidation
https://docs.python.org/3/library/compileall.html
https://peps.python.org/pep-0488/
https://peps.python.org/pep-0552/
https://github.com/python/cpython/blob/v3.10.4/Makefile.pre.in#L1603-L1629

GUS-W-10988998.
GUS-W-10989125.