### PR TITLE
Add a deprecation warning for Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a deprecation warning for Python 3.7 ([#1404](https://github.com/heroku/heroku-buildpack-python/pull/1404)).
 
 ## v224 (2022-12-07)
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -58,6 +58,14 @@ case "${PYTHON_VERSION}" in
     warn_if_patch_update_available "${PYTHON_VERSION}" "${LATEST_38}"
     ;;
   python-3.7.*)
+    puts-warn
+    puts-warn "Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which"
+    puts-warn "point it will no longer receive security updates:"
+    puts-warn "https://devguide.python.org/versions/#supported-versions"
+    puts-warn
+    puts-warn "Upgrade to a newer Python version as soon as possible to keep your app secure."
+    puts-warn "See: https://devcenter.heroku.com/articles/python-runtimes"
+    puts-warn
     warn_if_patch_update_available "${PYTHON_VERSION}" "${LATEST_37}"
     ;;
   python-3.6.*)

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'Pipenv support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.6', allow_failure: allow_failure) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
-      it 'builds with the latest Python 3.6' do
+      it 'builds with the latest Python 3.6 but shows an EOL warning' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
@@ -182,7 +182,27 @@ RSpec.describe 'Pipenv support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.7', allow_failure: allow_failure) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
-      include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_7
+      it 'builds with the latest Python 3.7 but shows a deprecation warning' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to include(<<~OUTPUT)
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in Pipfile.lock
+            remote:  !     
+            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-#{LATEST_PYTHON_3_7}
+            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+            remote: -----> Installing dependencies with Pipenv 2020.11.15
+            remote:        Installing dependencies from Pipfile.lock (3adc54)...
+            remote: -----> Installing SQLite3
+          OUTPUT
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -76,7 +76,27 @@ RSpec.describe 'Python update warnings' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7_outdated', allow_failure: allow_failure) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
-      include_examples 'warns there is a Python update available', '3.7.12', LATEST_PYTHON_3_7
+      it 'warns about both the deprecated major version and the patch update' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
+            remote:  !     
+            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote:  !     
+            remote:  !     A Python security update is available! Upgrade as soon as possible to: python-#{LATEST_PYTHON_3_7}
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-3.7.12
+          REGEX
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'Python version support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.6', allow_failure: allow_failure) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
-      it 'builds with Python 3.6.15' do
+      it 'builds with Python 3.6.15 but shows an EOL warning' do
         app.deploy do |app|
           expect(clean_output(app.output)).to include(<<~OUTPUT)
             remote: -----> Python app detected
@@ -220,7 +220,28 @@ RSpec.describe 'Python version support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7', allow_failure: allow_failure) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
-      include_examples 'builds with the requested Python version', LATEST_PYTHON_3_7
+      it 'builds with Python 3.7.16 but shows a deprecation warning' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to include(<<~OUTPUT)
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
+            remote:  !     
+            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-#{LATEST_PYTHON_3_7}
+            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+            remote: -----> Installing SQLite3
+            remote: -----> Installing requirements with pip
+            remote:        Collecting urllib3
+          OUTPUT
+          expect(app.run('python -V')).to include("Python #{LATEST_PYTHON_3_7}")
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do


### PR DESCRIPTION
Since it's only 4 months away from upstream end-of-life:
https://devguide.python.org/versions/#supported-versions

GUS-W-12345799.