### PR TITLE
Explicitly install `libdb-dev` when building Python runtimes

### DIFF
--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -9,6 +9,7 @@ USER root
 
 RUN apt-get update --error-on=any \
     && apt-get install -y --no-install-recommends \
+      libdb-dev \
       libreadline-dev \
       libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Required so that the Python `dbm.ndbm` stdlib module will be built, now that [libdb-dev](https://packages.ubuntu.com/noble/libdb-dev) is no longer in the Heroku-24 build image:
https://github.com/heroku/base-images/pull/303

(These headers are only needed when the Python runtimes are being compiled. The run image still has the necessary runtime library counterparts.)

GUS-W-15159536.