### PR TITLE
Enable rspec-retry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
       HATCHET_APP_LIMIT: 200
       HATCHET_DEFAULT_STACK: ${{ matrix.stack }}
       HATCHET_EXPENSIVE_MODE: 1
-      HATCHET_RETRIES: 2
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
       HEROKU_DISABLE_AUTOUPDATE: 1
       PARALLEL_SPLIT_TEST_PROCESSES: 60
+      RSPEC_RETRY_RETRY_COUNT: 3
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test, :development do
   gem 'parallel_split_test'
   gem 'rspec-core'
   gem 'rspec-expectations'
+  gem 'rspec-retry'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.5.1)
     erubis (2.7.0)
-    excon (0.109.0)
+    excon (0.110.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
@@ -21,14 +21,14 @@ GEM
     language_server-protocol (3.17.0.3)
     moneta (1.0.0)
     multi_json (1.15.0)
-    parallel (1.24.0)
+    parallel (1.25.1)
     parallel_split_test (0.10.0)
       parallel (>= 0.5.13)
       rspec-core (>= 3.9.0)
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
-    platform-api (3.6.0)
+    platform-api (3.7.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
@@ -36,14 +36,16 @@ GEM
     rainbow (3.1.1)
     rate_throttle_client (0.1.2)
     regexp_parser (2.9.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.0)
+      strscan
     rrrretry (1.0.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.1)
     rubocop (1.64.1)
       json (~> 2.3)
@@ -58,16 +60,16 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
-    rubocop-capybara (2.20.0)
+    rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.1)
+    rubocop-factory_bot (2.26.0)
       rubocop (~> 1.41)
-    rubocop-rspec (2.29.2)
+    rubocop-rspec (2.31.0)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
       rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.3)
+    rubocop-rspec_rails (2.29.0)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     strscan (3.1.0)
@@ -84,11 +86,12 @@ DEPENDENCIES
   parallel_split_test
   rspec-core
   rspec-expectations
+  rspec-retry
   rubocop
   rubocop-rspec
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.3.2p78
 
 BUNDLED WITH
-   2.5.6
+   2.5.11

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['HATCHET_BUILDPACK_BASE'] ||= 'https://github.com/heroku/heroku-buildpack-py
 ENV['HATCHET_DEFAULT_STACK'] ||= 'heroku-24'
 
 require 'rspec/core'
+require 'rspec/retry'
 require 'hatchet'
 
 LATEST_PYTHON_3_8 = '3.8.19'
@@ -43,6 +44,8 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   # Allows declaring on which stacks a test/group should run by tagging it with `stacks`.
   config.filter_run_excluding stacks: ->(stacks) { !stacks.include?(ENV.fetch('HATCHET_DEFAULT_STACK')) }
+  # Make rspec-retry output a retry message when its had to retry a test.
+  config.verbose_retry = true
 end
 
 def clean_output(output)


### PR DESCRIPTION
In the last week or two, the Heroku-24 jobs in CI have started failing a very high percentage of the time due to build log output assertion errors. These assertions are failing since some expected log lines are intermittently not seen in the build logs. Whilst the individual failure rate is low, given CI runs ~60 builds, this results in a near permanent failure rate.

Attempting to reproduce locally using a minimal logging-only inline buildpack testcase failed to reproduce. I eventually found that the issue only occurs when there is a reasonably long delay (eg 10 seconds) between a log entry and the next - in which case the first message (and sometimes two) after the log output resumes can be dropped.

This issue only affects the logs streamed via endosome, and does not affect the stored log on S3.

Whilst the intermittent failures in CI were only being seen on Heroku-24, the issue also reproduces on older stacks when using fixed sleep times in this testcase. As such, this appears to be an existing logging bug, that's only been exposed on Heroku-24 due to its builds running on different infrastructure, presumably now causing the time between some build steps (and log output entries) to be slower.

The builds team are looking into both the existing logging bug and the perf variances of the new build infrastructure. However, to make CI green in the meantime we'll have to use `rspec-retry`:
https://github.com/NoRedInk/rspec-retry

(`rspec-retry` differs from Hatchet's built-in retry mechanism, in that it will retry failures outside of the deploy itself, plus doesn't suffer from rebuilds now being potentially cached builds, throwing off the test assertions.)

See also:
https://salesforce-internal.slack.com/archives/C01068P24S3/p1717769443967999

GUS-W-15978877.