### PR TITLE
Use local scope for variables in output helpers

### DIFF
--- a/lib/output.sh
+++ b/lib/output.sh
@@ -40,6 +40,7 @@ function output::indent() {
 # EOF
 # ```
 function output::notice() {
+	local line
 	echo >&2
 	while IFS= read -r line; do
 		echo -e "${ANSI_BLUE} !     ${line}${ANSI_RESET}" >&2
@@ -58,6 +59,7 @@ function output::notice() {
 # EOF
 # ```
 function output::warning() {
+	local line
 	echo >&2
 	while IFS= read -r line; do
 		echo -e "${ANSI_YELLOW} !     ${line}${ANSI_RESET}" >&2
@@ -76,6 +78,7 @@ function output::warning() {
 # EOF
 # ```
 function output::error() {
+	local line
 	echo >&2
 	while IFS= read -r line; do
 		echo -e "${ANSI_RED} !     ${line}${ANSI_RESET}" >&2


### PR DESCRIPTION
Since `read` defines the `line` variable as global by default, meaning `line` was previously visible outside these functions.
