### PR TITLE
Downgrade pipenv from 2023.2.18 to 2023.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Downgrade pipenv from 2023.2.18 to 2023.2.4 ([#1425](https://github.com/heroku/heroku-buildpack-python/pull/1425)).
 
 ## v228 (2023-02-21)
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -42,7 +42,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
-        PIPENV_VERSION='2023.2.18'
+        PIPENV_VERSION='2023.2.4'
 
         /app/.heroku/python/bin/pip install --quiet --disable-pip-version-check --no-cache-dir "pipenv==${PIPENV_VERSION}"
 


### PR DESCRIPTION
pipenv 2023.2.18 raised its minimum setuptools version to 67.x, which is newer than the setuptools version the buildpack pins to. This succeeds on the first build, however, for cached rebuilds then fails due to pip's version resolver not allowing overriding already-installed dependency versions when resolving version conflicts.

A new testcase has been added for pipenv caching (caching was already extensively tested when using pip, just not when using pipenv).

Resolves:

```
remote: -----> Installing pip 23.0.1, setuptools 63.4.3 and wheel 0.38.4
remote: ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
remote: pipenv 2023.2.18 requires setuptools>=67.0.0, but you have setuptools 63.4.3 which is incompatible.
```

Longer term we will update to newer setuptools ourselves (once the dust settles on the many breaking changes introduced in newer setuptools versions), and hopefully newer pipenv will also relax its minimum setuptools version slightly.

GUS-W-12670935.