### PR TITLE
Add a deprecation warning for Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add a deprecation warning for Python 3.8. ([#1515](https://github.com/heroku/heroku-buildpack-python/pull/1515))
 
 ## [v240] - 2023-11-30
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -58,6 +58,16 @@ case "${PYTHON_VERSION}" in
     warn_if_patch_update_available "${PYTHON_VERSION}" "${LATEST_39}"
     ;;
   python-3.8.*)
+    puts-warn
+    puts-warn "Python 3.8 will reach its upstream end-of-life in October 2024, at which"
+    puts-warn "point it will no longer receive security updates:"
+    puts-warn "https://devguide.python.org/versions/#supported-versions"
+    puts-warn
+    puts-warn "Support for Python 3.8 will be removed from this buildpack on December 4th, 2024."
+    puts-warn
+    puts-warn "Upgrade to a newer Python version as soon as possible to keep your app secure."
+    puts-warn "See: https://devcenter.heroku.com/articles/python-runtimes"
+    puts-warn
     warn_if_patch_update_available "${PYTHON_VERSION}" "${LATEST_38}"
     ;;
   python-3.7.*)

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -139,7 +139,29 @@ RSpec.describe 'Pipenv support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.8', allow_failure:) }
 
     context 'when using Heroku-20', stacks: %w[heroku-20] do
-      include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_8
+      it 'builds with the latest Python 3.8 but shows a deprecation warning' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in Pipfile.lock
+            remote:  !     
+            remote:  !     Python 3.8 will reach its upstream end-of-life in October 2024, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-#{LATEST_PYTHON_3_8}
+            remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
+            remote: -----> Installing dependencies with Pipenv #{PIPENV_VERSION}
+            remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
+            remote: -----> Installing SQLite3
+          REGEX
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -61,7 +61,29 @@ RSpec.describe 'Python update warnings' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8_outdated', allow_failure:) }
 
     context 'when using Heroku-20', stacks: %w[heroku-20] do
-      include_examples 'warns there is a Python update available', '3.8.12', LATEST_PYTHON_3_8
+      it 'warns about both the deprecated major version and the patch update' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
+            remote:  !     
+            remote:  !     Python 3.8 will reach its upstream end-of-life in October 2024, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote:  !     
+            remote:  !     A Python security update is available! Upgrade as soon as possible to: python-#{LATEST_PYTHON_3_8}
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-3.8.12
+          REGEX
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -142,7 +142,30 @@ RSpec.describe 'Python version support' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.8', allow_failure:) }
 
     context 'when using Heroku-20', stacks: %w[heroku-20] do
-      include_examples 'builds with the requested Python version', LATEST_PYTHON_3_8
+      it 'builds with Python 3.8.18 but shows a deprecation warning' do
+        app.deploy do |app|
+          expect(clean_output(app.output)).to include(<<~OUTPUT)
+            remote: -----> Python app detected
+            remote: -----> Using Python version specified in runtime.txt
+            remote:  !     
+            remote:  !     Python 3.8 will reach its upstream end-of-life in October 2024, at which
+            remote:  !     point it will no longer receive security updates:
+            remote:  !     https://devguide.python.org/versions/#supported-versions
+            remote:  !     
+            remote:  !     Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+            remote:  !     
+            remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
+            remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes
+            remote:  !     
+            remote: -----> Installing python-#{LATEST_PYTHON_3_8}
+            remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
+            remote: -----> Installing SQLite3
+            remote: -----> Installing requirements with pip
+            remote:        Collecting urllib3 (from -r requirements.txt (line 1))
+          OUTPUT
+          expect(app.run('python -V')).to include("Python #{LATEST_PYTHON_3_8}")
+        end
+      end
     end
 
     context 'when using Heroku-22', stacks: %w[heroku-22] do


### PR DESCRIPTION
Since it has <1 year left of its 5 year support lifecycle: https://devguide.python.org/versions/#supported-versions

This uses the same approach as for Python 3.7 in #1404.

GUS-W-14607855.