### PR TITLE
Group minor/patch version Ruby Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       - "dependencies"
       - "ruby"
       - "skip changelog"
+    groups:
+      ruby-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This aims to reduces Dependabot PR noise by enabling Dependabot's new semver version level grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

It's only enabled for Ruby dependencies, since for this repo they are typically the most noisy, plus they are development-only dependencies that typically don't need any compatibility changes so bundling them together won't make debugging any harder.

GUS-W-13990911.