### PR TITLE
Deprecate support for the `runtime.txt` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Deprecated support for the `runtime.txt` file. ([#1743](https://github.com/heroku/heroku-buildpack-python/pull/1743))
+- Improved the error messages shown when `.python-version`, `runtime.txt` or `Pipfile.lock` contain an invalid Python version. ([#1743](https://github.com/heroku/heroku-buildpack-python/pull/1743))
 
 ## [v275] - 2025-01-13
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ For example, to request the latest patch release of Python 3.13, create a `.pyth
 the root directory of your app containing:
 `3.13`
 
+We strongly recommend that you use the major version form instead of pinning to an exact version,
+since it will allow your app to receive Python security updates.
+
 The buildpack will look for a Python version in the following places (in descending order of precedence):
 
 1. `runtime.txt` file (deprecated)

--- a/bin/compile
+++ b/bin/compile
@@ -125,7 +125,6 @@ meta_set "python_version_reason" "${python_version_origin}"
 
 # TODO: More strongly recommend specifying a Python version (eg switch the messaging to
 # be a warning instead, after version resolution, and mention .python-version inline)
-# TODO: Add runtime.txt deprecation warning.
 case "${python_version_origin}" in
 	default)
 		output::step "No Python version was specified. Using the buildpack default: Python ${requested_python_version}"
@@ -144,6 +143,31 @@ python_full_version="$(python_version::resolve_python_version "${requested_pytho
 python_major_version="${python_full_version%.*}"
 meta_set "python_version" "${python_full_version}"
 meta_set "python_version_major" "${python_major_version}"
+
+if [[ "${python_version_origin}" == "runtime.txt" ]]; then
+	output::warning <<-EOF
+		Warning: The runtime.txt file is deprecated.
+
+		The runtime.txt file is deprecated since it has been replaced
+		by the more widely supported .python-version file.
+
+		Please delete your runtime.txt file and create a new file named:
+		.python-version
+
+		Make sure to include the '.' at the start of the filename.
+
+		In the new file, specify your app's Python version without
+		quotes or a 'python-' prefix. For example:
+		${python_major_version}
+
+		We strongly recommend that you use the major version form
+		instead of pinning to an exact version, since it will allow
+		your app to receive Python security updates.
+
+		In the future support for runtime.txt will be removed and
+		this warning will be made an error.
+	EOF
+fi
 
 cache::restore "${BUILD_DIR}" "${CACHE_DIR}" "${STACK}" "${cached_python_full_version}" "${python_full_version}" "${package_manager}"
 

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -219,20 +219,24 @@ RSpec.describe 'Pipenv support' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: 
-          remote:  !     Error: Invalid Python version in Pipfile / Pipfile.lock.
+          remote:  !     Error: Invalid Python version in Pipfile.lock.
           remote:  !     
-          remote:  !     The Python version specified in Pipfile / Pipfile.lock by the
-          remote:  !     'python_version' or 'python_full_version' field isn't valid.
+          remote:  !     The Python version specified in your Pipfile.lock file by the
+          remote:  !     'python_version' or 'python_full_version' fields isn't valid.
           remote:  !     
           remote:  !     The following version was found:
           remote:  !     ^3.12
           remote:  !     
-          remote:  !     However, the version must be specified as either:
-          remote:  !     1. '<major>.<minor>' (recommended, for automatic patch updates)
-          remote:  !     2. '<major>.<minor>.<patch>' (to pin to an exact patch version)
+          remote:  !     However, the Python version must be specified as either:
+          remote:  !     1. The major version only: 3.X  (recommended)
+          remote:  !     2. An exact patch version: 3.X.Y
           remote:  !     
-          remote:  !     Please update your 'Pipfile' to use a valid Python version and
-          remote:  !     then run 'pipenv lock' to regenerate the lockfile.
+          remote:  !     Please update your Pipfile to use a valid Python version and
+          remote:  !     then run 'pipenv lock' to regenerate Pipfile.lock.
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
           remote:  !     
           remote:  !     For more information, see:
           remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
@@ -251,20 +255,24 @@ RSpec.describe 'Pipenv support' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: 
-          remote:  !     Error: Invalid Python version in Pipfile / Pipfile.lock.
+          remote:  !     Error: Invalid Python version in Pipfile.lock.
           remote:  !     
-          remote:  !     The Python version specified in Pipfile / Pipfile.lock by the
-          remote:  !     'python_version' or 'python_full_version' field isn't valid.
+          remote:  !     The Python version specified in your Pipfile.lock file by the
+          remote:  !     'python_version' or 'python_full_version' fields isn't valid.
           remote:  !     
           remote:  !     The following version was found:
           remote:  !     3.9.*
           remote:  !     
-          remote:  !     However, the version must be specified as either:
-          remote:  !     1. '<major>.<minor>' (recommended, for automatic patch updates)
-          remote:  !     2. '<major>.<minor>.<patch>' (to pin to an exact patch version)
+          remote:  !     However, the Python version must be specified as either:
+          remote:  !     1. The major version only: 3.X  (recommended)
+          remote:  !     2. An exact patch version: 3.X.Y
           remote:  !     
-          remote:  !     Please update your 'Pipfile' to use a valid Python version and
-          remote:  !     then run 'pipenv lock' to regenerate the lockfile.
+          remote:  !     Please update your Pipfile to use a valid Python version and
+          remote:  !     then run 'pipenv lock' to regenerate Pipfile.lock.
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
           remote:  !     
           remote:  !     For more information, see:
           remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe 'Python update warnings' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: -----> Using Python 3.9.0 specified in runtime.txt
+          remote: 
+          remote:  !     Warning: The runtime.txt file is deprecated.
+          remote:  !     
+          remote:  !     The runtime.txt file is deprecated since it has been replaced
+          remote:  !     by the more widely supported .python-version file.
+          remote:  !     
+          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     .python-version
+          remote:  !     
+          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     
+          remote:  !     In the new file, specify your app's Python version without
+          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     3.9
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
+          remote:  !     
+          remote:  !     In the future support for runtime.txt will be removed and
+          remote:  !     this warning will be made an error.
+          remote: 
           remote: -----> Installing Python 3.9.0
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -148,22 +148,26 @@ RSpec.describe 'Python version support' do
           remote: 
           remote:  !     Error: Invalid Python version in .python-version.
           remote:  !     
-          remote:  !     The Python version specified in '.python-version' isn't in
-          remote:  !     the correct format.
+          remote:  !     The Python version specified in your .python-version file
+          remote:  !     isn't in the correct format.
           remote:  !     
           remote:  !     The following version was found:
           remote:  !       3.12.0invalid  
           remote:  !     
-          remote:  !     However, the version must be specified as either:
-          remote:  !     1. '<major>.<minor>' (recommended, for automatic patch updates)
-          remote:  !     2. '<major>.<minor>.<patch>' (to pin to an exact patch version)
+          remote:  !     However, the Python version must be specified as either:
+          remote:  !     1. The major version only: 3.X  (recommended)
+          remote:  !     2. An exact patch version: 3.X.Y
           remote:  !     
           remote:  !     Don't include quotes or a 'python-' prefix. To include
           remote:  !     comments, add them on their own line, prefixed with '#'.
           remote:  !     
           remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-          remote:  !     update the '.python-version' file so it contains:
+          remote:  !     update your .python-version file so it contains:
           remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -181,10 +185,13 @@ RSpec.describe 'Python version support' do
           remote: 
           remote:  !     Error: Invalid Python version in .python-version.
           remote:  !     
-          remote:  !     No Python version was found in the '.python-version' file.
+          remote:  !     No Python version was found in your .python-version file.
           remote:  !     
-          remote:  !     Update the file so that it contains a valid Python version
-          remote:  !     such as '#{DEFAULT_PYTHON_MAJOR_VERSION}'.
+          remote:  !     Update the file so that it contains a valid Python version.
+          remote:  !     
+          remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     update your .python-version file so it contains:
+          remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:  !     
           remote:  !     If the file already contains a version, check the line doesn't
           remote:  !     begin with a '#', otherwise it will be treated as a comment.
@@ -205,8 +212,7 @@ RSpec.describe 'Python version support' do
           remote: 
           remote:  !     Error: Invalid Python version in .python-version.
           remote:  !     
-          remote:  !     Multiple Python versions were found in the '.python-version'
-          remote:  !     file:
+          remote:  !     Multiple versions were found in your .python-version file:
           remote:  !     
           remote:  !     // invalid comment
           remote:  !     3.12
@@ -214,8 +220,8 @@ RSpec.describe 'Python version support' do
           remote:  !     
           remote:  !     Update the file so it contains only one Python version.
           remote:  !     
-          remote:  !     If the additional versions are actually comments, prefix
-          remote:  !     those lines with '#'.
+          remote:  !     If you have added comments to the file, make sure that those
+          remote:  !     lines begin with a '#', so that they are ignored.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -312,21 +318,29 @@ RSpec.describe 'Python version support' do
           remote: 
           remote:  !     Error: Invalid Python version in runtime.txt.
           remote:  !     
-          remote:  !     The Python version specified in 'runtime.txt' isn't in
-          remote:  !     the correct format.
+          remote:  !     The Python version specified in your runtime.txt file isn't
+          remote:  !     in the correct format.
           remote:  !     
-          remote:  !     The following file contents were found:
+          remote:  !     The following file contents were found, which aren't valid:
           remote:  !     python-3.12.0invalid
           remote:  !     
-          remote:  !     However, the version must be specified as either:
-          remote:  !     1. 'python-<major>.<minor>' (recommended, for automatic patch updates)
-          remote:  !     2. 'python-<major>.<minor>.<patch>' (to pin to an exact patch version)
+          remote:  !     However, the runtime.txt file is deprecated since it has
+          remote:  !     been replaced by the .python-version file. As such, we
+          remote:  !     recommend that you switch to using a .python-version file
+          remote:  !     instead of fixing your runtime.txt file.
           remote:  !     
-          remote:  !     Remember to include the 'python-' prefix. Comments aren't supported.
+          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     .python-version
           remote:  !     
-          remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-          remote:  !     update the 'runtime.txt' file so it contains:
-          remote:  !     python-#{DEFAULT_PYTHON_MAJOR_VERSION}
+          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     
+          remote:  !     In the new file, specify your app's Python version without
+          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -371,6 +385,28 @@ RSpec.describe 'Python version support' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: -----> Using Python 3.13 specified in runtime.txt
+          remote: 
+          remote:  !     Warning: The runtime.txt file is deprecated.
+          remote:  !     
+          remote:  !     The runtime.txt file is deprecated since it has been replaced
+          remote:  !     by the more widely supported .python-version file.
+          remote:  !     
+          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     .python-version
+          remote:  !     
+          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     
+          remote:  !     In the new file, specify your app's Python version without
+          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     3.13
+          remote:  !     
+          remote:  !     We strongly recommend that you use the major version form
+          remote:  !     instead of pinning to an exact version, since it will allow
+          remote:  !     your app to receive Python security updates.
+          remote:  !     
+          remote:  !     In the future support for runtime.txt will be removed and
+          remote:  !     this warning will be made an error.
+          remote: 
           remote: -----> Installing Python #{LATEST_PYTHON_3_13}
           remote: -----> Installing pip #{PIP_VERSION}
           remote: -----> Installing dependencies using 'pip install -r requirements.txt'


### PR DESCRIPTION
This is the classic Python buildpack equivalent of:
https://github.com/heroku/buildpacks-python/pull/325

The `runtime.txt` file is a classic Heroku Python buildpack invention that's not widely supported in the Python ecosystem. Instead, most other tooling (pyenv, package managers, GitHub Actions, dependency update bots etc) support/use the `.python-version` file.

As such, we recently added `.python-version` support to both the Python CNB and the classic Python buildpack, and updated all documentation and guides to use it instead of the `runtime.txt` file. eg:
https://devcenter.heroku.com/articles/python-runtimes

We would prefer apps use the new file, since it helps ensure their deployed app is using the same Python version used locally (via eg pyenv or uv) or in CI.

As such this adds a deprecation warning for apps using `runtime.txt`.

Closes #1642.
GUS-W-16878260.