### PR TITLE
Remove metrics event for `==0.0.0` requirements

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -24,11 +24,6 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     # Measure that we're using pip.
     mcount "tool.pip"
 
-    # Count expected build failures.
-    if grep -q '==0.0.0' requirements.txt; then
-        mcount "failure.none-version"
-    fi
-
     if [ ! -f "$BUILD_DIR/.heroku/python/bin/pip" ]; then
         exit 1
     fi


### PR DESCRIPTION
Since:
- there are many invalid styles of requirements specifiers users can use, and we don't special-case metrics for any of the others
- the `==0.0.0` case is an old issue due to an Ubuntu quirk that doesn't occur much any more now
- metrics aren't working at the moment anyway, until we implement `bin/report` for Honeycomb