### PR TITLE
Support setuptools v64's PEP660 editable install mode

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -323,7 +323,7 @@ EOT
 # - lib-python/3/site-packages/ (PyPy)
 if [[ "${BUILD_DIR}" != "/app" ]]; then
   cat <<EOT >> "$PROFILE_PATH"
-find .heroku/python/lib*/*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' \) -exec sed -i -e 's#${BUILD_DIR}#/app#' {} \+
+find .heroku/python/lib*/*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' -or -name '__editable___*_finder.py' \) -exec sed -i -e 's#${BUILD_DIR}#/app#' {} \+
 EOT
 fi
 

--- a/spec/fixtures/requirements_editable/bin/test-entrypoints
+++ b/spec/fixtures/requirements_editable/bin/test-entrypoints
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-# List the filenames and contents of all .egg-link and .pth files in site-packages.
-find .heroku/python/lib*/*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' \) | sort | xargs -exec tail -n +1
+# List the filenames and contents of all .egg-link, .pth, and finder files in site-packages.
+find .heroku/python/lib*/*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' -or -name '__editable___*_finder.py' \) | sort | xargs -exec tail -n +1
 echo
 
 echo -n "Running entrypoint for the local package: "


### PR DESCRIPTION
We were running into `ModuleNotFoundError` errors when trying
to run our application. After some investigation we noticed
that newer setuptools places new files `site-packages` when
using editable installs (I guess only in some situations):

```
mylib-0.0.0.dist-info
__editable__.mylib-0.0.0.pth
__editable___mylib_0_0_0_finder.py
```

The `*.pth` file in that case contains this stub:

```
import __editable___mylib_0_0_0_finder; __editable___mylib_0_0_0_finder.install()
```

while the `py` module is generated from a [template][1] and contains this line:

```
MAPPING = {'mylib': '/tmp/build_892299be/py-packages/mylib/src/mylib'}
```

This all seems to be related to setuptools 63 and might be mitigated
by the [compat mode in 64][2]. I assume we just started to see this
issue because of the [upgrade from 60 to 63][3] yesterday.

This PR updates the buildpack to also patch the paths in those files.
Please let me know if you have any recommendations for tests to add.

[1]: https://github.com/pypa/setuptools/blob/0a1906819c568ceb3ffccc61d531fecd6b8662de/setuptools/command/editable_wheel.py#L740
[2]: https://github.com/pypa/setuptools/pull/3484
[3]: https://github.com/heroku/heroku-buildpack-python/commit/4646cffde336340c44b88adc499633df4f832c5e