### PR TITLE
Fix leftover `output::error` args usages

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -18,7 +18,9 @@ function utils::bundled_pip_module_path() {
 	local bundled_pip_wheel="${bundled_pip_wheel_list[0]}"
 
 	if [[ -z "${bundled_pip_wheel}" ]]; then
-		output::error "Error: Failed to locate the bundled pip wheel."
+		output::error <<-'EOF'
+			Error: Failed to locate the bundled pip wheel.
+		EOF
 		meta_set "failure_reason" "bundled-pip-not-found"
 		return 1
 	fi
@@ -28,7 +30,9 @@ function utils::bundled_pip_module_path() {
 
 function utils::abort_internal_error() {
 	local message="${1}"
-	output::error "Internal error: ${message} (line $(caller || true))."
+	output::error <<-EOF
+		Internal error: ${message} (line $(caller || true)).
+	EOF
 	meta_set "failure_reason" "internal-error"
 	exit 1
 }


### PR DESCRIPTION
In #1666 the API for `output::error` was simplified, such that it only supports the message being passed via stdin (since that's the pattern used when passing a multi-line HERE-doc, and we want to encourage detailed error messages).

However, there were a couple of remaining instances not switched over to the stdin API.

These usages are in codepaths that cannot be tested via integration tests since they are unreachable unless there was an internal buildpack bug. (And Shellcheck also didn't spot these instances of unconsumed passed args.)

GUS-W-17048951.