### PR TITLE
Provision a Heroku Postgres DB in fewer cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The Heroku Postgres database auto-provisioning feature now provisions a DB in fewer cases ([#1363](https://github.com/heroku/heroku-buildpack-python/pull/1363)).
 
 ## v218 (2022-09-07)
 

--- a/bin/release
+++ b/bin/release
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+set -euo pipefail
+
 BUILD_DIR=$1
+BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-MANAGE_FILE=$(cd "$BUILD_DIR" && find . -maxdepth 3 -type f -name 'manage.py' | head -1)
-MANAGE_FILE=${MANAGE_FILE:2}
+# shellcheck source=bin/utils
+source "$BIN_DIR/utils"
 
+if [[ -f "${BUILD_DIR}/manage.py" ]] && is_module_available 'django' && is_module_available 'psycopg2'; then
 cat <<EOF
 ---
-config_vars:
-
-EOF
-
-
-if [[ $MANAGE_FILE ]]; then
-cat <<EOF
-
 addons:
   - heroku-postgresql
 EOF

--- a/bin/utils
+++ b/bin/utils
@@ -59,7 +59,7 @@ measure-size() {
 }
 
 is_module_available() {
-  # Returns 0 is the specified module exists, otherwise returns 1.
+  # Returns 0 if the specified module exists, otherwise returns 1.
   # Uses pkgutil rather than pkg_resources or pip's CLI, since pkgutil exists
   # in the stdlib, and doesn't depend on the choice of package manager.
   local module_name="${1}"


### PR DESCRIPTION
As part of the Buildpack API, a buildpack can request the provisioning of addons on the first build of an app via the `bin/release` payload. (This feature does not apply to subsequent builds of existing apps.)

Previously the Python buildpack requested a Heroku Postgres DB be provisioned if the app source contained a `manage.py` file in the source root or any subdirectory up to three levels deep.

This meant a Postgres DB was provisioned even in cases where the app wasn't a Django app (but just happened to have a `manage.py` script) or used an alternative DB backend (eg MySQL), or didn't use a DB at all.

Now, the DB is only provisioned if all of the following are true:
- a `manage.py` file exists in the root of the app source
- `django` is installed
- `psycopg2` is installed

This ensures it's still provisioned in the Python getting-started guide case (and any other similar cases), but not in the other scenarios mentioned above.

Fixes #1067.
GUS-W-8098791.