### PR TITLE
Test WEB_CONCURRENCY calculation for larger dyno sizes

### DIFF
--- a/spec/hatchet/profile_d_scripts_spec.rb
+++ b/spec/hatchet/profile_d_scripts_spec.rb
@@ -110,6 +110,36 @@ RSpec.describe '.profile.d/ scripts' do
         OUTPUT
       end
 
+      # Performance-L-RAM
+      app.run_multi(list_concurrency_envs_cmd, heroku: { size: 'performance-l-ram', type: 'web' }) do |output, _|
+        expect(output).to eq(<<~OUTPUT)
+          Python buildpack: Detected 30720 MB available memory and 4 CPU cores.
+          Python buildpack: Defaulting WEB_CONCURRENCY to 9 based on the number of CPU cores.
+          DYNO_RAM=30720
+          WEB_CONCURRENCY=9
+        OUTPUT
+      end
+
+      # Performance-XL
+      app.run_multi(list_concurrency_envs_cmd, heroku: { size: 'performance-xl', type: 'web' }) do |output, _|
+        expect(output).to eq(<<~OUTPUT)
+          Python buildpack: Detected 63488 MB available memory and 8 CPU cores.
+          Python buildpack: Defaulting WEB_CONCURRENCY to 17 based on the number of CPU cores.
+          DYNO_RAM=63488
+          WEB_CONCURRENCY=17
+        OUTPUT
+      end
+
+      # Performance-2XL
+      app.run_multi(list_concurrency_envs_cmd, heroku: { size: 'performance-2xl', type: 'web' }) do |output, _|
+        expect(output).to eq(<<~OUTPUT)
+          Python buildpack: Detected 129024 MB available memory and 16 CPU cores.
+          Python buildpack: Defaulting WEB_CONCURRENCY to 33 based on the number of CPU cores.
+          DYNO_RAM=129024
+          WEB_CONCURRENCY=33
+        OUTPUT
+      end
+
       # Check that WEB_CONCURRENCY is preserved if set, but that we still set DYNO_RAM.
       app.run_multi(list_concurrency_envs_cmd, heroku: { env: 'WEB_CONCURRENCY=999', type: 'web' }) do |output, _|
         expect(output).to eq(<<~OUTPUT)

--- a/vendor/WEB_CONCURRENCY.sh
+++ b/vendor/WEB_CONCURRENCY.sh
@@ -14,6 +14,9 @@
 # - Standard-2X / Private-S / Shield-S: 4 (capped by the 1 GB available memory)
 # - Performance-M / Private-M / Shield-M: 5 (based on the 2 CPU cores)
 # - Performance-L / Private-L / Shield-L: 17 (based on the 8 CPU cores)
+# - Performance-L-RAM / Private-L-RAM / Shield-L-RAM: 9 (based on the 4 CPU cores)
+# - Performance-XL / Private-XL / Shield-XL: 17 (based on the 8 CPU cores)
+# - Performance-2XL / Private-2XL / Shield-2XL: 33 (based on the 16 CPU cores)
 #
 # To override these default values, either set `WEB_CONCURRENCY` as an explicit config var
 # on the app, or pass `--workers <num>` when invoking gunicorn/uvicorn in your Procfile.


### PR DESCRIPTION
Adds tests for the automatic WEB_CONCURRENCY calculation for the larger dyno sizes that were just announced:
https://devcenter.heroku.com/changelog-items/2848

GUS-W-15350360.
