### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Switch to the recommended regional S3 domain instead of the global one ([#1334](https://github.com/heroku/heroku-buildpack-python/pull/1334)).
 
 ## v212 (2022-06-07)
 

--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,7 @@ export BUILD_DIR CACHE_DIR ENV_DIR
 # The user can provide BUILDPACK_S3_BASE_URL to specify a custom target.
 # Note: this is designed for non-Heroku use, as it does not use the user-provided
 # environment variable mechanism (the ENV_DIR).
-S3_BASE_URL="${BUILDPACK_S3_BASE_URL:-"https://heroku-buildpack-python.s3.amazonaws.com"}"
+S3_BASE_URL="${BUILDPACK_S3_BASE_URL:-"https://heroku-buildpack-python.s3.us-east-1.amazonaws.com"}"
 # This has to be exported since it's used by the geo-libs step which is run in a subshell.
 
 # Default Python Versions


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.