### PR TITLE
Add metrics for the existence of a uv lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed Dev Center links to reflect recent article URL changes. ([#1723](https://github.com/heroku/heroku-buildpack-python/pull/1723))
+- Added metrics for the existence of a uv lockfile. ([#1725](https://github.com/heroku/heroku-buildpack-python/pull/1725))
 
 ## [v271] - 2024-12-12
 

--- a/bin/report
+++ b/bin/report
@@ -94,6 +94,7 @@ ALL_OTHER_FIELDS=(
 	setup_py_only
 	sqlite_install_duration
 	total_duration
+	uv_lockfile
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -59,6 +59,10 @@ function package_manager::determine_package_manager() {
 		meta_set "setup_py_only" "false"
 	fi
 
+	if [[ -f "${build_dir}/uv.lock" ]]; then
+		meta_set "uv_lockfile" "true"
+	fi
+
 	local num_package_managers_found=${#package_managers_found[@]}
 
 	case "${num_package_managers_found}" in
@@ -86,6 +90,11 @@ function package_manager::determine_package_manager() {
 
 				Otherwise, add a package manager file to your app. If your app has
 				no dependencies, then create an empty 'requirements.txt' file.
+
+				If you would like to see support for the package manager uv,
+				please vote and comment on these GitHub issues:
+				https://github.com/heroku/heroku-buildpack-python/issues/1616
+				https://github.com/heroku/roadmap/issues/323
 
 				For help with using Python on Heroku, see:
 				https://devcenter.heroku.com/articles/getting-started-with-python

--- a/spec/hatchet/package_manager_spec.rb
+++ b/spec/hatchet/package_manager_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe 'Package manager support' do
           remote:  !     Otherwise, add a package manager file to your app. If your app has
           remote:  !     no dependencies, then create an empty 'requirements.txt' file.
           remote:  !     
+          remote:  !     If you would like to see support for the package manager uv,
+          remote:  !     please vote and comment on these GitHub issues:
+          remote:  !     https://github.com/heroku/heroku-buildpack-python/issues/1616
+          remote:  !     https://github.com/heroku/roadmap/issues/323
+          remote:  !     
           remote:  !     For help with using Python on Heroku, see:
           remote:  !     https://devcenter.heroku.com/articles/getting-started-with-python
           remote:  !     https://devcenter.heroku.com/articles/python-support


### PR DESCRIPTION
To help gauge how often a uv lockfile exists. (Either from someone trying to use uv and the build failing, or when a third-party buildpack is used to export the uv lockfile to a requirements file etc).

Towards #1616.
GUS-W-17431743.
