### PR TITLE
Fix editable mode tests after latest setuptools release

### DIFF
--- a/spec/fixtures/pipenv_editable/bin/test-entrypoints
+++ b/spec/fixtures/pipenv_editable/bin/test-entrypoints
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
-# List the filenames and contents of all .egg-link, .pth, and finder files in site-packages.
-find .heroku/python/lib/python*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' -or -name '__editable___*_finder.py' \) | sort | xargs -exec tail -n +1
+cd .heroku/python/lib/python*/site-packages/
+
+# List any path like strings in .egg-link, .pth, and finder files in site-packages.
+grep --extended-regexp --only-matching '/\S+' *.egg-link *.pth __editable___*_finder.py | sort
 echo
 
 echo -n "Running entrypoint for the pyproject.toml-based local package: "

--- a/spec/fixtures/requirements_editable/bin/test-entrypoints
+++ b/spec/fixtures/requirements_editable/bin/test-entrypoints
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
-# List the filenames and contents of all .egg-link, .pth, and finder files in site-packages.
-find .heroku/python/lib/python*/site-packages/ -type f -and \( -name '*.egg-link' -or -name '*.pth' -or -name '__editable___*_finder.py' \) | sort | xargs -exec tail -n +1
+cd .heroku/python/lib/python*/site-packages/
+
+# List any path like strings in .egg-link, .pth, and finder files in site-packages.
+grep --extended-regexp --only-matching '/\S+' *.egg-link *.pth __editable___*_finder.py | sort
 echo
 
 echo -n "Running entrypoint for the pyproject.toml-based local package: "

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -98,131 +98,61 @@ RSpec.describe 'Pip support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running post-compile hook
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /app/.heroku/src/gunicorn
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /app/.heroku/src/gunicorn
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
         REGEX
 
         # Test rewritten paths work at runtime.
-        expect(app.run('bin/test-entrypoints')).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-          ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          .*
+        expect(app.run('bin/test-entrypoints')).to include(<<~OUTPUT)
+          easy-install.pth:/app/.heroku/src/gunicorn
+          easy-install.pth:/app/packages/local_package_setup_py
+          __editable___local_package_pyproject_toml_0_0_1_finder.py:/app/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          gunicorn.egg-link:/app/.heroku/src/gunicorn
+          local-package-setup-py.egg-link:/app/packages/local_package_setup_py
 
-          ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          /app/packages/local_package_setup_py
-          /app/.heroku/src/gunicorn
-
-          ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          .*
-          MAPPING = \\{'local_package_pyproject_toml': '/app/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          .*
-
-          ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          import __editable___.*
-          ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          /app/.heroku/src/gunicorn
-          .
-          ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          /app/packages/local_package_setup_py
-          .
           Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           Running entrypoint for the setup.py-based local package: Hello setup.py!
-          Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
-        REGEX
+          Running entrypoint for the VCS package: gunicorn (version 20.1.0)
+        OUTPUT
 
         # Test that the cached .pth files work correctly.
         app.commit!
         app.push!
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running post-compile hook
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /app/.heroku/src/gunicorn
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /app/.heroku/src/gunicorn
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -349,131 +349,61 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running post-compile hook
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /app/.heroku/src/gunicorn
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: /app/.heroku/src/gunicorn
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
         REGEX
 
         # Test rewritten paths work at runtime.
-        expect(app.run('bin/test-entrypoints')).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-          ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          .*
+        expect(app.run('bin/test-entrypoints')).to include(<<~OUTPUT)
+          easy-install.pth:/app/.heroku/src/gunicorn
+          easy-install.pth:/app/packages/local_package_setup_py
+          __editable___local_package_pyproject_toml_0_0_1_finder.py:/app/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          gunicorn.egg-link:/app/.heroku/src/gunicorn
+          local-package-setup-py.egg-link:/app/packages/local_package_setup_py
 
-          ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          /app/packages/local_package_setup_py
-          /app/.heroku/src/gunicorn
-
-          ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          .*
-          MAPPING = \\{'local_package_pyproject_toml': '/app/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          .*
-
-          ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          import __editable___.*
-          ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          /app/.heroku/src/gunicorn
-          .
-          ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          /app/packages/local_package_setup_py
-          .
           Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           Running entrypoint for the setup.py-based local package: Hello setup.py!
-          Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
-        REGEX
+          Running entrypoint for the VCS package: gunicorn (version 20.1.0)
+        OUTPUT
 
         # Test that the cached .pth files work correctly.
         app.commit!
         app.push!
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running post-compile hook
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /app/.heroku/src/gunicorn
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Inline app detected
-          remote: ==> .heroku/python/lib/python.*/site-packages/distutils-precedence.pth <==
-          remote: .*
+          remote: easy-install.pth:/app/.heroku/src/gunicorn
+          remote: easy-install.pth:/tmp/build_.*/packages/local_package_setup_py
+          remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
+          remote: gunicorn.egg-link:/app/.heroku/src/gunicorn
+          remote: local-package-setup-py.egg-link:/tmp/build_.*/packages/local_package_setup_py
           remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/easy-install.pth <==
-          remote: /app/.heroku/src/gunicorn
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable___local_package_pyproject_toml_0_0_1_finder.py <==
-          remote: .*
-          remote: MAPPING = \\{'local_package_pyproject_toml': '/tmp/build_.*/packages/local_package_pyproject_toml/local_package_pyproject_toml'\\}
-          remote: .*
-          remote: 
-          remote: ==> .heroku/python/lib/python.*/site-packages/__editable__.local_package_pyproject_toml-0.0.1.pth <==
-          remote: import __editable___.*
-          remote: ==> .heroku/python/lib/python.*/site-packages/gunicorn.egg-link <==
-          remote: /app/.heroku/src/gunicorn
-          remote: .
-          remote: ==> .heroku/python/lib/python.*/site-packages/local-package-setup-py.egg-link <==
-          remote: /tmp/build_.*/packages/local_package_setup_py
-          remote: .
           remote: Running entrypoint for the pyproject.toml-based local package: Hello pyproject.toml!
           remote: Running entrypoint for the setup.py-based local package: Hello setup.py!
           remote: Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)


### PR DESCRIPTION
This fixes the editable mode tests that are currently failing on `main` after the most recent setuptools release:
https://github.com/heroku/heroku-buildpack-python/actions/runs/9189160606

These tests have to test packaging implementation details since the buildpack has to perform path rewriting to work around Python being relocated between build and run time. The test fixtures also intentionally don't pin the setuptools version used as the package build backend, since most `project.toml`-using projects in the wild don't do so, and we want to ensure compatibility with the latest setuptools version.

However, I've managed to write the tests to still test the implementation details we care about (the rewritten paths) but make them less susceptible to breakage due to changes format of the finder `.py` files - by switching to `grep --only-matching` to extract only the filepath like strings.

GUS-W-15827366.