### PR TITLE
Release v228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v228 (2023-02-21)
+
 - Drop support for Python 3.6 ([#1415](https://github.com/heroku/heroku-buildpack-python/pull/1415)).
 
 ## v227 (2023-02-20)

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -44,13 +44,6 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
 
         PIPENV_VERSION='2023.2.18'
 
-        case "${PYTHON_VERSION}" in
-            python-3.6.*)
-                # Python 3.6 support was dropped in pipenv 2022.4.20.
-                PIPENV_VERSION='2022.4.8'
-                ;;
-        esac
-
         /app/.heroku/python/bin/pip install --quiet --disable-pip-version-check --no-cache-dir "pipenv==${PIPENV_VERSION}"
 
         # Install the test dependencies, for CI.


### PR DESCRIPTION
To pick up #1415.

Also removes a Python 3.6 remnant leftover from #1415.