### PR TITLE
Add support for Python 3.9 on Heroku-24

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -80,8 +80,8 @@ jobs:
         run: aws s3 sync ./upload "s3://${S3_BUCKET}"
 
   heroku-24:
-    # On Heroku-24 we only support Python 3.10+.
-    if: inputs.stack == 'heroku-24' || (inputs.stack == 'auto' && !startsWith(inputs.python_version,'3.8.') && !startsWith(inputs.python_version,'3.9.'))
+    # On Heroku-24 we only support Python 3.9+.
+    if: inputs.stack == 'heroku-24' || (inputs.stack == 'auto' && !startsWith(inputs.python_version,'3.8.'))
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added support for Python 3.9 on Heroku-24. ([#1656](https://github.com/heroku/heroku-buildpack-python/pull/1656))
 - Improved the robustness of buildpack error handling by enabling `inherit_errexit`. ([#1655](https://github.com/heroku/heroku-buildpack-python/pull/1655))
 
 ## [v258] - 2024-10-01

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ Supported runtime options include:
 - `python-3.12.7` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.11.10` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.10.15` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
-- `python-3.9.20` on Heroku-20 and Heroku-22 only
+- `python-3.9.20` on all [supported stacks](https://devcenter.heroku.com/articles/stack#stack-support-details)
 - `python-3.8.20` on Heroku-20 only

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -21,14 +21,7 @@ function abort() {
 }
 
 case "${STACK:?}" in
-	heroku-24)
-		SUPPORTED_PYTHON_VERSIONS=(
-			"3.10"
-			"3.11"
-			"3.12"
-		)
-		;;
-	heroku-22)
+	heroku-22 | heroku-24)
 		SUPPORTED_PYTHON_VERSIONS=(
 			"3.9"
 			"3.10"

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -216,19 +216,9 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'with a Pipfile.lock containing python_version 3.9' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.9', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_python_3.9') }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_9
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.9 on Heroku-22 and older.
-      include_examples 'aborts the build with a runtime not available message (Pipenv)', LATEST_PYTHON_3_9
-    end
+    include_examples 'builds using Pipenv with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'with a Pipfile.lock containing python_version 3.10' do

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -79,38 +79,25 @@ RSpec.describe 'Python update warnings' do
   end
 
   context 'with a runtime.txt containing python-3.9.0' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9_outdated', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9_outdated') }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'warns there is a Python update available', '3.9.0', LATEST_PYTHON_3_9
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.9 on Heroku-22 and older.
-      include_examples 'aborts the build without showing an update warning', '3.9.0'
-    end
+    include_examples 'warns there is a Python update available', '3.9.0', LATEST_PYTHON_3_9
   end
 
   context 'with a runtime.txt containing python-3.10.0' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10_outdated', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10_outdated') }
 
     include_examples 'warns there is a Python update available', '3.10.0', LATEST_PYTHON_3_10
   end
 
   context 'with a runtime.txt containing python-3.11.0' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.11_outdated', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.11_outdated') }
 
     include_examples 'warns there is a Python update available', '3.11.0', LATEST_PYTHON_3_11
   end
 
   context 'with a runtime.txt containing python-3.12.0' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.12_outdated', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.12_outdated') }
 
     include_examples 'warns there is a Python update available', '3.12.0', LATEST_PYTHON_3_12
   end

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -179,19 +179,9 @@ RSpec.describe 'Python version support' do
   end
 
   context 'when runtime.txt contains python-3.9.20' do
-    let(:allow_failure) { false }
-    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9', allow_failure:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.9') }
 
-    context 'when using Heroku-22 or older', stacks: %w[heroku-20 heroku-22] do
-      include_examples 'builds with the requested Python version', LATEST_PYTHON_3_9
-    end
-
-    context 'when using Heroku-24', stacks: %w[heroku-24] do
-      let(:allow_failure) { true }
-
-      # We only support Python 3.9 on Heroku-22 and older.
-      include_examples 'aborts the build with a runtime not available message', "python-#{LATEST_PYTHON_3_9}"
-    end
+    include_examples 'builds with the requested Python version', LATEST_PYTHON_3_9
   end
 
   context 'when runtime.txt contains python-3.10.15' do


### PR DESCRIPTION
Previously Python 3.9 was only supported on the Heroku-22 stack and older, since it [reaches EOL in Oct 2025](https://devguide.python.org/versions/#supported-versions).

However, adding support for Python 3.9 to Heroku-24 will make it easier for users upgrading stacks, and also give more Python version options to CNB users that need ARM64 support, given that multi-arch is only available for Heroku-24+. It also simplifies the version error checks we need to perform in the upcoming Python version handling refactor.

GUS-W-16917997.