### PR TITLE
Unskip env var tests on Heroku-22

### DIFF
--- a/spec/hatchet/hooks_spec.rb
+++ b/spec/hatchet/hooks_spec.rb
@@ -3,9 +3,7 @@
 require_relative '../spec_helper'
 
 RSpec.describe 'Compile hooks' do
-  # TODO: Run this on Heroku-22 too, once it has also migrated to the new build infrastructure.
-  # (Currently the test fails on the old infrastructure due to subtle differences in system PATH elements.)
-  context 'when an app has bin/pre_compile and bin/post_compile scripts', stacks: %w[heroku-20 heroku-24] do
+  context 'when an app has bin/pre_compile and bin/post_compile scripts' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/hooks', config: { 'SOME_APP_CONFIG_VAR' => '1' }) }
 
     it 'runs the hooks with the correct environment' do

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -12,9 +12,7 @@ RSpec.shared_examples 'installs successfully using pip' do
 end
 
 RSpec.describe 'pip support' do
-  # TODO: Run this on Heroku-22 too, once it has also migrated to the new build infrastructure.
-  # (Currently the test fails on the old infrastructure due to subtle differences in system PATH elements.)
-  context 'when requirements.txt is unchanged since the last build', stacks: %w[heroku-20 heroku-24] do
+  context 'when requirements.txt is unchanged since the last build' do
     let(:buildpacks) { [:default, 'heroku-community/inline'] }
     let(:app) { Hatchet::Runner.new('spec/fixtures/requirements_basic', buildpacks:) }
 

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe 'Pipenv support' do
     let(:buildpacks) { [:default, 'heroku-community/inline'] }
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_basic', buildpacks:) }
 
-    # TODO: Run this on Heroku-22 too, once it has also migrated to the new build infrastructure.
-    # (Currently the test fails on the old infrastructure due to subtle differences in system PATH elements.)
-    it 'builds with the specified python_version and re-uses packages from the cache',
-       stacks: %w[heroku-20 heroku-24] do
+    it 'builds with the specified python_version and re-uses packages from the cache' do
       app.deploy do |app|
         # TODO: We should not be leaking the Pipenv installation into the app environment.
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))


### PR DESCRIPTION
Since Heroku-22 has now been migrated to the new build infrastructure too, so no longer has the small system env var differences that were causing these tests to fail on that stack (which is why they had been skipped as part of #1634).