### PR TITLE
Improve package manager bootstrap error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved the error messages shown if installing pip/Poetry/Pipenv fails. ([#1764](https://github.com/heroku/heroku-buildpack-python/pull/1764))
 - Stopped installing pip into Poetry's virtual environment. ([#1761](https://github.com/heroku/heroku-buildpack-python/pull/1761))
 
 ## [v278] - 2025-02-24

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -46,6 +46,7 @@ function pip::install_pip_setuptools_wheel() {
 	# app's requirements.txt in the last build). The install will be a no-op if the versions match.
 	output::step "Installing ${packages_display_text}"
 
+	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 	if ! {
 		python "${bundled_pip_module_path}" \
 			install \
@@ -53,15 +54,18 @@ function pip::install_pip_setuptools_wheel() {
 			--no-cache-dir \
 			--no-input \
 			--quiet \
-			"${packages_to_install[@]}"
+			"${packages_to_install[@]}" \
+			|& output::indent
 	}; then
 		output::error <<-EOF
 			Error: Unable to install pip.
 
+			In some cases, this happens due to a temporary issue with
+			the network connection or Python Package Index (PyPI).
+
 			Try building again to see if the error resolves itself.
 
-			If that does not help, check the status of PyPI (the Python
-			package repository service), here:
+			If that does not help, check the status of PyPI here:
 			https://status.python.org
 		EOF
 		meta_set "failure_reason" "install-package-manager::pip"

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -18,6 +18,8 @@ function pipenv::install_pipenv() {
 	# TODO: Install Pipenv into a venv so it isn't leaked into the app environment.
 	# TODO: Skip installing Pipenv if its version hasn't changed (once it's installed into a venv).
 	# TODO: Explore viability of making Pipenv only be available during the build, to reduce slug size.
+
+	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 	if ! {
 		pip \
 			install \
@@ -25,15 +27,18 @@ function pipenv::install_pipenv() {
 			--no-cache-dir \
 			--no-input \
 			--quiet \
-			"pipenv==${PIPENV_VERSION}"
+			"pipenv==${PIPENV_VERSION}" \
+			|& output::indent
 	}; then
 		output::error <<-EOF
 			Error: Unable to install Pipenv.
 
+			In some cases, this happens due to a temporary issue with
+			the network connection or Python Package Index (PyPI).
+
 			Try building again to see if the error resolves itself.
 
-			If that does not help, check the status of PyPI (the Python
-			package repository service), here:
+			If that does not help, check the status of PyPI here:
 			https://status.python.org
 		EOF
 		meta_set "failure_reason" "install-package-manager::pipenv"


### PR DESCRIPTION
* Any errors are now indented using the same indent helper used for other buildpack subprocesses. (These bootstrap commands use `--quiet` so don't output anything on the happy path, only when errors occur.)
* Adds "temporary network issue" verbiage based on that now used for the Python runtime download step.

GUS-W-17895970.