### PR TITLE
Upgrade SETUPTOOLS_VERSION to improve memory rss

### DIFF
--- a/bin/steps/python
+++ b/bin/steps/python
@@ -174,7 +174,7 @@ else
 fi
 
 PIP_VERSION='23.0.1'
-SETUPTOOLS_VERSION='63.4.3'
+SETUPTOOLS_VERSION='67.6.0'
 WHEEL_VERSION='0.38.4'
 
 puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"


### PR DESCRIPTION
We have been using heroku since 2015. Currently we are upgrading our stack. And we have upgraded heroku-buildpack-python from v184 to v229.

In our stack we have several dynos: web (with Django), worker (with celery worker), worker-slow (with celery worker to slow tasks) and beat (celery beat). This last is very very stable to measure. The next measures are of this dyno in preproduction environment, that is even more stable:

- v184: 126.45 MB
- v200: 126.44 MB
- v205: 126.46MB
- v208: 126.48 MB
- v209: 126.23 MB

Memory is increased

- v210: 130.83 MB
- v212: 130.96 MB
- v214: 130.99 MB

Memory is increased another time

- v215: 134,20 MB
- v220: 133,92 MB
- v229: 133,95 MB


Reasons:

- In v210 version you upgraded setuptools [from 57.5.0 to 60.10.0](https://github.com/heroku/heroku-buildpack-python/compare/v209...v210). In 60.0.0 version of setuptools changed the default value of SETUPTOOLS_USE_DISTUTILS [from stdlib to local](https://github.com/pypa/setuptools/compare/v59.0.1...v60.0.0)
- In v215 version you upgraded setuptools another time [from 60.10.0 to 63.4.3](https://github.com/heroku/heroku-buildpack-python/compare/v214...v215)

We have done [more tests](https://github.com/we-are-Joinup/heroku-buildpack-python/commits/test):

- v229 with setuptools==39.2.0: 126.45MB
- v229 with setuptools==59.8.0: 126.70 MB (previous version to 60.0.0)

Memory is increased:

- v229 with setuptools==60.0.0: 128.24 MB

Memory is decreased:

- v229 with setuptools==60.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 126.45MB
-  v229 with setuptools==61.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 126.89MB

Memory is increased:

- v229 with setuptools==62.3.2 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.41MB
 - v229 with setuptools==63.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.73MB
 - v229 with setuptools==63.4.3 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.41MB
 - v229 with setuptools==65.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.36MB
 - v229 with setuptools==66.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.44MB
 - v229 with setuptools==66.1.1 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 128.43MB 

Memory is decreased:

 - v229 with setuptools==67.0.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 125.37MB
 - v229 with setuptools==67.6.0 and env variable SETUPTOOLS_USE_DISTUTILS=stdlib: 125.63MB

So, if we upgrade setuptools and we use (or document) SETUPTOOLS_USE_DISTUTILS environment variable we can reduce our project by 9MB (7%). But 9MB for celery beat, this process consumes low memory. In our stack, we have decreased next MB per dyno:

- Web decreases about 40MB
- Worker descreses about 50 MB
- Worker slow decreases about 50MB too
- Beat decreases about 9MB

