### PR TITLE
Fix Dev Center links to reflect recent article URL changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Dev Center links to reflect recent article URL changes. ([#1723](https://github.com/heroku/heroku-buildpack-python/pull/1723))
 
 ## [v271] - 2024-12-12
 

--- a/bin/steps/nltk
+++ b/bin/steps/nltk
@@ -47,6 +47,5 @@ if is_module_available 'nltk'; then
 	else
 		meta_set "nltk_downloader" "skipped-no-nltk-file"
 		echo "       'nltk.txt' not found, not downloading any corpora"
-		echo "       Learn more: https://devcenter.heroku.com/articles/python-nltk"
 	fi
 fi

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -20,7 +20,7 @@ if ! curl --output /dev/null --silent --head --fail --retry 3 --retry-connrefuse
 		Error: Python ${python_full_version} isn't available for this stack (${STACK}).
 
 		For a list of the supported Python versions, see:
-		https://devcenter.heroku.com/articles/python-support#supported-runtimes
+		https://devcenter.heroku.com/articles/python-support#supported-python-versions
 	EOF
 	meta_set "failure_reason" "python-version-not-found"
 	exit 1

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -299,7 +299,7 @@ function python_version::resolve_python_version() {
 				${DEFAULT_PYTHON_MAJOR_VERSION}
 
 				For a list of the supported Python versions, see:
-				https://devcenter.heroku.com/articles/python-support#supported-runtimes
+				https://devcenter.heroku.com/articles/python-support#supported-python-versions
 			EOF
 		else
 			output::error <<-EOF
@@ -315,7 +315,7 @@ function python_version::resolve_python_version() {
 				version configured via the '${python_version_origin}' file.
 
 				For a list of the supported Python versions, see:
-				https://devcenter.heroku.com/articles/python-support#supported-runtimes
+				https://devcenter.heroku.com/articles/python-support#supported-python-versions
 			EOF
 		fi
 		meta_set "failure_reason" "python-version::eol"
@@ -347,11 +347,12 @@ function python_version::resolve_python_version() {
 				Check that this Python version has been officially released,
 				and that the Python buildpack has added support for it:
 				https://devguide.python.org/versions/#supported-versions
-				https://devcenter.heroku.com/articles/python-support#supported-runtimes
+				https://devcenter.heroku.com/articles/python-support#supported-python-versions
 
 				If it has, make sure that you are using the latest version
-				of this buildpack:
-				https://devcenter.heroku.com/articles/python-support#checking-the-python-buildpack-version
+				of this buildpack, and have not pinned to an older release:
+				https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
+				https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
 
 				Otherwise, switch to a supported version (such as Python ${DEFAULT_PYTHON_MAJOR_VERSION})
 				by updating the version configured via the '${python_version_origin}' file.

--- a/spec/hatchet/nltk_spec.rb
+++ b/spec/hatchet/nltk_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe 'NLTK corpora support' do
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Downloading NLTK corpora...
           remote:        'nltk.txt' not found, not downloading any corpora
-          remote:        Learn more: https://devcenter.heroku.com/articles/python-nltk
         REGEX
       end
     end

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     version configured via the 'Pipfile.lock' file.
           remote:  !     
           remote:  !     For a list of the supported Python versions, see:
-          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Python update warnings' do
             remote:  !     Error: Python 3.8.0 isn't available for this stack (#{app.stack}).
             remote:  !     
             remote:  !     For a list of the supported Python versions, see:
-            remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+            remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
             remote: 
             remote:  !     Push rejected, failed to compile Python app.
           OUTPUT

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Python version support' do
             remote:  !     Error: Python #{LATEST_PYTHON_3_8} isn't available for this stack (#{app.stack}).
             remote:  !     
             remote:  !     For a list of the supported Python versions, see:
-            remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+            remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
             remote: 
             remote:  !     Push rejected, failed to compile Python app.
           OUTPUT
@@ -266,7 +266,7 @@ RSpec.describe 'Python version support' do
           remote:  !     version configured via the '.python-version' file.
           remote:  !     
           remote:  !     For a list of the supported Python versions, see:
-          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -290,11 +290,12 @@ RSpec.describe 'Python version support' do
           remote:  !     Check that this Python version has been officially released,
           remote:  !     and that the Python buildpack has added support for it:
           remote:  !     https://devguide.python.org/versions/#supported-versions
-          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
           remote:  !     
           remote:  !     If it has, make sure that you are using the latest version
-          remote:  !     of this buildpack:
-          remote:  !     https://devcenter.heroku.com/articles/python-support#checking-the-python-buildpack-version
+          remote:  !     of this buildpack, and have not pinned to an older release:
+          remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
+          remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
           remote:  !     
           remote:  !     Otherwise, switch to a supported version (such as Python #{DEFAULT_PYTHON_MAJOR_VERSION})
           remote:  !     by updating the version configured via the '.python-version' file.
@@ -317,7 +318,7 @@ RSpec.describe 'Python version support' do
           remote:  !     Error: Python 3.12.999 isn't available for this stack (#{app.stack}).
           remote:  !     
           remote:  !     For a list of the supported Python versions, see:
-          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -378,7 +379,7 @@ RSpec.describe 'Python version support' do
           remote:  !     version configured via the 'runtime.txt' file.
           remote:  !     
           remote:  !     For a list of the supported Python versions, see:
-          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-runtimes
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT


### PR DESCRIPTION
After the recent Dev Center re-org, some of the articles URLs and/or heading anchor link names have changed.

GUS-W-17428557.