### PR TITLE
Convert heroku/heroku-buildpack-python to GitHub Actions

### DIFF
--- a/.github/actions/install-ruby-dependencies/action.yml
+++ b/.github/actions/install-ruby-dependencies/action.yml
@@ -1,0 +1,16 @@
+name: install-ruby-dependencies
+runs:
+  using: composite
+  steps:
+  - name: restore_cache
+    uses: actions/cache@v2
+    with:
+      key: gems-v1-{{ arch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "Gemfile.lock" }}
+  - name: Install Ruby dependencies
+    run: bundle install --deployment --jobs 2
+    shell: bash
+  - name: save_cache
+    uses: actions/cache@v2
+    with:
+      path: vendor/bundle
+      key: gems-v1-{{ arch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "Gemfile.lock" }}

--- a/.github/workflows/default-ci-workflow.yml
+++ b/.github/workflows/default-ci-workflow.yml
@@ -1,0 +1,65 @@
+name: heroku/heroku-buildpack-python/default-ci-workflow
+on:
+  push:
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  shellcheck:
+    defaults:
+      run:
+        working-directory: "/mnt/ramdisk/project"
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ubuntu
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install shellcheck
+      run: |-
+        curl -L --fail --retry 3 --retry-connrefused --connect-timeout 5 --max-time 30 \
+            https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz \
+          | sudo tar -xJ --strip-components=1 -C /usr/local/bin
+    - name: Lint bash scripts with shellcheck
+      run: make lint-scripts
+  rubocop:
+    defaults:
+      run:
+        working-directory: "/mnt/ramdisk/project"
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    steps:
+    - uses: actions/checkout@v2
+    - uses: "./.github/actions/install-ruby-dependencies"
+    - name: Lint Ruby files with Rubocop
+      run: bundle exec rubocop
+  hatchet:
+    defaults:
+      run:
+        working-directory: "/mnt/ramdisk/project"
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    env:
+      HATCHET_APP_LIMIT: xxxxxxx
+      HATCHET_DEFAULT_STACK: xxxxxxx
+      HATCHET_RETRIES: xxxxxxx
+      HEROKU_DISABLE_AUTOUPDATE: xxxxxxx
+      PARALLEL_SPLIT_TEST_PROCESSES: xxxxxxx
+      TMPDIR: xxxxxxx
+    strategy:
+      matrix:
+        stack:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+    steps:
+    - uses: actions/checkout@v2
+    - uses: "./.github/actions/install-ruby-dependencies"
+    - name: Hatchet setup
+      run: bundle exec hatchet ci:setup
+    - name: Run Hatchet rspec tests
+      run: bundle exec parallel_split_test spec/hatchet/ --format progress --format RspecJunitFormatter --out test-results/rspec/results.xml --no-merge
+    - uses: actions/upload-artifact@v2
+      with:
+        path: test-results


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-python) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/heroku-buildpack-python/default-ci-workflow
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest