### PR TITLE
Update wheel from 0.37.1 to 0.38.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use Python 3.11 as the default Python version for new apps (previously Python 3.10) ([#1408](https://github.com/heroku/heroku-buildpack-python/pull/1408)).
+- Update wheel from 0.37.1 to 0.38.4 for Python 3.7+ ([#1409](https://github.com/heroku/heroku-buildpack-python/pull/1409)).
 
 ## v225 (2023-02-08)
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -183,13 +183,14 @@ fi
 
 PIP_VERSION='22.3.1'
 SETUPTOOLS_VERSION='63.4.3'
-WHEEL_VERSION='0.37.1'
+WHEEL_VERSION='0.38.4'
 
 case "${PYTHON_VERSION}" in
   python-3.6.*)
-    # Python 3.6 support was dropped in pip 22+ and setuptools 59.7.0+.
+    # Python 3.6 support was dropped in pip 22+, setuptools 59.7.0+ and wheel 0.38.0+.
     PIP_VERSION='21.3.1'
     SETUPTOOLS_VERSION='59.6.0'
+    WHEEL_VERSION='0.37.1'
     ;;
 esac
 

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Pip support' do
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -38,7 +38,7 @@ RSpec.describe 'Pip support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Using cached install of python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote: -----> Discovering process types
@@ -61,7 +61,7 @@ RSpec.describe 'Pip support' do
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Requirements file has been changed, clearing cached dependencies
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'builds using Pipenv with the requested Python version' do
         remote: -----> Python app detected
         remote: -----> Using Python version specified in Pipfile.lock
         remote: -----> Installing python-#{python_version}
-        remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+        remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
         remote: -----> Installing dependencies with Pipenv 2023.2.4
         remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
         remote: -----> Installing SQLite3
@@ -43,7 +43,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile...
           remote: -----> Installing SQLite3
@@ -62,7 +62,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
@@ -196,7 +196,7 @@ RSpec.describe 'Pipenv support' do
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
             remote:  !     
             remote: -----> Installing python-#{LATEST_PYTHON_3_7}
-            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
             remote: -----> Installing dependencies with Pipenv 2023.2.4
             remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
             remote: -----> Installing SQLite3
@@ -250,7 +250,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_11}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
@@ -273,7 +273,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
           remote:  !     
           remote: -----> Installing python-3.10.7
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
@@ -322,7 +322,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in runtime.txt
           remote: -----> Installing python-#{LATEST_PYTHON_3_10}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
@@ -340,7 +340,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Python app detected
           remote: -----> Using Python version specified in Pipfile.lock
           remote: -----> Installing python-#{LATEST_PYTHON_3_10}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Installing SQLite3
@@ -359,7 +359,7 @@ RSpec.describe 'Pipenv support' do
           remote: -----> No Python version was specified. Using the buildpack default: python-#{DEFAULT_PYTHON_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing dependencies with Pipenv 2023.2.4
           remote:        Your Pipfile.lock \\(.+\\) is out of date. Expected: \\(.+\\).
           remote:        .+

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'builds with the requested Python version' do |python_vers
         remote: -----> Python app detected
         remote: -----> Using Python version specified in runtime.txt
         remote: -----> Installing python-#{python_version}
-        remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+        remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
         remote: -----> Installing SQLite3
         remote: -----> Installing requirements with pip
         remote:        Collecting urllib3
@@ -234,7 +234,7 @@ RSpec.describe 'Python version support' do
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
             remote:  !     
             remote: -----> Installing python-#{LATEST_PYTHON_3_7}
-            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+            remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
             remote: -----> Installing SQLite3
             remote: -----> Installing requirements with pip
             remote:        Collecting urllib3
@@ -346,7 +346,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Python version has changed from python-#{LATEST_PYTHON_3_9} to python-#{LATEST_PYTHON_3_10}, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-#{LATEST_PYTHON_3_10}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Stack has changed from heroku-20 to heroku-22, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-3.10.5
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3
@@ -63,7 +63,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Stack has changed from heroku-22 to heroku-20, clearing cache
           remote: -----> No change in requirements detected, installing from cache
           remote: -----> Installing python-#{DEFAULT_PYTHON_VERSION}
-          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.37.1
+          remote: -----> Installing pip 22.3.1, setuptools 63.4.3 and wheel 0.38.4
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
           remote:        Collecting urllib3


### PR DESCRIPTION
Updates the `wheel` packaging tool from 0.37.1 to 0.38.4 when using Python 3.7+. The version is unchanged for Python 3.6 since the newer wheel version has dropped support for it.

See:
https://wheel.readthedocs.io/en/stable/news.html
https://github.com/pypa/wheel/compare/0.37.1...0.38.4

GUS-W-12030292.