### PR TITLE
Avoid trailing colon when prepending to optional env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Stopped adding a trailing `:` to `C_INCLUDE_PATH`, `CPLUS_INCLUDE_PATH`, `LIBRARY_PATH`, `LD_LIBRARY_PATH` and `PKG_CONFIG_PATH`. ([#1645](https://github.com/heroku/heroku-buildpack-python/pull/1645))
 - Removed remnants of the unused `.heroku/vendor/` directory. ([#1644](https://github.com/heroku/heroku-buildpack-python/pull/1644))
 
 ## [v257] - 2024-09-24

--- a/bin/compile
+++ b/bin/compile
@@ -77,11 +77,11 @@ export PYTHONUNBUFFERED=1
 # Ensure Python uses a Unicode locale, to prevent the issues described in:
 # https://github.com/docker-library/python/pull/570
 export LANG="en_US.UTF-8"
-export C_INCLUDE_PATH="/app/.heroku/python/include:${C_INCLUDE_PATH}"
-export CPLUS_INCLUDE_PATH="/app/.heroku/python/include:${CPLUS_INCLUDE_PATH}"
-export LIBRARY_PATH="/app/.heroku/python/lib:${LIBRARY_PATH}"
-export LD_LIBRARY_PATH="/app/.heroku/python/lib:${LD_LIBRARY_PATH}"
-export PKG_CONFIG_PATH="/app/.heroku/python/lib/pkg-config:${PKG_CONFIG_PATH}"
+export C_INCLUDE_PATH="/app/.heroku/python/include${C_INCLUDE_PATH:+:${C_INCLUDE_PATH}}"
+export CPLUS_INCLUDE_PATH="/app/.heroku/python/include${CPLUS_INCLUDE_PATH:+:${CPLUS_INCLUDE_PATH}}"
+export LIBRARY_PATH="/app/.heroku/python/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+export LD_LIBRARY_PATH="/app/.heroku/python/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export PKG_CONFIG_PATH="/app/.heroku/python/lib/pkg-config${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 
 # Global pip options (https://pip.pypa.io/en/stable/user_guide/#environment-variables).
 # Disable pip's warnings about EOL Python since we show our own.
@@ -248,8 +248,8 @@ set_env PYTHONUNBUFFERED true
 # Tell Python where it lives.
 set_env PYTHONHOME "\${HOME}/.heroku/python"
 # Set variables for C libraries.
-set_env LIBRARY_PATH "\${HOME}/.heroku/python/lib:\${LIBRARY_PATH}"
-set_env LD_LIBRARY_PATH "\${HOME}/.heroku/python/lib:\${LD_LIBRARY_PATH}"
+set_env LIBRARY_PATH "\${HOME}/.heroku/python/lib\${LIBRARY_PATH:+:\${LIBRARY_PATH}}"
+set_env LD_LIBRARY_PATH "\${HOME}/.heroku/python/lib\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
 # Locale.
 set_default_env LANG en_US.UTF-8
 # The Python hash seed is set to random.

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -26,22 +26,22 @@ RSpec.describe 'Heroku CI' do
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running post-compile hook
           CI=true
-          CPLUS_INCLUDE_PATH=/app/.heroku/python/include:
-          C_INCLUDE_PATH=/app/.heroku/python/include:
+          CPLUS_INCLUDE_PATH=/app/.heroku/python/include
+          C_INCLUDE_PATH=/app/.heroku/python/include
           DISABLE_COLLECTSTATIC=1
           INSTALL_TEST=1
           LANG=en_US.UTF-8
           LC_ALL=C.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin::/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
           PIP_NO_PYTHON_VERSION_WARNING=1
-          PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config:
+          PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           PYTHONUNBUFFERED=1
           -----> Inline app detected
           LANG=en_US.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
           PYTHONHASHSEED=random
           PYTHONHOME=/app/.heroku/python
@@ -54,8 +54,8 @@ RSpec.describe 'Heroku CI' do
           FORWARDED_ALLOW_IPS=\\*
           GUNICORN_CMD_ARGS=--access-logfile -
           LANG=en_US.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/:/app/.sprettur/bin/
           PYTHONHASHSEED=random
           PYTHONHOME=/app/.heroku/python
@@ -104,22 +104,22 @@ RSpec.describe 'Heroku CI' do
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running post-compile hook
           CI=true
-          CPLUS_INCLUDE_PATH=/app/.heroku/python/include:
-          C_INCLUDE_PATH=/app/.heroku/python/include:
+          CPLUS_INCLUDE_PATH=/app/.heroku/python/include
+          C_INCLUDE_PATH=/app/.heroku/python/include
           DISABLE_COLLECTSTATIC=1
           INSTALL_TEST=1
           LANG=en_US.UTF-8
           LC_ALL=C.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin::/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
           PIP_NO_PYTHON_VERSION_WARNING=1
-          PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config:
+          PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           PYTHONUNBUFFERED=1
           -----> Inline app detected
           LANG=en_US.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
           PYTHONHASHSEED=random
           PYTHONHOME=/app/.heroku/python
@@ -132,8 +132,8 @@ RSpec.describe 'Heroku CI' do
           FORWARDED_ALLOW_IPS=\\*
           GUNICORN_CMD_ARGS=--access-logfile -
           LANG=en_US.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/:/app/.sprettur/bin/
           PYTHONHASHSEED=random
           PYTHONHOME=/app/.heroku/python

--- a/spec/hatchet/hooks_spec.rb
+++ b/spec/hatchet/hooks_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe 'Compile hooks' do
           remote: ~ pre_compile ran with env vars:
           remote: BUILD_DIR=/tmp/build_<hash>
           remote: CACHE_DIR=/tmp/codon/tmp/cache
-          remote: C_INCLUDE_PATH=/app/.heroku/python/include:
-          remote: CPLUS_INCLUDE_PATH=/app/.heroku/python/include:
+          remote: C_INCLUDE_PATH=/app/.heroku/python/include
+          remote: CPLUS_INCLUDE_PATH=/app/.heroku/python/include
           remote: ENV_DIR=/tmp/...
           remote: HOME=/app
           remote: LANG=en_US.UTF-8
-          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          remote: LIBRARY_PATH=/app/.heroku/python/lib:
+          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
+          remote: LIBRARY_PATH=/app/.heroku/python/lib
           remote: PATH=/app/.heroku/python/bin::/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote: PIP_NO_PYTHON_VERSION_WARNING=1
-          remote: PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config:
+          remote: PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           remote: PWD=/tmp/build_<hash>
           remote: PYTHONUNBUFFERED=1
           remote: SOME_APP_CONFIG_VAR=1
@@ -42,16 +42,16 @@ RSpec.describe 'Compile hooks' do
           remote: ~ post_compile ran with env vars:
           remote: BUILD_DIR=/tmp/build_<hash>
           remote: CACHE_DIR=/tmp/codon/tmp/cache
-          remote: C_INCLUDE_PATH=/app/.heroku/python/include:
-          remote: CPLUS_INCLUDE_PATH=/app/.heroku/python/include:
+          remote: C_INCLUDE_PATH=/app/.heroku/python/include
+          remote: CPLUS_INCLUDE_PATH=/app/.heroku/python/include
           remote: ENV_DIR=/tmp/...
           remote: HOME=/app
           remote: LANG=en_US.UTF-8
-          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          remote: LIBRARY_PATH=/app/.heroku/python/lib:
+          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
+          remote: LIBRARY_PATH=/app/.heroku/python/lib
           remote: PATH=/app/.heroku/python/bin::/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote: PIP_NO_PYTHON_VERSION_WARNING=1
-          remote: PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config:
+          remote: PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           remote: PWD=/tmp/build_<hash>
           remote: PYTHONUNBUFFERED=1
           remote: SOME_APP_CONFIG_VAR=1

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe 'pip support' do
           remote:        Successfully installed typing-extensions-4.12.2
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
-          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          remote: LIBRARY_PATH=/app/.heroku/python/lib:
+          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
+          remote: LIBRARY_PATH=/app/.heroku/python/lib
           remote: PATH=/app/.heroku/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote: PYTHONHASHSEED=random
           remote: PYTHONHOME=/app/.heroku/python

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe 'Pipenv support' do
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
-          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          remote: LIBRARY_PATH=/app/.heroku/python/lib:
+          remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
+          remote: LIBRARY_PATH=/app/.heroku/python/lib
           remote: PATH=/app/.heroku/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote: PYTHONHASHSEED=random
           remote: PYTHONHOME=/app/.heroku/python

--- a/spec/hatchet/profile_d_scripts_spec.rb
+++ b/spec/hatchet/profile_d_scripts_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe '.profile.d/ scripts' do
           GUNICORN_CMD_ARGS=--access-logfile -
           HOME=/app
           LANG=en_US.UTF-8
-          LD_LIBRARY_PATH=/app/.heroku/python/lib:
-          LIBRARY_PATH=/app/.heroku/python/lib:
+          LD_LIBRARY_PATH=/app/.heroku/python/lib
+          LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin
           PWD=/app
           PYTHONHASHSEED=random


### PR DESCRIPTION
When prepending a value to an env var that uses a delimiter, the delimiter should not be added when the env var wasn't previously set. 

To achieve this we use the `${var:+VALUE_IF_SET}` parameter expansion feature. See:
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

GUS-W-16864019.