### PR TITLE
Explicitly install `libreadline-dev` when building Python runtimes

### DIFF
--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -9,6 +9,7 @@ USER root
 
 RUN apt-get update --error-on=any \
     && apt-get install -y --no-install-recommends \
+      libreadline-dev \
       libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Required so that the Python `readline` and `curses` stdlib modules will be built, now that [libreadline-dev](https://packages.ubuntu.com/noble/libreadline-dev) is intentionally no longer in the Heroku-24 build image: https://github.com/heroku/base-images/pull/296

(These headers are only needed when the Python runtimes are being compiled. The run image still has the necessary runtime library counterparts.)

GUS-W-15159536.