### PR TITLE
Link to the stable release version of Pipenv's docs

### DIFF
--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -204,7 +204,7 @@ function python_version::parse_python_version_file() {
 # Read the Python version from a Pipfile.lock, which can exist in one of two optional fields,
 # `python_full_version` (as N.N.N) and `python_version` (as N.N). If both fields are
 # defined, we will use the value set in `python_full_version`. See:
-# https://pipenv.pypa.io/en/latest/specifiers.html#specifying-versions-of-python
+# https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
 function python_version::read_pipenv_python_version() {
 	local build_dir="${1}"
 	local pipfile_lock_path="${build_dir}/Pipfile.lock"
@@ -259,7 +259,7 @@ function python_version::read_pipenv_python_version() {
 			then run 'pipenv lock' to regenerate the lockfile.
 
 			For more information, see:
-			https://pipenv.pypa.io/en/latest/specifiers.html#specifying-versions-of-python
+			https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
 		EOF
 		meta_set "failure_reason" "pipfile-lock::invalid-version"
 		exit 1

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     then run 'pipenv lock' to regenerate the lockfile.
           remote:  !     
           remote:  !     For more information, see:
-          remote:  !     https://pipenv.pypa.io/en/latest/specifiers.html#specifying-versions-of-python
+          remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -247,7 +247,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     then run 'pipenv lock' to regenerate the lockfile.
           remote:  !     
           remote:  !     For more information, see:
-          remote:  !     https://pipenv.pypa.io/en/latest/specifiers.html#specifying-versions-of-python
+          remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT


### PR DESCRIPTION
Since the `/latest/` URLs are for the unreleased development version, rather than the latest stable release.