### PR TITLE
Handle the case where there are multiple bundled pip wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Updated pip from 23.0.1 to 23.1.2. ([#1441](https://github.com/heroku/heroku-buildpack-python/pull/1441))
 - Updated setuptools from 67.6.1 to 67.7.2. ([#1441](https://github.com/heroku/heroku-buildpack-python/pull/1441))
-- The pip bootstrap step is now performed using the pip wheel bundled with the Python stdlib, rather than one downloaded from S3. ([#1442](https://github.com/heroku/heroku-buildpack-python/pull/1442))
+- The pip bootstrap step is now performed using the pip wheel bundled with the Python stdlib, rather than one downloaded from S3. ([#1442](https://github.com/heroku/heroku-buildpack-python/pull/1442) and [#1444](https://github.com/heroku/heroku-buildpack-python/pull/1444))
 
 ## v231 (2023-04-12)
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -182,8 +182,12 @@ puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and w
 # Python bundles Pip within its standard library, which we can use to install our chosen
 # pip version from PyPI, saving us from having to download the usual pip bootstrap script.
 # We have to use a glob since the bundled wheel filename contains the pip version, which
-# differs between Python versions.
-BUNDLED_PIP_WHEEL="$(compgen -G ".heroku/python/lib/python*/ensurepip/_bundled/pip-*.whl" || true)"
+# differs between Python versions. We also have to handle the case where there are multiple
+# matching pip wheels, since in some versions of Python (eg 3.9.0) multiple versions of pip
+# were accidentally bundled upstream. Note: This implementation relies upon `nullglob` being
+# set, which is the case thanks to the `bin/utils` that was run earlier.
+BUNDLED_PIP_WHEEL_LIST=(.heroku/python/lib/python*/ensurepip/_bundled/pip-*.whl)
+BUNDLED_PIP_WHEEL="${BUNDLED_PIP_WHEEL_LIST[0]}"
 
 if [[ -z "${BUNDLED_PIP_WHEEL}" ]]; then
   mcount "failure.python.locate-bundled-pip-wheel"


### PR DESCRIPTION
In some older versions of Python multiple pip wheels have been accidentally bundled with the Python stdlib upstream. For example in Python 3.9.0 (which has been superseded by newer patch versions of Python 3.9.x): 
https://github.com/python/cpython/tree/v3.9.0/Lib/ensurepip/_bundled

After #1442, this results in eg:

```
-----> Installing pip 23.1.2, setuptools 67.7.2 and wheel 0.40.0
/app/.heroku/python/bin/python: can't open file '/build/.heroku/python/lib/python3.9/ensurepip/_bundled/pip-20.2.1-py2.py3-none-any.whl
.heroku/python/lib/python3.9/ensurepip/_bundled/pip-20.2.3-py2.py3-none-any.whl/pip': [Errno 2] No such file or directory
```

Whilst these affected Python versions are old/insecure and not available on newer stacks, we should still make sure they work as expected.

As such, the lookup of the bundled pip wheel needs to handle this case, which it now does by just picking the first found pip wheel.

This was spotted via https://heroku.support/1245122, which was from an app using the `main` branch of this buildpack (since #1442 hasn't yet been released to the buildpack registry).

GUS-W-13111316.