### PR TITLE
Adjust compiler options used to build Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Adjusted compiler options used to build Python for improved parity with the Docker Hub Python images. ([#1566](https://github.com/heroku/heroku-buildpack-python/pull/1566))
 - Excluded `LD_LIBRARY_PATH` and `PYTHONHOME` app config vars when invoking subprocesses during the build. ([#1565](https://github.com/heroku/heroku-buildpack-python/pull/1565))
 
 ## [v248] - 2024-04-09


### PR DESCRIPTION
In order to improve parity with the upstream Docker Hub Python image builds, the build scripts used for our Python binary builds have been adjusted as follows:
- The Ubuntu security hardening compiler/linker flags are now retrieved using `dpkg-buildflags` and passed to the `make` invocation. See:
    - https://wiki.ubuntu.com/ToolChain/CompilerFlags
    - https://wiki.debian.org/Hardening
    - https://github.com/docker-library/python/issues/810
- Configure is now called with an explicit `--build` architecture.
- The directory into which Python is installed during packaging has been changed to make it clearer that this it is only a temporary packaging path (and so why this path doesn't match that used in the CNB for example), since Python is relocated by both this buildpack and the CNB into different locations.

After these changes, our compiler/linker options are now closer to:
https://github.com/docker-library/python/blob/330331fbe3c8d19befaba10ee329c5bf3a9dc225/3.12/slim-bookworm/Dockerfile#L70-L89

These changes are being made now since we'll soon be generating new Python binaries/archives under a new URL structure, which will provide a safer/more convenient transition point to switching to these new compiler options (vs overwriting the existing archives on S3, or only making this change for new Python releases onwards).

GUS-W-14217295.