### PR TITLE
Fix caching of editable VCS Pipenv dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated pip from 23.3.1 to 23.3.2. ([#1524](https://github.com/heroku/heroku-buildpack-python/pull/1524))
 - Fixed repeat/cached Pipenv builds of local `file =` dependencies. ([#1526](https://github.com/heroku/heroku-buildpack-python/pull/1526))
+- Fixed the caching of editable VCS Pipenv dependency repositories. ([#1528](https://github.com/heroku/heroku-buildpack-python/pull/1528))
 
 ## [v241] - 2023-12-08
 

--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -28,7 +28,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         exit 1
     fi
 
-    /app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
+    /app/.heroku/python/bin/pip install -r requirements.txt --exists-action=w --src='/app/.heroku/src' --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e
 
@@ -46,7 +46,7 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
     if [ "$INSTALL_TEST" ]; then
         if [[ -f requirements-test.txt ]]; then
             puts-step "Installing test dependencies…"
-            /app/.heroku/python/bin/pip install -r requirements-test.txt --exists-action=w --src=./.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
+            /app/.heroku/python/bin/pip install -r requirements-test.txt --exists-action=w --src='/app/.heroku/src' --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
         fi
     fi
 fi

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -38,18 +38,18 @@ if [[ -f Pipfile ]]; then
     # Install the test dependencies, for CI.
     if [ "$INSTALL_TEST" ]; then
         puts-step "Installing test dependencies"
-        /app/.heroku/python/bin/pipenv install --dev --system --deploy 2>&1 | cleanup | indent
+        /app/.heroku/python/bin/pipenv install --dev --system --deploy --extra-pip-args='--src=/app/.heroku/src' 2>&1 | cleanup | indent
 
     # Install the dependencies.
     elif [[ ! -f Pipfile.lock ]]; then
         puts-step "Installing dependencies with Pipenv ${PIPENV_VERSION}"
-        /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
+        /app/.heroku/python/bin/pipenv install --system --skip-lock --extra-pip-args='--src=/app/.heroku/src' 2>&1 | indent
 
     else
         pipenv-to-pip Pipfile.lock > requirements.txt
         cp requirements.txt .heroku/python/requirements-declared.txt
 
         puts-step "Installing dependencies with Pipenv ${PIPENV_VERSION}"
-        /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
+        /app/.heroku/python/bin/pipenv install --system --deploy --extra-pip-args='--src=/app/.heroku/src' 2>&1 | indent
     fi
 fi

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe 'Pipenv support' do
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
           remote: .*
@@ -351,7 +351,7 @@ RSpec.describe 'Pipenv support' do
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
           remote: import __editable___.*
           remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: .
           remote: ==> .heroku/python/lib/python.*/site-packages/local_package_setup_py.egg-link <==
           remote: /tmp/build_.*/packages/local_package_setup_py
@@ -365,7 +365,7 @@ RSpec.describe 'Pipenv support' do
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
           remote: .*
@@ -375,7 +375,7 @@ RSpec.describe 'Pipenv support' do
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
           remote: import __editable___.*
           remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: .
           remote: ==> .heroku/python/lib/python.*/site-packages/local_package_setup_py.egg-link <==
           remote: /tmp/build_.*/packages/local_package_setup_py
@@ -392,7 +392,7 @@ RSpec.describe 'Pipenv support' do
 
           ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
           /app/packages/local_package_setup_py
-          /app/src/gunicorn
+          /app/.heroku/src/gunicorn
 
           ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
           .*
@@ -402,7 +402,7 @@ RSpec.describe 'Pipenv support' do
           ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
           import __editable___.*
           ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          /app/src/gunicorn
+          /app/.heroku/src/gunicorn
           .
           ==> .heroku/python/lib/python.*/site-packages/local_package_setup_py.egg-link <==
           /app/packages/local_package_setup_py
@@ -421,8 +421,8 @@ RSpec.describe 'Pipenv support' do
           remote: .*
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
+          remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /tmp/build_.*/src/gunicorn
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
           remote: .*
@@ -432,7 +432,7 @@ RSpec.describe 'Pipenv support' do
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
           remote: import __editable___.*
           remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: .
           remote: ==> .heroku/python/lib/python.*/site-packages/local_package_setup_py.egg-link <==
           remote: /tmp/build_.*/packages/local_package_setup_py
@@ -445,8 +445,8 @@ RSpec.describe 'Pipenv support' do
           remote: .*
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
+          remote: /app/.heroku/src/gunicorn
           remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /tmp/build_.*/src/gunicorn
           remote: 
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
           remote: .*
@@ -456,7 +456,7 @@ RSpec.describe 'Pipenv support' do
           remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
           remote: import __editable___.*
           remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /tmp/build_.*/src/gunicorn
+          remote: /app/.heroku/src/gunicorn
           remote: .
           remote: ==> .heroku/python/lib/python.*/site-packages/local_package_setup_py.egg-link <==
           remote: /tmp/build_.*/packages/local_package_setup_py


### PR DESCRIPTION
When installing a VCS dependency in editable mode, the source repository has to be git cloned somewhere, and that location referenced via a `.pth` file added to `site-packages`.

Previously, when using Pipenv the default source repository location was used, which is a `src/` directory inside the current working directory. ie: `/app/src/`.

However, this directory is not preserved/cached across builds, meaning that on the next Pipenv install the repository has to be cloned from scratch.

Now, the source repository location when using Pipenv has been overridden to `/app/.heroku/src/`, which is cached, and matches the location used for Pip projects. This is configured via Pipenv's `--extra-pip-args` feature:
https://pipenv.pypa.io/en/latest/advanced.html#supplying-additional-arguments-to-pip

Lastly, the standard Pip install invocation args have been tweaked to consistently use quotes and the absolute path.

Fixes #1527.
GUS-W-14764812.