### PR TITLE
Disable fail-fast in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,8 +27,9 @@ jobs:
         run: bundle exec rubocop
 
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         stack: ["heroku-18", "heroku-20", "heroku-22"]
     env:


### PR DESCRIPTION
Since otherwise it prevents Hatchet from cleaning up apps.

(Further improvements to Hatchet and end of CI run setup will happen soon, however, for now this is better than nothing.)

Also switches the CI workflow to the `ubuntu-latest` runner alias, now that it's equivalent to `ubuntu-22.04`.