### PR TITLE
Update pipenv tests

### DIFF
--- a/spec/fixtures/pipenv_python_3.10/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.10/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.11/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.11/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.7/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.7/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.8/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.8/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_3.9/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_3.9/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_full_version/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_full_version/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_full_version_invalid/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_full_version_invalid/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_version_invalid/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_version_invalid/Pipfile.lock
@@ -18,11 +18,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/fixtures/pipenv_python_version_unspecified/Pipfile.lock
+++ b/spec/fixtures/pipenv_python_version_unspecified/Pipfile.lock
@@ -16,11 +16,12 @@
     "default": {
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
             "index": "pypi",
-            "version": "==1.26.14"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
         }
     },
     "develop": {}

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -171,19 +171,7 @@ RSpec.describe 'Pipenv support' do
   context 'with a Pipfile.lock containing python_version 3.11' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.11') }
 
-    it 'builds with the latest Python 3.11' do
-      app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
-          remote: -----> Python app detected
-          remote: -----> Using Python version specified in Pipfile.lock
-          remote: -----> Installing python-#{LATEST_PYTHON_3_11}
-          remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
-          remote: -----> Installing dependencies with Pipenv #{PIPENV_VERSION}
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
-          remote: -----> Installing SQLite3
-        REGEX
-      end
-    end
+    include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_11
   end
 
   context 'with a Pipfile.lock containing python_full_version 3.10.7' do


### PR DESCRIPTION
* Refresh fixtures to use latest version of dependencies
* Switch the Pipenv Python 3.11 test back to using the standard `include_examples` used by other versions (now that Pipenv no longer outputs deprecation warnings on Python 3.11)

This cleanup has been split out of the upcoming Python 3.12 PR.

GUS-W-14217111.