### PR TITLE
Migrate to Rubocop's new plugin syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:


### PR DESCRIPTION
To suppress this Rubocop warning:

```
$ make lint
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of
`require: rubocop-rspec` in /Users/emorley/src/heroku-buildpack-python/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```
