### PR TITLE
Update pip to 23.1.2 and setuptools to 67.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated pip from 23.0.1 to 23.1.2. ([#1441](https://github.com/heroku/heroku-buildpack-python/pull/1441))
+- Updated setuptools from 67.6.1 to 67.7.2. ([#1441](https://github.com/heroku/heroku-buildpack-python/pull/1441))
 - The pip bootstrap step is now performed using the pip wheel bundled with the Python stdlib, rather than one downloaded from S3. ([#1442](https://github.com/heroku/heroku-buildpack-python/pull/1442))
 
 ## v231 (2023-04-12)

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -28,7 +28,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         exit 1
     fi
 
-    /app/.heroku/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
+    /app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e
 
@@ -44,9 +44,9 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
 
     # Install test dependencies, for CI.
     if [ "$INSTALL_TEST" ]; then
-        if [[ -f "$1/requirements-test.txt" ]]; then
+        if [[ -f requirements-test.txt ]]; then
             puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pip install -r "$1/requirements-test.txt" --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
+            /app/.heroku/python/bin/pip install -r requirements-test.txt --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
         fi
     fi
 fi

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -173,8 +173,8 @@ else
   hash -r
 fi
 
-PIP_VERSION='23.0.1'
-SETUPTOOLS_VERSION='67.6.1'
+PIP_VERSION='23.1.2'
+SETUPTOOLS_VERSION='67.7.2'
 WHEEL_VERSION='0.40.0'
 
 puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Pip support' do
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 \\(from -r requirements.txt \\(line 1\\)\\)
           remote:          Downloading urllib3-.*
           remote:        Installing collected packages: urllib3
           remote:        Successfully installed urllib3-.*
@@ -64,9 +64,9 @@ RSpec.describe 'Pip support' do
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 \\(from -r requirements.txt \\(line 1\\)\\)
           remote:          Downloading urllib3-.*
-          remote:        Collecting six
+          remote:        Collecting six \\(from -r requirements.txt \\(line 2\\)\\)
           remote:          Downloading six-.*
           remote:        Installing collected packages: urllib3, six
           remote:        Successfully installed six-.* urllib3-.*
@@ -248,7 +248,7 @@ RSpec.describe 'Pip support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 (from -r requirements.txt (line 1))
         OUTPUT
         expect(app.output).not_to include('Running setup.py develop')
       end

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples 'builds with the requested Python version' do |python_vers
         remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
         remote: -----> Installing SQLite3
         remote: -----> Installing requirements with pip
-        remote:        Collecting urllib3
+        remote:        Collecting urllib3 (from -r requirements.txt (line 1))
       OUTPUT
       expect(app.run('python -V')).to include("Python #{python_version}")
     end
@@ -230,7 +230,7 @@ RSpec.describe 'Python version support' do
             remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
             remote: -----> Installing SQLite3
             remote: -----> Installing requirements with pip
-            remote:        Collecting urllib3
+            remote:        Collecting urllib3 (from -r requirements.txt (line 1))
           OUTPUT
           expect(app.run('python -V')).to include("Python #{LATEST_PYTHON_3_7}")
         end
@@ -342,7 +342,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 (from -r requirements.txt (line 1))
         OUTPUT
       end
     end

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 (from -r requirements.txt (line 1))
         OUTPUT
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
           remote: -----> Installing SQLite3
           remote: -----> Installing requirements with pip
-          remote:        Collecting urllib3
+          remote:        Collecting urllib3 (from -r requirements.txt (line 1))
         OUTPUT
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,8 @@ LATEST_PYTHON_3_10 = '3.10.11'
 LATEST_PYTHON_3_11 = '3.11.3'
 DEFAULT_PYTHON_VERSION = LATEST_PYTHON_3_11
 
-PIP_VERSION = '23.0.1'
-SETUPTOOLS_VERSION = '67.6.1'
+PIP_VERSION = '23.1.2'
+SETUPTOOLS_VERSION = '67.7.2'
 WHEEL_VERSION = '0.40.0'
 
 # Work around the return value for `default_buildpack` changing after deploy:


### PR DESCRIPTION
- Updates pip from 23.0.1 to 23.1.2
- Updates setuptools from 67.6.1 to 67.7.2

See:
https://pip.pypa.io/en/stable/news/#v23-1-2
https://setuptools.pypa.io/en/stable/history.html#v67-7-2

The new pip version now outputs the origin of each requirement (eg the requirements file path which listed it). As such, the `pip install` invocations have also been adjusted to use a relative path to the app's requirements file, so that the log output doesn't end up including the full tmp directory path (eg `(/tmp/build_d73c77c7/requirements.txt`), which would make the logs more cluttered and harder to diff between builds.

Lastly, since #1442 has now landed, we no longer need to upload the new pip wheel version to S3, and so this pip upgrade just works as is.

GUS-W-12345615.
GUS-W-13108504.