### PR TITLE
Remove `BUILD_WITH_GEO_LIBRARIES` sunset messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove `BUILD_WITH_GEO_LIBRARIES` sunset messaging ([#1347](https://github.com/heroku/heroku-buildpack-python/pull/1347)).
 - Remove outdated Django version warning ([#1345](https://github.com/heroku/heroku-buildpack-python/pull/1345)).
 
 ## v214 (2022-08-02)

--- a/bin/compile
+++ b/bin/compile
@@ -84,21 +84,6 @@ source "$BIN_DIR/utils"
 # shellcheck source=bin/warnings
 source "$BIN_DIR/warnings"
 
-if [[ -f "${ENV_DIR}/BUILD_WITH_GEO_LIBRARIES" ]]; then
-  mcount "failure.unsupported.BUILD_WITH_GEO_LIBRARIES"
-  puts-warn "The Python buildpack's legacy BUILD_WITH_GEO_LIBRARIES functionality is"
-  puts-warn "no longer supported:"
-  puts-warn "https://devcenter.heroku.com/changelog-items/1947"
-  puts-warn
-  puts-warn "To continue to use GDAL, GEOS or PROJ support, see the migration guide:"
-  puts-warn "https://help.heroku.com/D5INLB1A/python-s-build_with_geo_libraries-legacy-feature-is-no-longer-supported"
-  puts-warn
-  puts-warn "Or if you no longer need those libraries, this message can be hidden by"
-  puts-warn "unsetting the BUILD_WITH_GEO_LIBRARIES environment variable, using:"
-  puts-warn "heroku config:unset BUILD_WITH_GEO_LIBRARIES"
-  exit 1
-fi
-
 # Make the directory in which we will create symlinks from the temporary build directory
 # to `/app`.
 # Symlinks are required, since Python is not a portable installation.

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -238,20 +238,4 @@ RSpec.describe 'Pip support' do
       end
     end
   end
-
-  context 'when the legacy BUILD_WITH_GEO_LIBRARIES env var is set' do
-    let(:config) { { 'BUILD_WITH_GEO_LIBRARIES' => '' } }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', config: config, allow_failure: true) }
-
-    it 'aborts the build with an unsupported error message' do
-      app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
-          remote: -----> Python app detected
-          remote:  !     The Python buildpack's legacy BUILD_WITH_GEO_LIBRARIES functionality is
-          remote:  !     no longer supported:
-          remote:  !     https://devcenter.heroku.com/changelog-items/1947
-        OUTPUT
-      end
-    end
-  end
 end


### PR DESCRIPTION
Since:
- the error has been in place since Nov 2020 (#1115), so the vast majority of apps/users will have already seen it
- even without this explicit check, if a GDAL install fails we still print the standard instructions via the warnings system:
   https://github.com/heroku/heroku-buildpack-python/blob/5f896a434c29c6835395083503f4768457e9adc1/bin/warnings#L53-L56

GUS-W-11593037.