### PR TITLE
Update setuptools from 67.7.2 to 67.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Python 3.7.17, 3.8.17, 3.9.17, 3.10.12 and 3.11.4 are now available ([#1454](https://github.com/heroku/heroku-buildpack-python/pull/1454)).
 - The default Python version for new apps is now 3.11.4 (previously 3.11.3) ([#1454](https://github.com/heroku/heroku-buildpack-python/pull/1454)).
+- Updated setuptools from 67.7.2 to 67.8.0. ([#1456](https://github.com/heroku/heroku-buildpack-python/pull/1456))
 - Removed support for Heroku-18. ([#1449](https://github.com/heroku/heroku-buildpack-python/pull/1449))
 
 ## v232 (2023-04-27)

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -145,7 +145,7 @@ else
 fi
 
 PIP_VERSION='23.1.2'
-SETUPTOOLS_VERSION='67.7.2'
+SETUPTOOLS_VERSION='67.8.0'
 WHEEL_VERSION='0.40.0'
 
 puts-step "Installing pip ${PIP_VERSION}, setuptools ${SETUPTOOLS_VERSION} and wheel ${WHEEL_VERSION}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ LATEST_PYTHON_3_11 = '3.11.4'
 DEFAULT_PYTHON_VERSION = LATEST_PYTHON_3_11
 
 PIP_VERSION = '23.1.2'
-SETUPTOOLS_VERSION = '67.7.2'
+SETUPTOOLS_VERSION = '67.8.0'
 WHEEL_VERSION = '0.40.0'
 
 # Work around the return value for `default_buildpack` changing after deploy:


### PR DESCRIPTION
https://setuptools.pypa.io/en/stable/history.html#v67-8-0
https://github.com/pypa/setuptools/compare/v67.7.2...v67.8.0

This is the classic buildpack equivalent of:
https://github.com/heroku/buildpacks-python/pull/43

GUS-W-13551852.