### PR TITLE
Build Python 3.10 runtimes for Heroku-24 too

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -70,21 +70,21 @@ jobs:
         run: aws s3 sync ./upload "s3://${S3_BUCKET}"
 
   heroku-24:
-    # On Heroku-24 we only support Python 3.11+.
-    if: inputs.stack == 'heroku-24' || (inputs.stack == 'auto' && !startsWith(inputs.python_version,'3.8.') && !startsWith(inputs.python_version,'3.9.') && !startsWith(inputs.python_version,'3.10.'))
+    # On Heroku-24 we only support Python 3.10+.
+    if: inputs.stack == 'heroku-24' || (inputs.stack == 'auto' && !startsWith(inputs.python_version,'3.8.') && !startsWith(inputs.python_version,'3.9.'))
     strategy:
       fail-fast: false
       matrix:
-        architecture: ["amd64", "arm64"]
-    runs-on: ${{ matrix.architecture == 'arm64' && 'pub-hk-ubuntu-22.04-arm-large' || 'pub-hk-ubuntu-22.04-xlarge' }}
+        arch: ["amd64", "arm64"]
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-large' || 'pub-hk-ubuntu-22.04-xlarge' }}
     env:
       STACK_VERSION: "24"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # The beta Arm64 runners don't yet ship with the normal installed tools.
+      # The beta ARM64 runners don't yet ship with the normal installed tools.
       - name: Install Docker and AWS CLI (ARM64 only)
-        if: matrix.architecture == 'arm64'
+        if: matrix.arch == 'arm64'
         run: |
           sudo apt-get update --error-on=any
           sudo apt-get install -y --no-install-recommends acl docker.io docker-buildx unzip
@@ -95,7 +95,7 @@ jobs:
           sudo ./aws/install
           rm -rf awscliv2.zip ./aws/
       - name: Build Docker image
-        run: docker build --platform="linux/${{ matrix.architecture }}" --pull --tag buildenv --build-arg=STACK_VERSION builds/
+        run: docker build --platform="linux/${{ matrix.arch }}" --pull --tag buildenv --build-arg=STACK_VERSION builds/
       - name: Build and package Python runtime
         run: docker run --rm --volume="${PWD}/upload:/tmp/upload" buildenv ./build_python_runtime.sh "${{ inputs.python_version }}"
       - name: Upload Python runtime archive to S3

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Supported runtime options include:
 
 - `python-3.12.3` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.11.9` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
-- `python-3.10.14` on Heroku-20 and Heroku-22 only
+- `python-3.10.14` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.9.19` on Heroku-20 and Heroku-22 only
 - `python-3.8.19` on Heroku-20 only

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -22,6 +22,7 @@ function error() {
 case "${STACK}" in
   heroku-24)
     SUPPORTED_PYTHON_VERSIONS=(
+      "3.10"
       "3.11"
       "3.12"
     )

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -184,19 +184,9 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'with a Pipfile.lock containing python_version 3.10' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.10', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.10') }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_10
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.10 on Heroku-22 and older.
-      include_examples 'aborts the build with a runtime not available message (Pipenv)', LATEST_PYTHON_3_10
-    end
+    include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_10
   end
 
   context 'with a Pipfile.lock containing python_version 3.11' do

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -94,16 +94,7 @@ RSpec.describe 'Python update warnings' do
     let(:allow_failure) { false }
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10_outdated', allow_failure:) }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'warns there is a Python update available', '3.10.5', LATEST_PYTHON_3_10
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.10 on Heroku-22 and older.
-      include_examples 'aborts the build without showing an update warning', '3.10.5'
-    end
+    include_examples 'warns there is a Python update available', '3.10.5', LATEST_PYTHON_3_10
   end
 
   context 'with a runtime.txt containing python-3.11.0' do

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -192,19 +192,9 @@ RSpec.describe 'Python version support' do
   end
 
   context 'when runtime.txt contains python-3.10.14' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10') }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'builds with the requested Python version', LATEST_PYTHON_3_10
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.10 on Heroku-22 and older.
-      include_examples 'aborts the build with a runtime not available message', "python-#{LATEST_PYTHON_3_10}"
-    end
+    include_examples 'builds with the requested Python version', LATEST_PYTHON_3_10
   end
 
   context 'when runtime.txt contains python-3.11.9' do


### PR DESCRIPTION
Expands the Heroku-24 Python version support to include Python 3.10, in addition to the existing Python 3.11 and 3.12.

This will give more Python version options to CNB users that need ARM64 support, given that it will only available be on Heroku-24+.

I've not added a changelog entry since Heroku-24 is not yet released, so no one is using it anyway, and this is covered by the existing Heroku-24 changelog entry (the previous release of the buildpack will be able to use these binaries from S3 too).

GUS-W-15571102.