### PR TITLE
Update AWS_DEFAULT_REGION to match the current S3 region

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -20,7 +20,7 @@ permissions:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: "us-west-2"
+  AWS_DEFAULT_REGION: "us-east-1"
   S3_BUCKET: "heroku-buildpack-python"
 
 # Unfortunately these jobs cannot be easily written as a matrix since `matrix.exclude` does not


### PR DESCRIPTION
The AWS CLI requires that the `AWS_DEFAULT_REGION` env var be set in order for authentication to work.

Previously `AWS_DEFAULT_REGION` was set to `us-west-2`, however, this is different from the region our S3 buckets are in (`us-east-1`).

Whilst this doesn't affect the command we run at all (ie: this PR is a no-op in terms of functionality), it caused confusion recently as to what region the Python bucket was in, so for clarity the default value has now been changed to match the region of the S3 bucket `heroku-buildpack-python`.