### PR TITLE
Fix automatic provisioning of Postgres DB addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix automatic provisioning of Postgres DB addons ([#1375](https://github.com/heroku/heroku-buildpack-python/pull/1375)).
 
 ## v220 (2022-09-28)
 

--- a/bin/release
+++ b/bin/release
@@ -4,10 +4,20 @@
 set -euo pipefail
 
 BUILD_DIR=$1
-BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+# Unfortunately the build system doesn't source the `export` script before
+# running `bin/release`, so we have to do so manually to ensure the buildpack
+# Python is used by `is_module_available` instead of system Python.
+# We also have to disable Bash error on undefined variables, since not all env
+# vars used in the export script will be set by default (eg `LIBRARY_PATH`).
+set +u
+# shellcheck source=/dev/null
+source "${BUILDPACK_DIR}/export"
+set -u
 
 # shellcheck source=bin/utils
-source "$BIN_DIR/utils"
+source "${BUILDPACK_DIR}/bin/utils"
 
 if [[ -f "${BUILD_DIR}/manage.py" ]] && is_module_available 'django' && is_module_available 'psycopg2'; then
 cat <<EOF


### PR DESCRIPTION
In #1363 the logic for determining when to automatically provision a Heroku Postgres database addon was adjusted to reduce false positives.

Unfortunately, this broke provisioning in all cases, since it turns out that the build system does not source the `export` script prior to running `bin/release` (like it does when running subsequent buildpacks), and so the buildpack configured env vars (such as `PATH`) are not set.

This meant that when `bin/release` used the `is_module_available` utility, it was calling system Python (where the Django and psycopg2 packages were not installed) and so always failing the conditional.

Unfortunately we do not currently have an easy way to test `bin/release`, otherwise a test case would have been added in the original PR.

I had manually tested the original PR using the Python getting started guide, but had only checked via accessing the app and trying to run the Django `./manage.py migrate` command. However it seems the Django config for that project silently falls back to sqlite if `DATABASE_URL` is not set - so the project (and the migrate command) still worked.

For this PR I have manually tested to ensure the addon itself appears on the app.

Fix #1374.
GUS-W-11851647.