### PR TITLE
Remove redundant package install warning checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `BUILD_WITH_GEO_LIBRARIES` sunset messaging ([#1347](https://github.com/heroku/heroku-buildpack-python/pull/1347)).
 - Remove outdated Django version warning ([#1345](https://github.com/heroku/heroku-buildpack-python/pull/1345)).
+- Remove redundant package install warning checks ([#1348](https://github.com/heroku/heroku-buildpack-python/pull/1348)).
 
 ## v214 (2022-08-02)
 

--- a/bin/compile
+++ b/bin/compile
@@ -63,7 +63,6 @@ PYPY36="pypy3.6"
 # The `warnings` subscript then greps through this for common problems and guides
 # the user towards resolution of known issues.
 WARNINGS_LOG=$(mktemp)
-RECOMMENDED_PYTHON_VERSION=$DEFAULT_PYTHON_VERSION
 
 # The buildpack ships with a few executable tools.
 # This installs them into the path, so we can execute them directly.

--- a/bin/warnings
+++ b/bin/warnings
@@ -1,51 +1,6 @@
 #!/usr/bin/env bash
 shopt -s extglob
 
-old-platform() {
-  if grep -qi 'InsecurePlatformWarning' "$WARNINGS_LOG"; then
-    echo
-    puts-warn "Hello! It looks like your application is using an outdated version of Python."
-    puts-warn "This caused the security warning you saw above during the 'pip install' step."
-    puts-warn "We recommend '$RECOMMENDED_PYTHON_VERSION', which you can specify in a 'runtime.txt' file."
-    puts-warn "  -- Much Love, Heroku."
-    mcount 'warnings.python.old'
-  fi
-}
-
-scipy-included() {
-  if grep -qi 'running setup.py install for scipy' "$WARNINGS_LOG"; then
-    echo
-    puts-warn "Hello! It looks like you're trying to use scipy on Heroku."
-    puts-warn "Unfortunately, at this time, we do not directly support this library."
-    puts-warn "There is, however, a buildpack available that makes it possible to use it on Heroku."
-    puts-warn "You can learn more here:  https://devcenter.heroku.com/articles/python-c-deps"
-    puts-warn "Sorry for the inconvenience.   -- Much Love, Heroku."
-    mcount 'warnings.scipy'
-  fi
-}
-
-distribute-included() {
-  if grep -qi 'Running setup.py install for distribute' "$WARNINGS_LOG"; then
-    echo
-    puts-warn "Hello! Your requirements.txt file contains the distribute package."
-    puts-warn "This library is automatically installed by Heroku and shouldn't be in"
-    puts-warn "Your requirements.txt file. This can cause unexpected behavior."
-    puts-warn "  -- Much Love, Heroku."
-    mcount 'warnings.distribute'
-  fi
-}
-
-six-included() {
-  if grep -qi 'Running setup.py install for six' "$WARNINGS_LOG"; then
-    echo
-    puts-warn "Hello! Your requirements.txt file contains the six package."
-    puts-warn "This library is automatically installed by Heroku and shouldn't be in"
-    puts-warn "Your requirements.txt file. This can cause unexpected behavior."
-    puts-warn "  -- Much Love, Heroku."
-    mcount 'warnings.six'
-  fi
-}
-
 gdal-missing() {
   if grep -qi 'Could not find gdal-config' "$WARNINGS_LOG"; then
     mcount 'warnings.gdal'
@@ -58,10 +13,5 @@ gdal-missing() {
 }
 
 show-warnings() {
-  old-platform
-  scipy-included
-  distribute-included
-  six-included
   gdal-missing
 }
-


### PR DESCRIPTION
Since:
* `InsecurePlatformWarning` only affects Python versions that are no longer available on the current stacks.
* `scipy` can be installed, so the warning about it not being compatible is wrong.
* `six`/`distribute` are no longer installed automatically, so those warnings are wrong.

GUS-W-11594475.