### PR TITLE
Enable Bash's `inherit_errexit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved the robustness of buildpack error handling by enabling `inherit_errexit`. ([#1655](https://github.com/heroku/heroku-buildpack-python/pull/1655))
 
 ## [v258] - 2024-10-01
 

--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,7 @@
 # shellcheck disable=SC2250 # TODO: Use braces around variable references even when not strictly required.
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 # Note: This can't be enabled via app config vars, since at this point they haven't been loaded from ENV_DIR.
 if [[ "${BUILDPACK_XTRACE:-0}" == "1" ]]; then

--- a/bin/detect
+++ b/bin/detect
@@ -3,6 +3,7 @@
 # See: https://devcenter.heroku.com/articles/buildpack-api
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 BUILD_DIR="${1}"
 

--- a/bin/release
+++ b/bin/release
@@ -3,6 +3,7 @@
 # See: https://devcenter.heroku.com/articles/buildpack-api
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 BUILD_DIR="${1}"
 

--- a/bin/report
+++ b/bin/report
@@ -18,6 +18,7 @@
 # when developing run `make compile` in this repo locally, which runs `bin/report` too.
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 CACHE_DIR="${2}"
 

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -3,6 +3,7 @@
 # See: https://devcenter.heroku.com/articles/testpack-api
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 # The absolute path to the root of the buildpack.
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 PYTHON_VERSION="${1:?"Error: The Python version to build must be specified as the first argument."}"
 PYTHON_MAJOR_VERSION="${PYTHON_VERSION%.*}"

--- a/builds/test_python_runtime.sh
+++ b/builds/test_python_runtime.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 ARCHIVE_FILEPATH="${1:?"Error: The filepath of the Python runtime archive must be specified as the first argument."}"
 

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2250 # TODO: Use braces around variable references even when not strictly required.
 
 set -euo pipefail
+shopt -s inherit_errexit
 
 BP_NAME=${1:-"heroku/python"}
 


### PR DESCRIPTION
By default Bash subshells (including command substitutions) do not inherit exit on error from the caller. This can cause surprises when functions are called from within command substitutions whose error handling is relying upon exit on error. For example, this cause error handling not to work as expected in the upcoming Python version handling reimplementation.

However, as of Bash 4.4 this can be changed by enabling `inherit_errexit`. (The oldest Bash on our supported stacks is 5.0.)

See:
https://www.shellcheck.net/wiki/SC2311
https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html

GUS-W-16899232.