### PR TITLE
Correct default/supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A `requirements.txt` must be present at the root of your application's repositor
 
 To specify your python version, you also need a `runtime.txt` file - unless you are using the default Python runtime version.
 
-Current default Python Runtime: Python 3.10.4
+Current default Python Runtime: Python 3.10.6
 
 Alternatively, you can provide a `setup.py` file, or a `Pipfile`.
 Using `pipenv` will generate `runtime.txt` at build time if one of the field `python_version` or `python_full_version` is specified in the `requires` section of your `Pipfile`.
@@ -60,7 +60,7 @@ Specify a Python Runtime
 
 Supported runtime options include:
 
-- `python-3.10.4` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
+- `python-3.10.6` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.9.13` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.8.13` on Heroku-18 and Heroku-20 only
 - `python-3.7.13` on Heroku-18 and Heroku-20 only


### PR DESCRIPTION
These should have been updated as part of previous releases, to match the actual default versions (and the versions documented on Dev Center).