### PR TITLE
Change Dependabot pip directory to repo root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       - "github actions"
       - "skip changelog"
   - package-ecosystem: "pip"
-    directory: "/requirements"
+    directory: "/"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
Since Dependabot will find the `requirements/` directory automatically, and by using the repo root we avoid the unnecessary `in /requirements` suffix on all Python Dependabot PR titles.