### PR TITLE
Add more files to the buildpack publishing file exclusion list

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,9 +5,11 @@ name = "Python"
 files = [
   ".github/",
   "builds/",
+  "etc/publish.sh",
   "spec/",
   ".gitignore",
   ".rubocop.yml",
+  ".shellcheckrc",
   "Gemfile",
   "Gemfile.lock",
   "hatchet.json",


### PR DESCRIPTION
Since these files aren't needed for the buildpack to run, so can be excluded from the archive published to the buildpack registry.

```
$ curl -sSf https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/python.tgz | tar -t
./CHANGELOG.md
./bin
./bin/detect
./bin/warnings
./bin/release
./bin/compile
./bin/utils
./bin/default_pythons
./bin/report
./bin/steps
./bin/steps/collectstatic
./bin/steps/pip-install
./bin/steps/nltk
./bin/steps/sqlite3
./bin/steps/pipenv-python-version
./bin/steps/python
./bin/steps/hooks
./bin/steps/hooks/post_compile
./bin/steps/hooks/pre_compile
./bin/steps/pipenv
./bin/test-compile
./etc
./etc/publish.sh
./requirements
./requirements/wheel.txt
./requirements/pip.txt
./requirements/pipenv.txt
./requirements/setuptools.txt
./lib
./lib/metadata.sh
./lib/kvstore.sh
./LICENSE
./.shellcheckrc
./vendor
./vendor/python.gunicorn.sh
./vendor/WEB_CONCURRENCY.sh
./vendor/buildpack-stdlib_v8.sh
./buildpack.toml
./README.md
```