### PR TITLE
Stop filtering out pip's "Requirement already satisfied" log lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Stopped filtering out pip's `Requirement already satisfied:` log lines when installing dependencies. ([#1765](https://github.com/heroku/heroku-buildpack-python/pull/1765))
 - Improved the error messages shown if installing pip/Poetry/Pipenv fails. ([#1764](https://github.com/heroku/heroku-buildpack-python/pull/1764))
 - Stopped installing pip into Poetry's virtual environment. ([#1761](https://github.com/heroku/heroku-buildpack-python/pull/1761))
 

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -106,6 +106,8 @@ function pip::install_dependencies() {
 	# We only display the most relevant command args here, to improve the signal to noise ratio.
 	output::step "Installing dependencies using '${pip_install_command[*]}'"
 
+	# The sed usage is to reduce the verbosity of output lines like:
+	# "Requirement already satisfied: typing-extensions==4.12.2 in /app/.heroku/python/lib/python3.13/site-packages (from -r requirements.txt (line 5)) (4.12.2)"
 	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 	if ! {
 		"${pip_install_command[@]}" \
@@ -116,7 +118,7 @@ function pip::install_dependencies() {
 			--progress-bar off \
 			--src='/app/.heroku/python/src' \
 			|& tee "${WARNINGS_LOG:?}" \
-			|& sed --unbuffered --expression '/Requirement already satisfied/d' \
+			|& sed --unbuffered --expression 's# in /app/.heroku/python/lib/python.*/site-packages##' \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling.

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -62,16 +62,19 @@ RSpec.describe 'Heroku CI' do
         REGEX
 
         test_run.run_again
-        expect(clean_output(test_run.output)).to include(<<~OUTPUT)
+        expect(clean_output(test_run.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           -----> Python app detected
           -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           -----> Restoring cache
           -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
           -----> Installing pip #{PIP_VERSION}
           -----> Installing dependencies using 'pip install -r requirements.txt -r requirements-test.txt'
+                 Requirement already satisfied: typing-extensions==.+
+                 Requirement already satisfied: pytest==.+
+                 .+
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running bin/post_compile hook
-        OUTPUT
+        REGEX
       end
     end
   end

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'pip support' do
           remote: -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Installing pip #{PIP_VERSION}
           remote: -----> Installing dependencies using 'pip install -r requirements.txt'
+          remote:        Requirement already satisfied: typing-extensions==4.12.2 (from -r requirements.txt (line 5)) (4.12.2)
           remote: -----> Inline app detected
         OUTPUT
       end


### PR DESCRIPTION
Since while removing them makes the install logs for cached builds slightly shorter, it hides what is happening and makes it harder to see what package version a historic build may have been using from the logs alone. For example, when comparing a last successful build to a newly failing build after a cache-invalidation event.

This now matches the behaviour for our other supported package managers, where we don't filter out install lines relating to already installed/cached packages.

As a compromise, we still edit the lines slightly, to remove the redundant site-packages path information, which would otherwise cause each package message to wrap across multiple lines.

GUS-W-17897541.