### PR TITLE
revert setuptools version

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -157,7 +157,7 @@ case "${PYTHON_VERSION}" in
   python-3.6.*|pypy3.6-*)
     # Python 3.6 support was dropped in pip 22+ and setuptools 59.7.0+.
     PIP_VERSION='21.3.1'
-    SETUPTOOLS_VERSION='59.6.0'
+    SETUPTOOLS_VERSION='57.5.0'
     ;;
   python-3.5.*)
     # Python 3.5 support was dropped in pip 21+ and setuptools 51+.


### PR DESCRIPTION
 to one that works with django-celery 3.1.25

<!-- Hi and welcome to the Heroku Python buildpack repository!

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
