### PR TITLE
Expand buildpack detection known file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added more Python project related file and directory names to the list recognised by buildpack detection. ([#1729](https://github.com/heroku/heroku-buildpack-python/pull/1729))
 - Improved the file listing in the error messages shown when buildpack detection fails or when no Python package manager files are found. ([#1728](https://github.com/heroku/heroku-buildpack-python/pull/1728))
 
 ## [v272] - 2024-12-13

--- a/bin/detect
+++ b/bin/detect
@@ -20,6 +20,7 @@ source "${BUILDPACK_DIR}/lib/output.sh"
 # allowing us to show a helpful error message during the build phase.
 KNOWN_PYTHON_PROJECT_FILES=(
 	.python-version
+	__init__.py
 	app.py
 	main.py
 	manage.py
@@ -30,13 +31,27 @@ KNOWN_PYTHON_PROJECT_FILES=(
 	pyproject.toml
 	requirements.txt
 	runtime.txt
+	server.py
 	setup.cfg
 	setup.py
 	uv.lock
+	# Commonly seen misspellings of requirements.txt. (Which occur since pip doesn't
+	# create/manage requirements files itself, so the filenames are manually typed.)
+	requirement.txt
+	Requirements.txt
+	requirements.text
+	requirements.txt.txt
+	requirments.txt
+	# Whilst virtual environments shouldn't be committed to Git (and so shouldn't
+	# normally be present during the build), they are often present for beginner
+	# Python apps that are missing all of the other Python related files above.
+	.venv/
+	venv/
 )
 
-for filename in "${KNOWN_PYTHON_PROJECT_FILES[@]}"; do
-	if [[ -f "${BUILD_DIR}/${filename}" ]]; then
+for filepath in "${KNOWN_PYTHON_PROJECT_FILES[@]}"; do
+	# Using -e since we need to check for both files and directories.
+	if [[ -e "${BUILD_DIR}/${filepath}" ]]; then
 		echo "Python"
 		exit 0
 	fi


### PR DESCRIPTION
This adds more Python project related file and directory names to the list recognised by buildpack detection. Such apps will still fail to build successfully (since they are missing a package manager file), but will now be shown a more helpful error message during compile, rather than the generic:
"No default language could be detected for this app"

The list is based on builds logs analysis of builds that filed to pass detection, plus builds that passed detection but didn't have a valid package manager file. (Possible since the build logs error message includes a file listing of the root directory of the app.)

GUS-W-17530056.