### PR TITLE
Update the Python 3.8 EOL warning sunset date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Updated the Python 3.8 EOL warning message with the new sunset date. ([#1721](https://github.com/heroku/heroku-buildpack-python/pull/1721))
 - Improved the error message shown when pip install fails due to pip rejecting a package with invalid version metadata. ([#1718](https://github.com/heroku/heroku-buildpack-python/pull/1718))
 - Improved the error message shown when the copy of pip bundled in the `ensurepip` module cannot be found. ([#1720](https://github.com/heroku/heroku-buildpack-python/pull/1720))
 

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -78,11 +78,11 @@ if [[ "${python_major_version}" == "3.8" ]]; then
 	output::warning <<-'EOF'
 		Warning: Support for Python 3.8 is ending soon!
 
-		Python 3.8 will reach its upstream end-of-life in October 2024, at which
-		point it will no longer receive security updates:
+		Python 3.8 reached its upstream end-of-life on 7th October 2024, and so
+		no longer receives security updates:
 		https://devguide.python.org/versions/#supported-versions
 
-		Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+		Support for Python 3.8 will be removed from this buildpack on 7th January 2025.
 
 		Upgrade to a newer Python version as soon as possible to keep your app secure.
 		See: https://devcenter.heroku.com/articles/python-runtimes

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'Python update warnings' do
             remote: 
             remote:  !     Warning: Support for Python 3.8 is ending soon!
             remote:  !     
-            remote:  !     Python 3.8 will reach its upstream end-of-life in October 2024, at which
-            remote:  !     point it will no longer receive security updates:
+            remote:  !     Python 3.8 reached its upstream end-of-life on 7th October 2024, and so
+            remote:  !     no longer receives security updates:
             remote:  !     https://devguide.python.org/versions/#supported-versions
             remote:  !     
-            remote:  !     Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+            remote:  !     Support for Python 3.8 will be removed from this buildpack on 7th January 2025.
             remote:  !     
             remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -89,11 +89,11 @@ RSpec.describe 'Python version support' do
             remote: 
             remote:  !     Warning: Support for Python 3.8 is ending soon!
             remote:  !     
-            remote:  !     Python 3.8 will reach its upstream end-of-life in October 2024, at which
-            remote:  !     point it will no longer receive security updates:
+            remote:  !     Python 3.8 reached its upstream end-of-life on 7th October 2024, and so
+            remote:  !     no longer receives security updates:
             remote:  !     https://devguide.python.org/versions/#supported-versions
             remote:  !     
-            remote:  !     Support for Python 3.8 will be removed from this buildpack on December 4th, 2024.
+            remote:  !     Support for Python 3.8 will be removed from this buildpack on 7th January 2025.
             remote:  !     
             remote:  !     Upgrade to a newer Python version as soon as possible to keep your app secure.
             remote:  !     See: https://devcenter.heroku.com/articles/python-runtimes


### PR DESCRIPTION
Since I've decided to defer Python 3.8 sunset by a month given the upcoming holidays and imminent change moratorium.

This will also allow for adding an equivalent warning to the Python CNB, so both can be sunset at the same time.

Xref:
https://devcenter.heroku.com/changelog-items/2768
https://devcenter.heroku.com/articles/python-support#supported-python-versions

GUS-W-17422347.