### PR TITLE
Improve metrics for builds that fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved buildpack metrics for builds that fail. ([#1746](https://github.com/heroku/heroku-buildpack-python/pull/1746))
 
 ## [v276] - 2025-02-05
 

--- a/bin/report
+++ b/bin/report
@@ -62,6 +62,7 @@ kv_pair_string() {
 STRING_FIELDS=(
 	cache_status
 	django_collectstatic
+	failure_detail
 	failure_reason
 	nltk_downloader
 	package_manager

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -23,6 +23,7 @@ if ! curl --output /dev/null --silent --head --fail --retry 3 --retry-connrefuse
 		https://devcenter.heroku.com/articles/python-support#supported-python-versions
 	EOF
 	meta_set "failure_reason" "python-version-not-found"
+	meta_set "failure_detail" "${python_full_version}"
 	exit 1
 fi
 
@@ -42,6 +43,7 @@ else
 			Please try again and to see if the error resolves itself.
 		EOF
 		meta_set "failure_reason" "python-download"
+		# TODO: Set failure_detail here once refactored.
 		exit 1
 	fi
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -20,6 +20,7 @@ function checks::ensure_supported_stack() {
 				Upgrade to a newer stack to continue using this buildpack.
 			EOF
 			meta_set "failure_reason" "stack::eol"
+			meta_set "failure_detail" "${stack}"
 			exit 1
 			;;
 		*)
@@ -34,6 +35,7 @@ function checks::ensure_supported_stack() {
 				https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
 			EOF
 			meta_set "failure_reason" "stack::unknown"
+			meta_set "failure_detail" "${stack}"
 			exit 1
 			;;
 	esac

--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -23,8 +23,20 @@ kv_set() {
 	# TODO: Stop ignoring an incorrect number of passed arguments.
 	if [[ $# -eq 3 ]]; then
 		local f="${1}"
+		local key="${2}"
+
+		# Truncate the value to an arbitrary 100 characters since it will sometimes contain user-provided
+		# inputs which may be unbounded in size. Ideally individual call sites will perform more aggressive
+		# truncation themselves based on the expected value size, however this is here as a fallback.
+		# (Honeycomb supports string fields up to 64KB in size, however, it's not worth filling up the
+		# metadata store or bloating the payload passed back to Vacuole/submitted to Honeycomb given the
+		# extra content in those cases is not normally useful.)
+		local value="${3:0:100}"
+		# Replace newlines since the data store file format requires that keys don't span multiple lines.
+		value="${value//$'\n'/ }"
+
 		if [[ -f "${f}" ]]; then
-			echo "${2}=${3}" >>"${f}"
+			echo "${key}=${value}" >>"${f}"
 		fi
 	fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -48,10 +48,12 @@ function utils::bundled_pip_module_path() {
 }
 
 function utils::abort_internal_error() {
-	local message="${1}"
+	local message
+	message="${1} (line $(caller || true))"
 	output::error <<-EOF
-		Internal error: ${message} (line $(caller || true)).
+		Internal error: ${message}.
 	EOF
 	meta_set "failure_reason" "internal-error"
+	meta_set "failure_detail" "${message}"
 	exit 1
 }


### PR DESCRIPTION
Adds a `failure_detail` field in addition to the existing `failure_reason`, which contains additional context relevant to the failure where available. This will make it easier to find trends in the most frequent user-caused failure modes (eg invalid Python version specifier) so I can then adjust error messages/docs/implementation to improve UX.

This context sometimes contain user input, so the values saved to the metadata store now also have additional escaping and validation performed before writing the value (in addition to the existing YAML escaping performed in `bin/report`).

GUS-W-17800067.