### PR TITLE
Add a warning when multiple package managers are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added a warning when the files for multiple package managers are found. In the future this warning will become an error. ([#1692](https://github.com/heroku/heroku-buildpack-python/pull/1692))
 - Updated the build log message shown when installing dependencies to include the package manager command being run. ([#1689](https://github.com/heroku/heroku-buildpack-python/pull/1689))
 - Improved the error messages and buildpack metrics for package manager related failures. ([#1689](https://github.com/heroku/heroku-buildpack-python/pull/1689))
 - Changed test dependency installation on Heroku CI to now install `requirements.txt` and `requirements-test.txt` in a single `pip install` invocation rather than separately. This allows pip's resolver to resolve any version conflicts between the two files. ([#1689](https://github.com/heroku/heroku-buildpack-python/pull/1689))

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -4,6 +4,7 @@
 # however, it helps Shellcheck realise the options under which these functions will run.
 set -euo pipefail
 
+ANSI_BLUE='\033[1;34m'
 ANSI_RED='\033[1;31m'
 ANSI_YELLOW='\033[1;33m'
 ANSI_RESET='\033[0m'
@@ -26,6 +27,24 @@ function output::step() {
 # ```
 function output::indent() {
 	sed --unbuffered "s/^/       /"
+}
+
+# Output a styled multi-line notice message to stderr.
+#
+# Usage:
+# ```
+# output::notice <<-EOF
+# 	Note: The note summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::notice() {
+	echo >&2
+	while IFS= read -r line; do
+		echo -e "${ANSI_BLUE} !     ${line}${ANSI_RESET}" >&2
+	done
+	echo >&2
 }
 
 # Output a styled multi-line warning message to stderr.

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -346,6 +346,22 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
+          remote: 
+          remote:  !     Warning: Multiple Python package manager files were found.
+          remote:  !     
+          remote:  !     Exactly one package manager file should be present in your app's
+          remote:  !     source code, however, several were found:
+          remote:  !     
+          remote:  !     Pipfile.lock \\(Pipenv\\)
+          remote:  !     requirements.txt \\(pip\\)
+          remote:  !     
+          remote:  !     For now, we will build your app using the first package manager
+          remote:  !     listed above, however, in the future this warning will become
+          remote:  !     an error.
+          remote:  !     
+          remote:  !     Decide which package manager you want to use with your app, and
+          remote:  !     then delete the file\\(s\\) and any config from the others.
+          remote: 
           remote: -----> Using Python 3.12 specified in Pipfile.lock
           remote: -----> Installing Python #{LATEST_PYTHON_3_12}
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -245,6 +245,28 @@ RSpec.describe 'Poetry support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
+          remote: 
+          remote:  !     Warning: Multiple Python package manager files were found.
+          remote:  !     
+          remote:  !     Exactly one package manager file should be present in your app's
+          remote:  !     source code, however, several were found:
+          remote:  !     
+          remote:  !     requirements.txt (pip)
+          remote:  !     poetry.lock (Poetry)
+          remote:  !     
+          remote:  !     For now, we will build your app using the first package manager
+          remote:  !     listed above, however, in the future this warning will become
+          remote:  !     an error.
+          remote:  !     
+          remote:  !     Decide which package manager you want to use with your app, and
+          remote:  !     then delete the file(s) and any config from the others.
+          remote: 
+          remote: 
+          remote:  !     Note: We recently added support for the package manager Poetry.
+          remote:  !     If you are using a third-party Poetry buildpack you must remove
+          remote:  !     it, otherwise the requirements.txt file it generates will cause
+          remote:  !     the warning above.
+          remote: 
           remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           remote: -----> Installing Python #{LATEST_PYTHON_3_12}
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}


### PR DESCRIPTION
Currently the buildpack will use whichever package manager it finds first, if the files of multiple package managers are found.

This occasionally results in support tickets where the user believes the build to not be installing dependencies correctly, when in fact they are adding dependencies to the wrong package manager file.

As such, we want to make the presence of multiple package manager files an error, but we're first adding a warning so it's not a surprise. (Plus with the recent Poetry support addition, there will be apps using the third party Poetry buildpack that have both a `poetry.lock` and the generated `requirements.txt` until they remove the third-party buildpack.)

Towards #1691.
GUS-W-17167927.
