### PR TITLE
Update Python 3.7 deprecation message now it has reached EOL

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-and-upload-heroku-22:
     # We only support Python 3.9+ on Heroku-22.
-    if: (!startsWith(inputs.python_version, '3.7.') && !startsWith(inputs.python_version,'3.8.'))
+    if: (!startsWith(inputs.python_version,'3.8.'))
     runs-on: pub-hk-ubuntu-22.04-xlarge
     env:
       STACK_VERSION: "22"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update the Python 3.7 deprecation message to reflect that it has now reached end-of-life. ([#1460](https://github.com/heroku/heroku-buildpack-python/pull/1460))
 
 ## v233 (2023-06-07)
 

--- a/README.md
+++ b/README.md
@@ -64,4 +64,3 @@ Supported runtime options include:
 - `python-3.10.12` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.9.17` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.8.17` on Heroku-20 only
-- `python-3.7.17` on Heroku-20 only

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -59,9 +59,11 @@ case "${PYTHON_VERSION}" in
     ;;
   python-3.7.*)
     puts-warn
-    puts-warn "Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which"
-    puts-warn "point it will no longer receive security updates:"
+    puts-warn "Python 3.7 reached its upstream end-of-life on June 27th, 2023, so no longer"
+    puts-warn "receives any security updates:"
     puts-warn "https://devguide.python.org/versions/#supported-versions"
+    puts-warn
+    puts-warn "Support for Python 3.7 will be removed from this buildpack in October 2023."
     puts-warn
     puts-warn "Upgrade to a newer Python version as soon as possible to keep your app secure."
     puts-warn "See: https://devcenter.heroku.com/articles/python-runtimes"

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -114,9 +114,11 @@ RSpec.describe 'Pipenv support' do
             remote: -----> Python app detected
             remote: -----> Using Python version specified in Pipfile.lock
             remote:  !     
-            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
-            remote:  !     point it will no longer receive security updates:
+            remote:  !     Python 3.7 reached its upstream end-of-life on June 27th, 2023, so no longer
+            remote:  !     receives any security updates:
             remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.7 will be removed from this buildpack in October 2023.
             remote:  !     
             remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -67,9 +67,11 @@ RSpec.describe 'Python update warnings' do
             remote: -----> Python app detected
             remote: -----> Using Python version specified in runtime.txt
             remote:  !     
-            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
-            remote:  !     point it will no longer receive security updates:
+            remote:  !     Python 3.7 reached its upstream end-of-life on June 27th, 2023, so no longer
+            remote:  !     receives any security updates:
             remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.7 will be removed from this buildpack in October 2023.
             remote:  !     
             remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -119,9 +119,11 @@ RSpec.describe 'Python version support' do
             remote: -----> Python app detected
             remote: -----> Using Python version specified in runtime.txt
             remote:  !     
-            remote:  !     Python 3.7 will reach its upstream end-of-life on June 27th, 2023, at which
-            remote:  !     point it will no longer receive security updates:
+            remote:  !     Python 3.7 reached its upstream end-of-life on June 27th, 2023, so no longer
+            remote:  !     receives any security updates:
             remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.7 will be removed from this buildpack in October 2023.
             remote:  !     
             remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes


### PR DESCRIPTION
As of 30th June, Python 3.7 has reached end-of-life upstream:
https://devguide.python.org/versions/#supported-versions

This means there will be no new Python 3.7 patch versions released upstream, so no security updates or bug fixes.

The existing buildpack deprecation message has been updated to reflect this, and now also mentions that support for building Python 3.7 apps will be removed in October 2023.

In addition, the scripts and GitHub Actions workflows used to compile and upload new Python runtime versions have been updated to drop support, since there will be no new Python 3.7 releases for us to upload.

GUS-W-13717141.
GUS-W-13717143.