### PR TITLE
Make Python runtime archive tests more robust

### DIFF
--- a/builds/test_python_runtime.sh
+++ b/builds/test_python_runtime.sh
@@ -9,16 +9,19 @@ ARCHIVE_FILEPATH="${1:?"Error: The filepath of the Python runtime archive must b
 # depend on it). Since the Python binary was built in shared mode, `LD_LIBRARY_PATH` must be set
 # when relocating, so the Python binary (which itself contains very little) can find `libpython`.
 INSTALL_DIR=$(mktemp -d)
-PYTHON="${INSTALL_DIR}/bin/python"
 export LD_LIBRARY_PATH="${INSTALL_DIR}/lib/"
 
 tar --zstd --extract --verbose --file "${ARCHIVE_FILEPATH}" --directory "${INSTALL_DIR}"
 
-# Check Python is usable via the `python` symlink (and not just `python3`) and can start.
-"${PYTHON}" --version
+# Check Python is able to start and is usable via both the default `python3` command and the
+# `python` symlink we create during the build. We use the full filepath rather than adding the
+# directory to PATH to ensure the test doesn't pass because of falling through to system Python.
+"${INSTALL_DIR}/bin/python3" --version
+"${INSTALL_DIR}/bin/python" --version
 
 # Check that all dynamically linked libraries exist in the run image (since it has fewer packages than the build image).
-if find "${INSTALL_DIR}" -name '*.so' -exec ldd '{}' + | grep 'not found'; then
+LDD_OUTPUT=$(find "${INSTALL_DIR}" -type f,l \( -name 'python3' -o -name '*.so*' \) -exec ldd '{}' +)
+if grep 'not found' <<<"${LDD_OUTPUT}" | sort --unique; then
   echo "The above dynamically linked libraries were not found!"
   exit 1
 fi
@@ -39,7 +42,7 @@ optional_stdlib_modules=(
   xml.parsers.expat
   zlib
 )
-if ! "${PYTHON}" -c "import $(IFS=, ; echo "${optional_stdlib_modules[*]}")"; then
+if ! "${INSTALL_DIR}/bin/python3" -c "import $(IFS=, ; echo "${optional_stdlib_modules[*]}")"; then
   echo "The above optional stdlib module failed to import! Check the compile logs to see if it was skipped due to missing libraries/headers."
   exit 1
 fi


### PR DESCRIPTION
- Checks the python binary within the archive too, not just the `.so` libs.
- Checks `.so` libs whose filename doesn't end in `.so`, eg: `libpython3.12.so.1.0`.
- Moves the find/ldd usage out of the conditional, so a non-zero exit code from the find call isn't obscured.
- Removes the `$PYTHON` indirection.
