### PR TITLE
Migrate away from the deprecated `pkgutil.find_loader()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed `pkgutil.find_loader` deprecation warning when using Python 3.12. ([#1493](https://github.com/heroku/heroku-buildpack-python/pull/1493))
 
 ## v236 (2023-10-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v237 (2023-10-03)
+
 - Fixed `pkgutil.find_loader` deprecation warning when using Python 3.12. ([#1493](https://github.com/heroku/heroku-buildpack-python/pull/1493))
 
 ## v236 (2023-10-02)

--- a/bin/utils
+++ b/bin/utils
@@ -58,12 +58,10 @@ measure-size() {
   echo "$(du -s .heroku/python 2>/dev/null || echo 0) | awk '{print $1}')"
 }
 
+# Returns 0 if the specified module exists, otherwise returns 1.
 is_module_available() {
-  # Returns 0 if the specified module exists, otherwise returns 1.
-  # Uses pkgutil rather than pkg_resources or pip's CLI, since pkgutil exists
-  # in the stdlib, and doesn't depend on the choice of package manager.
   local module_name="${1}"
-  python -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('${module_name}') else 1)"
+  python -c "import sys, importlib.util; sys.exit(0 if importlib.util.find_spec('${module_name}') else 1)"
 }
 
 # The requirement versions are effectively buildpack constants, however, we want


### PR DESCRIPTION
In the newly released Python 3.12, the `pkgutil.find_loader()` API was deprecated:
https://docs.python.org/3.12/library/pkgutil.html#pkgutil.find_loader

This API was used by the buildpack to determine whether certain packages (like `django` or `nltk`) are installed.

It's been replaced by `importlib.util.find_spec` which has been supported since Python 3.4 (which is fine for us to use now, but wasn't an option back when `is_module_available()` was written, since at that time the buildpack still had to support Python 2.7):
https://docs.python.org/3.12/library/importlib.html#importlib.util.find_spec

Using the old API results in deprecation warnings being output in the build log:

```
<string>:1: DeprecationWarning: 'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead
```

These deprecation warnings also prevent the output from `bin/release` being parsed correctly for Django apps, resulting in:

```
failed to read buildpack metadata: (<unknown>): mapping values are not allowed in this context at line 1 column 31
```

These can be seen in the Heroku CI tests and Review App build logs of this PR which upgrades the Python getting started guide app to Python 3.12:
https://github.com/heroku/python-getting-started/pull/209
https://dashboard.heroku.com/pipelines/4826c212-2bb2-4882-a147-4d0501eee7a4/tests/190
https://dashboard.heroku.com/apps/getting-star-edmorley-p-biivve/activity/builds/a6feca96-d451-4f01-b66d-c5d2185d5107

GUS-W-14230170.