### PR TITLE
Tests: Refresh Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.5.0)
     erubis (2.7.0)
-    excon (0.79.0)
+    excon (0.93.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
@@ -26,22 +26,22 @@ GEM
       rspec-core (>= 3.9.0)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    platform-api (3.3.0)
+    platform-api (3.5.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rainbow (3.1.1)
     rate_throttle_client (0.1.2)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     rexml (3.2.5)
     rrrretry (1.0.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rspec-expectations (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
-    rspec_junit_formatter (0.5.1)
+    rspec-support (3.11.1)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.36.0)
       json (~> 2.3)
@@ -55,12 +55,12 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-rspec (2.12.1)
-      rubocop (~> 1.31)
+    rubocop-rspec (2.13.2)
+      rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
-    thor (1.1.0)
+    thor (1.2.1)
     threaded (0.0.4)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.3.0)
     webrick (1.7.0)
 
 PLATFORMS
@@ -76,7 +76,7 @@ DEPENDENCIES
   rubocop-rspec
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.6p219
 
 BUNDLED WITH
-   2.1.4
+   2.3.22

--- a/spec/hatchet/getting_started_spec.rb
+++ b/spec/hatchet/getting_started_spec.rb
@@ -5,7 +5,11 @@ require_relative '../spec_helper'
 RSpec.describe 'Python getting started project' do
   it 'builds successfully' do
     Hatchet::Runner.new('python-getting-started').deploy do |app|
-      # Deploy works
+      # TODO: Decide what to do with this test given it mostly duplicates the one in django_spec.rb.
+      expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        remote: -----> \\$ python manage.py collectstatic --noinput
+        remote:        \\d+ static files copied to '/tmp/build_.*/staticfiles', \\d+ post-processed.
+      REGEX
     end
   end
 end


### PR DESCRIPTION
To pick up updated dependencies, some of which are transitive and so don't get updated by Dependabot, and the others just haven't been updated yet since Dependabot is on a monthly schedule.

These changes have been split out of the upcoming Circle CI -> GitHub Actions migration PR, in order to reduce the size of that PR.

Updating the dependencies also required adjusting one of the tests, to fix a new lint failure:

```
$ bundle exec rubocop
Inspecting 13 files
....C........

Offenses:

spec/hatchet/getting_started_spec.rb:6:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'builds successfully' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```