### PR TITLE
Fix calls to `utils::abort_internal_error`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -192,7 +192,7 @@ case "${PACKAGE_MANAGER}" in
 		pipenv::install_pipenv
 		;;
 	*)
-		abort_internal_error "Unhandled package manager"
+		utils::abort_internal_error "Unhandled package manager"
 		;;
 esac
 meta_time "package_manager_install_duration" "${package_manager_install_start_time}"
@@ -215,7 +215,7 @@ case "${PACKAGE_MANAGER}" in
 		pipenv::install_dependencies
 		;;
 	*)
-		abort_internal_error "Unhandled package manager"
+		utils::abort_internal_error "Unhandled package manager"
 		;;
 esac
 meta_time "dependencies_install_duration" "${dependencies_install_start_time}"


### PR DESCRIPTION
Since the function was renamed as part of namespacing the functions under `lib/`.

These codepaths are only ever hit in the case of a buildpack ~enum inconsistency bug (they are the equivalent of Rust's `unreachable!`), so it's not possible to have tests for them.