### PR TITLE
Add setuptools to the Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # We're not updating to setuptools v71+ due to its new approach to vendored dependencies:
+      # https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653
+      - dependency-name: "setuptools"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
Since we can't update to setuptools v71+ due to its new approach to vendored dependencies:
https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653

When this buildpack adds support for Python 3.13 we will also be dropping the global installs of setuptools and wheel (when using Python 3.13).

GUS-W-16637281.