### PR TITLE
Deprecate using Pipenv without a lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Deprecated using Pipenv without a lockfile (`Pipfile.lock`). ([#1695](https://github.com/heroku/heroku-buildpack-python/pull/1695))
 
 ## [v266] - 2024-11-08
 

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -15,11 +15,19 @@ function package_manager::determine_package_manager() {
 		meta_set "pipenv_has_lockfile" "true"
 	elif [[ -f "${build_dir}/Pipfile" ]]; then
 		# TODO: Start requiring a Pipfile.lock and make this branch a "missing lockfile" error instead.
-		# TODO: Adjust this warning to mention support for missing Pipfile.lock will be removed soon.
 		output::warning <<-'EOF'
 			Warning: No 'Pipfile.lock' found!
 
-			We recommend you commit this into your repository.
+			A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
+			Pipenv lockfile was not. This means your app dependency versions
+			are not pinned, which means the package versions used on Heroku
+			might not match those installed in other environments.
+
+			For now, we will install your dependencies without a lockfile,
+			however, in the future this warning will become an error.
+
+			Run 'pipenv lock' locally to generate the lockfile, and make sure
+			that 'Pipfile.lock' is not listed in '.gitignore' or '.slugignore'.
 		EOF
 		package_managers_found+=(pipenv)
 		package_managers_found_display_text+=("Pipfile (Pipenv)")

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -146,7 +146,16 @@ RSpec.describe 'Pipenv support' do
           remote: 
           remote:  !     Warning: No 'Pipfile.lock' found!
           remote:  !     
-          remote:  !     We recommend you commit this into your repository.
+          remote:  !     A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
+          remote:  !     Pipenv lockfile was not. This means your app dependency versions
+          remote:  !     are not pinned, which means the package versions used on Heroku
+          remote:  !     might not match those installed in other environments.
+          remote:  !     
+          remote:  !     For now, we will install your dependencies without a lockfile,
+          remote:  !     however, in the future this warning will become an error.
+          remote:  !     
+          remote:  !     Run 'pipenv lock' locally to generate the lockfile, and make sure
+          remote:  !     that 'Pipfile.lock' is not listed in '.gitignore' or '.slugignore'.
           remote: 
           remote: -----> No Python version was specified. Using the buildpack default: Python #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes


### PR DESCRIPTION
Using Pipenv without a lockfile can result in nondeterministic package installs, and so for some years if `Pipfile.lock` is missing we've emitted a recommendation in the build log to add it.

In addition, Pipenv has also since deprecated the `--skip-lockfile` feature upstream.

As such, we'd like to sunset support for using Pipenv without a lockfile, but first we should make the existing warning more explicit and include instructions on how to generate a lockfile.

GUS-W-17201692.
