### PR TITLE
Update pipenv from 2020.11.15 to 2023.2.4 (/2022.4.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Python 3.10.10 and 3.11.2 are now available ([#1405](https://github.com/heroku/heroku-buildpack-python/pull/1405)).
 - The default Python version for new apps is now 3.10.10 (previously 3.10.9) ([#1405](https://github.com/heroku/heroku-buildpack-python/pull/1405)).
+- Update Pipenv from 2020.11.15 to: ([#1407](https://github.com/heroku/heroku-buildpack-python/pull/1407))
+  - 2022.4.8 for Python 3.6
+  - 2023.2.4 for Python 3.7+
 - Add a deprecation warning for Python 3.7 ([#1404](https://github.com/heroku/heroku-buildpack-python/pull/1404)).
 
 ## v224 (2022-12-07)

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -42,13 +42,16 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
-        PIPENV_VERSION='2020.11.15'
+        PIPENV_VERSION='2023.2.4'
 
-        # Install pipenv.
-        # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip
-        # to latest if only --upgrade is specified. Specify upgrade strategy to
-        # avoid this eager behavior.
-        /app/.heroku/python/bin/pip install "pipenv==${PIPENV_VERSION}" --upgrade --upgrade-strategy only-if-needed &> /dev/null
+        case "${PYTHON_VERSION}" in
+            python-3.6.*)
+                # Python 3.6 support was dropped in pipenv 2022.4.20.
+                PIPENV_VERSION='2022.4.8'
+                ;;
+        esac
+
+        /app/.heroku/python/bin/pip install --quiet --disable-pip-version-check --no-cache-dir "pipenv==${PIPENV_VERSION}"
 
         # Install the test dependencies, for CI.
         if [ "$INSTALL_TEST" ]; then

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -213,7 +213,7 @@ if ! curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-t
   exit 1
 fi
 
-/app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --disable-pip-version-check --no-cache \
+/app/.heroku/python/bin/python "${PIP_WHEEL}/pip" install --quiet --disable-pip-version-check --no-cache-dir \
   "${PIP_WHEEL}" "setuptools==${SETUPTOOLS_VERSION}" "wheel==${WHEEL_VERSION}"
 
 hash -r

--- a/spec/fixtures/pipenv_and_requirements_txt/Pipfile.lock
+++ b/spec/fixtures/pipenv_and_requirements_txt/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_and_runtime_txt/Pipfile
+++ b/spec/fixtures/pipenv_and_runtime_txt/Pipfile
@@ -9,4 +9,4 @@ urllib3 = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/spec/fixtures/pipenv_and_runtime_txt/Pipfile.lock
+++ b/spec/fixtures/pipenv_and_runtime_txt/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e9eb0bba6cb0a97533d25cd3d68db92d4afd6b1dc88cd7a51607d8c34475eae0"
+            "sha256": "7776f372e3411c742b3e8a4209e67f0832f9e249d4c86ce28ece146afaef68d1"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_lockfile_out_of_sync/Pipfile.lock
+++ b/spec/fixtures/pipenv_lockfile_out_of_sync/Pipfile.lock
@@ -16,11 +16,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_2.7/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_2.7/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.10/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.10/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.11/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.11/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.5/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.5/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.6/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.6/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.7/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.7/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.8/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.8/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.9/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.9/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_full_version/Pipfile
+++ b/spec/fixtures/pipenv_python_full_version/Pipfile
@@ -9,4 +9,4 @@ urllib3 = "*"
 [dev-packages]
 
 [requires]
-python_full_version = "3.10.4"
+python_full_version = "3.10.7"

--- a/spec/fixtures/pipenv_python_full_version/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_full_version/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "355262e6cca53c94b8ef8837baf9556429f1c714da82c063c544856c11e047bc"
+            "sha256": "de91ad50473fd60a3b46177cd3d8d8e93f339a5833e210efba5785b97e63b2b7"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_full_version": "3.10.4"
+            "python_full_version": "3.10.7"
         },
         "sources": [
             {
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
-                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.9"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_full_version_invalid/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_full_version_invalid/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_version_invalid/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_version_invalid/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_version_unspecified/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_version_unspecified/Pipfile.lock
@@ -16,11 +16,11 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.2"
+            "version": "==1.26.14"
         }
     },
     "develop": {}

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -10,8 +10,8 @@ RSpec.shared_examples 'builds using Pipenv with the requested Python version' do
         remote: -----> Using Python version specified in Pipfile.lock
         remote: -----> Installing python-#{python_version}
         remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-        remote: -----> Installing dependencies with Pipenv 2020.11.15
-        remote:        Installing dependencies from Pipfile.lock \\(.*\\)...
+        remote: -----> Installing dependencies with Pipenv 2023.2.4
+        remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
         remote: -----> Installing SQLite3
       REGEX
     end
@@ -44,7 +44,7 @@ RSpec.describe 'Pipenv support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile...
           remote: -----> Installing SQLite3
         OUTPUT
@@ -57,16 +57,16 @@ RSpec.describe 'Pipenv support' do
 
     it 'builds with the default Python version' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        Installing dependencies from Pipfile.lock (aad8b1)...
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
-        OUTPUT
+        REGEX
       end
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe 'Pipenv support' do
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       it 'builds with the latest Python 3.6 but shows an EOL warning' do
         app.deploy do |app|
-          expect(clean_output(app.output)).to include(<<~OUTPUT)
+          expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
             remote: -----> Python app detected
             remote: -----> Using Python version specified in Pipfile.lock
             remote:  !     
@@ -161,10 +161,10 @@ RSpec.describe 'Pipenv support' do
             remote:  !     
             remote: -----> Installing python-#{LATEST_PYTHON_3_6}
             remote: -----> Installing pip 21.3.1, setuptools 59.6.0 and wheel 0.37.1
-            remote: -----> Installing dependencies with Pipenv 2020.11.15
-            remote:        Installing dependencies from Pipfile.lock (b8b71b)...
+            remote: -----> Installing dependencies with Pipenv 2022.4.8
+            remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
             remote: -----> Installing SQLite3
-          OUTPUT
+          REGEX
         end
       end
     end
@@ -184,7 +184,7 @@ RSpec.describe 'Pipenv support' do
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       it 'builds with the latest Python 3.7 but shows a deprecation warning' do
         app.deploy do |app|
-          expect(clean_output(app.output)).to include(<<~OUTPUT)
+          expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
             remote: -----> Python app detected
             remote: -----> Using Python version specified in Pipfile.lock
             remote:  !     
@@ -197,10 +197,10 @@ RSpec.describe 'Pipenv support' do
             remote:  !     
             remote: -----> Installing python-#{LATEST_PYTHON_3_7}
             remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-            remote: -----> Installing dependencies with Pipenv 2020.11.15
-            remote:        Installing dependencies from Pipfile.lock (3adc54)...
+            remote: -----> Installing dependencies with Pipenv 2023.2.4
+            remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
             remote: -----> Installing SQLite3
-          OUTPUT
+          REGEX
         end
       end
     end
@@ -251,35 +251,33 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_11}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        /tmp/build_.*/.heroku/python/lib/python3.11/site-packages/pipenv/vendor/attr/_make.py:778: RuntimeWarning: Running interpreter doesn't sufficiently support code object introspection. .*
-          remote:          set_closure_cell\\(cell, cls\\)
-          remote:        Installing dependencies from Pipfile.lock \\(.*\\)...
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
         REGEX
       end
     end
   end
 
-  context 'with a Pipfile.lock containing python_full_version 3.10.4' do
+  context 'with a Pipfile.lock containing python_full_version 3.10.7' do
     let(:allow_failure) { false }
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_full_version', allow_failure: allow_failure) }
 
     it 'builds with the outdated Python version specified' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> Using Python version specified in Pipfile.lock
           remote:  !     
           remote:  !     A Python security update is available! Upgrade as soon as possible to: python-#{LATEST_PYTHON_3_10}
           remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
           remote:  !     
-          remote: -----> Installing python-3.10.4
+          remote: -----> Installing python-3.10.7
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        Installing dependencies from Pipfile.lock (e047bc)...
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
-        OUTPUT
+        REGEX
       end
     end
   end
@@ -320,15 +318,15 @@ RSpec.describe 'Pipenv support' do
 
     it 'builds with the Python version from runtime.txt' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing python-#{LATEST_PYTHON_3_10}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        Installing dependencies from Pipfile.lock (75eae0)...
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
-        OUTPUT
+        REGEX
       end
     end
   end
@@ -338,15 +336,15 @@ RSpec.describe 'Pipenv support' do
 
     it 'builds with Pipenv rather than pip' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_10}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        Installing dependencies from Pipfile.lock (2d32e8)...
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
-        OUTPUT
+        REGEX
       end
     end
   end
@@ -362,9 +360,9 @@ RSpec.describe 'Pipenv support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
           remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
-          remote: -----> Installing dependencies with Pipenv 2020.11.15
-          remote:        Your Pipfile.lock \\(aad8b1\\) is out of date. Expected: \\(2d32e8\\).
-          remote:        \\[DeployException\\]: .*
+          remote: -----> Installing dependencies with Pipenv 2023.2.4
+          remote:        Your Pipfile.lock \\(.+\\) is out of date. Expected: \\(.+\\).
+          remote:        .+
           remote:        ERROR:: Aborting deploy
         REGEX
       end


### PR DESCRIPTION
Updates Pipenv from 2020.11.15 to:
  - 2022.4.8 for Python 3.6
  - 2023.2.4 for Python 3.7+

Release notes:
https://github.com/pypa/pipenv/blob/main/CHANGELOG.rst#pipenv-202324-2023-02-04

Full changes:
https://github.com/pypa/pipenv/compare/v2020.11.15...v2023.2.4

Closes #1403.
GUS-W-9348641.