### PR TITLE
Tests: Update Ruby and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.1"
       - name: Run ShellCheck
         run: make lint-scripts
       - name: Run Rubocop
@@ -47,7 +47,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.1"
       - name: Hatchet setup
         run: bundle exec hatchet ci:setup
       - name: Run Hatchet integration tests

--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.1"
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '~> 2.7.0'
+ruby '>= 3.1', '< 3.3'
 
 group :test, :development do
   gem 'heroku_hatchet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       moneta
       multi_json (>= 1.9.2)
       webrick
-    heroku_hatchet (8.0.1)
+    heroku_hatchet (8.0.2)
       excon (~> 0)
       platform-api (~> 3)
       rrrretry (~> 1)
@@ -24,7 +24,7 @@ GEM
     parallel_split_test (0.10.0)
       parallel (>= 0.5.13)
       rspec-core (>= 3.9.0)
-    parser (3.2.1.0)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
     platform-api (3.5.0)
       heroics (~> 0.1.1)
@@ -41,7 +41,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.47.0)
+    rubocop (1.48.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -53,12 +53,12 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.17.0)
+    rubocop-capybara (2.17.1)
       rubocop (~> 1.41)
-    rubocop-rspec (2.18.1)
+    rubocop-rspec (2.19.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     thor (1.2.1)
     threaded (0.0.4)
     unicode-display_width (2.4.2)
@@ -76,7 +76,7 @@ DEPENDENCIES
   rubocop-rspec
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 3.2.1p31
 
 BUNDLED WITH
-   2.3.22
+   2.4.6

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Pip support' do
 
   context 'when requirements.txt contains editable requirements' do
     let(:buildpacks) { [:default, 'heroku-community/inline'] }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_editable', buildpacks: buildpacks) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_editable', buildpacks:) }
 
     it 'rewrites .pth, .egg-link and finder paths correctly for hooks, later buildpacks, runtime and cached builds' do
       app.deploy do |app|

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'Pipenv support' do
 
   context 'with a Pipfile.lock containing python_version 3.7' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.7', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.7', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       it 'builds with the latest Python 3.7 but shows a deprecation warning' do
@@ -211,7 +211,7 @@ RSpec.describe 'Pipenv support' do
 
   context 'with a Pipfile.lock containing python_version 3.8' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.8', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.8', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_8
@@ -257,7 +257,7 @@ RSpec.describe 'Pipenv support' do
 
   context 'with a Pipfile.lock containing python_full_version 3.10.7' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_full_version', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_full_version', allow_failure:) }
 
     it 'builds with the outdated Python version specified' do
       app.deploy do |app|

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -58,7 +58,7 @@ end
 RSpec.describe 'Python update warnings' do
   context 'with a runtime.txt containing python-3.7.12' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7_outdated', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       it 'warns about both the deprecated major version and the patch update' do
@@ -93,7 +93,7 @@ RSpec.describe 'Python update warnings' do
 
   context 'with a runtime.txt containing python-3.8.12' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8_outdated', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       include_examples 'warns there is a Python update available', '3.8.12', LATEST_PYTHON_3_8
@@ -114,14 +114,14 @@ RSpec.describe 'Python update warnings' do
 
   context 'with a runtime.txt containing python-3.10.5' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10_outdated', allow_failure:) }
 
     include_examples 'warns there is a Python update available', '3.10.5', LATEST_PYTHON_3_10
   end
 
   context 'with a runtime.txt containing python-3.11.0' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.11_outdated', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.11_outdated', allow_failure:) }
 
     include_examples 'warns there is a Python update available', '3.11.0', LATEST_PYTHON_3_11
   end

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -35,7 +35,7 @@ end
 RSpec.describe 'Python version support' do
   context 'when no Python version is specified' do
     let(:buildpacks) { [:default] }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks:) }
 
     context 'with a new app' do
       it 'builds with the default Python version' do
@@ -210,7 +210,7 @@ RSpec.describe 'Python version support' do
 
   context 'when runtime.txt contains python-3.7.16' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.7', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       it 'builds with Python 3.7.16 but shows a deprecation warning' do
@@ -247,7 +247,7 @@ RSpec.describe 'Python version support' do
 
   context 'when runtime.txt contains python-3.8.16' do
     let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8', allow_failure: allow_failure) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8', allow_failure:) }
 
     context 'when using Heroku-18 or Heroku-20', stacks: %w[heroku-18 heroku-20] do
       include_examples 'builds with the requested Python version', LATEST_PYTHON_3_8

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Stack changes' do
     # The buildpack version chosen is one which had an older default Python version, so
     # we can also prove that clearing the cache didn't lose the Python version metadata.
     let(:buildpacks) { ['https://github.com/heroku/heroku-buildpack-python#v213'] }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks: buildpacks) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks:) }
 
     it 'clears the cache before installing again whilst preserving the sticky Python version' do
       app.deploy do |app|


### PR DESCRIPTION
Update from Ruby 2.7 to 3.1 and bump dependencies, given Ruby 2.7 EOLs soon. Ruby 3.1 had to be used since Hatchet doesn't yet support Ruby 3.2.

After upgrading, a number of new Rubocop fixes are needed, to resolve eg:

```
spec/hatchet/pip_spec.rb:92:88: C: [Correctable] Style/HashSyntax: Omit the hash value.
    let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_editable', buildpacks: buildpacks) }
```

GUS-W-12670465.