### PR TITLE
`make run` workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
       - name: Run buildpack using default app fixture
         run: make run
       - name: Run buildpack using an app fixture that's expected to fail
-        run: make run FIXTURE=spec/fixtures/python_version_file_invalid_version/
+        run: make run FIXTURE=spec/fixtures/python_version_file_invalid_version/ COMPILE_FAILURE_EXIT_CODE=0

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 STACK ?= heroku-24
 FIXTURE ?= spec/fixtures/python_version_unspecified
+# Allow overriding the exit code in CI, so we can test bin/report works for failing builds.
+COMPILE_FAILURE_EXIT_CODE ?= 1
 
 # Converts a stack name of `heroku-NN` to its build Docker image tag of `heroku/heroku:NN-build`.
 STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
@@ -24,18 +26,21 @@ format:
 run:
 	@echo "Running buildpack using: STACK=$(STACK) FIXTURE=$(FIXTURE)"
 	@docker run --rm -v $(PWD):/src:ro --tmpfs /app -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
-		bash -euo pipefail -c '\
-			mkdir /tmp/buildpack /tmp/build /tmp/cache /tmp/env; \
+		bash -euo pipefail -O dotglob -c '\
+			mkdir /tmp/buildpack /tmp/cache /tmp/env; \
 			cp -r /src/{bin,lib,requirements,vendor} /tmp/buildpack; \
-			cp -rT /src/$(FIXTURE) /tmp/build; \
+			cp -r /src/$(FIXTURE) /tmp/build_1; \
 			cd /tmp/buildpack; \
 			unset $$(printenv | cut -d '=' -f 1 | grep -vE "^(HOME|LANG|PATH|STACK)$$"); \
-			echo -e "\n~ Detect:" && ./bin/detect /tmp/build; \
-			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build /tmp/cache /tmp/env || COMPILE_FAILED=1; }; \
-			echo -e "\n~ Report:" && ./bin/report /tmp/build /tmp/cache /tmp/env; \
-			[[ "$${COMPILE_FAILED:-}" == "1" ]] && exit 0; \
-			[[ -f /tmp/build/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build/bin/compile /tmp/build /tmp/cache /tmp/env); }; \
-			echo -e "\n~ Release:" && ./bin/release /tmp/build; \
+			echo -en "\n~ Detect: " && ./bin/detect /tmp/build_1; \
+			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build_1 /tmp/cache /tmp/env || COMPILE_FAILED=1; }; \
+			echo -e "\n~ Report:" && ./bin/report /tmp/build_1 /tmp/cache /tmp/env; \
+			[[ "$${COMPILE_FAILED:-}" == "1" ]] && exit $(COMPILE_FAILURE_EXIT_CODE); \
+			[[ -f /tmp/build_1/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build_1/bin/compile /tmp/build_1 /tmp/cache /tmp/env); }; \
+			echo -e "\n~ Release:" && ./bin/release /tmp/build_1; \
+			rm -rf /app/* /tmp/buildpack/export /tmp/build_1; \
+			cp -r /src/$(FIXTURE) /tmp/build_2; \
+			echo -e "\n~ Recompile:" && ./bin/compile /tmp/build_2 /tmp/cache /tmp/env; \
 			echo -e "\nBuild successful!"; \
 		'
 	@echo


### PR DESCRIPTION
Updates `make run` (used locally during development) to:
- Run a second build after the first, which allows for easy testing of cached workflows. This second build uses a different build directory path to the first, to match the Heroku Cedar/classic build system and allow for testing that relocation/path rewriting works as expected.
- Exit non-zero if the compile failed (it previously didn't, so we could test `bin/report` for failing builds - but that's now handled via a customisable exit code).

GUS-W-17879839.