### PR TITLE
Add Python binary build support for Heroku-24

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -15,6 +15,7 @@ on:
           - auto
           - heroku-20
           - heroku-22
+          - heroku-24
         default: auto
         required: false
       dry_run:
@@ -62,6 +63,39 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build --platform="linux/amd64" --pull --tag buildenv --build-arg=STACK_VERSION builds/
+      - name: Build and package Python runtime
+        run: docker run --rm --volume="${PWD}/upload:/tmp/upload" buildenv ./build_python_runtime.sh "${{ inputs.python_version }}"
+      - name: Upload Python runtime archive to S3
+        if: (!inputs.dry_run)
+        run: aws s3 sync ./upload "s3://${S3_BUCKET}"
+
+  heroku-24:
+    # On Heroku-24 we only support Python 3.12+.
+    if: inputs.stack == 'heroku-24' || (inputs.stack == 'auto' && startsWith(inputs.python_version,'3.12.'))
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: ["amd64", "arm64"]
+    runs-on: ${{ matrix.architecture == 'arm64' && 'pub-hk-ubuntu-22.04-arm-large' || 'pub-hk-ubuntu-22.04-xlarge' }}
+    env:
+      STACK_VERSION: "24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # The beta Arm64 runners don't yet ship with the normal installed tools.
+      - name: Install Docker and AWS CLI (ARM64 only)
+        if: matrix.architecture == 'arm64'
+        run: |
+          sudo apt-get update --error-on=any
+          sudo apt-get install -y --no-install-recommends acl docker.io docker-buildx unzip
+          sudo usermod -aG docker $USER
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+          curl https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip -o awscliv2.zip
+          unzip awscliv2.zip
+          sudo ./aws/install
+          rm -rf awscliv2.zip ./aws/
+      - name: Build Docker image
+        run: docker build --platform="linux/${{ matrix.architecture }}" --pull --tag buildenv --build-arg=STACK_VERSION builds/
       - name: Build and package Python runtime
         run: docker run --rm --volume="${PWD}/upload:/tmp/upload" buildenv ./build_python_runtime.sh "${{ inputs.python_version }}"
       - name: Upload Python runtime archive to S3

--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -1,8 +1,11 @@
-ARG STACK_VERSION="22"
+ARG STACK_VERSION="24"
 FROM heroku/heroku:${STACK_VERSION}-build
 
 ARG STACK_VERSION
 ENV STACK="heroku-${STACK_VERSION}"
+
+# For Heroku-24 and newer, the build image sets a non-root default `USER`.
+USER root
 
 RUN apt-get update --error-on=any \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This adds support for building Python binaries for Heroku-24 using GitHub Actions. Since the Heroku-24 base image supports both `amd64` and `arm64` (to allow for multi-arch CNBs), for Heroku-24 (only) we now also build binaries for both architectures.

A later PR will add support for Heroku-24 to the buildpack itself, however, that depends on (a) the Python binaries already having been built, (b) the Heroku build system for Heroku-24 being ready, so those changes are not being made yet.

GUS-W-15571102.