### PR TITLE
Fix the "Python security update available" version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the "Python security update is available" warning being shown when the requested version is newer than the latest version known to the buildpack. ([#1569](https://github.com/heroku/heroku-buildpack-python/pull/1569))
 - Fixed glibc warnings seen when downgrading the stack version. ([#1568](https://github.com/heroku/heroku-buildpack-python/pull/1568))
 - Adjusted compiler options used to build Python for improved parity with the Docker Hub Python images. ([#1566](https://github.com/heroku/heroku-buildpack-python/pull/1566))
 - Excluded `LD_LIBRARY_PATH` and `PYTHONHOME` app config vars when invoking subprocesses during the build. ([#1565](https://github.com/heroku/heroku-buildpack-python/pull/1565))

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -32,9 +32,12 @@ function eol_python_version_error() {
 }
 
 function warn_if_patch_update_available() {
-  local current_version="${1}"
+  local requested_version="${1}"
   local latest_patch_version="${2}"
-  if [[ "${current_version}" != "${latest_patch_version}" ]]; then
+  # Extract the patch version component of the version strings (ie: the '5' in '3.10.5').
+  local requested_patch_number="${requested_version##*.}"
+  local latest_patch_number="${latest_patch_version##*.}"
+  if (( requested_patch_number < latest_patch_number )); then
     puts-warn
     puts-warn "A Python security update is available! Upgrade as soon as possible to: ${latest_patch_version}"
     puts-warn "See: https://devcenter.heroku.com/articles/python-runtimes"


### PR DESCRIPTION
Previously the "Python security update is available" message was shown if the requested Python version does not exactly equal what the buildpack believes to be the latest Python patch version for that major release.

However, this means that the message is then incorrectly shown if the current version is actually newer than the latest version the buildpack knows about.

This scenario can occur:
(a) During the small time window when a new Python version has been built and uploaded to S3 but the buildpack updates have not yet been released.
(b) If an app pins to an older buildpack version but manually requests a newer Python patch release.

It's not possible to add an integration test for this specific case, since using a fake future version (like Python 3.12.999) will fail prior to the version check due to it not existing on S3. (The scenario being fixed is effectively a race condition that we can't emulate.)

However, the security version numbers are tested in general:
https://github.com/heroku/heroku-buildpack-python/blob/main/spec/hatchet/python_update_warning_spec.rb

GUS-W-15541305.