### PR TITLE
Improve `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,14 @@ run:
 	@echo "Running buildpack using: STACK=$(STACK) FIXTURE=$(FIXTURE)"
 	@docker run --rm -it -v $(PWD):/src:ro --tmpfs /app -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
 		bash -eo pipefail -c '\
-			mkdir /tmp/buildpack /tmp/build /tmp/cache /tmp/env \
-			&& cp -r /src/{bin,lib,requirements,vendor} /tmp/buildpack \
-			&& cp -rT /src/$(FIXTURE) /tmp/build \
-			&& cd /tmp/buildpack \
-			&& echo -e "\n~ Detect:" && bash ./bin/detect /tmp/build /tmp/cache /tmp/env \
-			&& echo -e "\n~ Compile:" && { ./bin/compile /tmp/build /tmp/cache /tmp/env || true; } \
-			&& echo -e "\n~ Report:" && ./bin/report /tmp/build /tmp/cache /tmp/env \
+			mkdir /tmp/buildpack /tmp/build /tmp/cache /tmp/env; \
+			cp -r /src/{bin,lib,requirements,vendor} /tmp/buildpack; \
+			cp -rT /src/$(FIXTURE) /tmp/build; \
+			cd /tmp/buildpack; \
+			echo -e "\n~ Detect:" && ./bin/detect /tmp/build; \
+			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build /tmp/cache /tmp/env || SKIP_RELEASE=1; }; \
+			echo -e "\n~ Report:" && ./bin/report /tmp/build /tmp/cache /tmp/env; \
+			[[ -n "$${SKIP_RELEASE}" ]] || { echo -e "\n~ Release:" && ./bin/release /tmp/build && echo -e "\nBuild successful!"; }; \
 		'
 	@echo
 


### PR DESCRIPTION
The `make run` target provides a quick way to execute the buildpack locally in a container when developing on the buildpack.

Previously it executed only `bin/{detect,compile,report}`.

Now it also runs `bin/release`.

In addition, the arguments passed to `bin/detect` have been corrected, so that they now match the Buildpack API (where only `BUILD_DIR` is passed to the script):
https://devcenter.heroku.com/articles/buildpack-api#bin-detect