### PR TITLE
Update Pip log output test assertion after PyPI metadata backfill

### DIFF
--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe 'Pip support' do
           remote:        Collecting six \\(from -r requirements.txt \\(line 2\\)\\)
           remote:          Downloading six-.*
           remote:        Downloading urllib3-.*
+          remote:        Downloading six-.*
           remote:        Installing collected packages: urllib3, six
           remote:        Successfully installed six-.* urllib3-.*
         REGEX


### PR DESCRIPTION
Pip prints slightly different log output depending on whether the package being installed has the new [PEP 658](https://peps.python.org/pep-0658/) `.metadata` file available on PyPI.

Until now, only packages uploaded to PyPI since the feature was implemented had this metadata generated by PyPI, however, the metadata file has now been backfilled for older packages too:
https://github.com/pypi/warehouse/issues/8254#issuecomment-1975234143

As a result, the Pip support log output assertion needs updating for the new output, to fix CI on `main`:
https://github.com/heroku/heroku-buildpack-python/actions/runs/8138313649/job/22238825835?pr=1545#step:5:479

GUS-W-15172805.