### PR TITLE
Remove support for Heroku-20

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -13,7 +13,6 @@ on:
         type: choice
         options:
           - auto
-          - heroku-20
           - heroku-22
           - heroku-24
         default: auto
@@ -36,27 +35,6 @@ env:
 # Unfortunately these jobs cannot be easily written as a matrix since `matrix.exclude` does not
 # support expression syntax, and the `matrix` context is not available inside the job `if` key.
 jobs:
-  heroku-20:
-    if: inputs.stack == 'heroku-20' || inputs.stack == 'auto'
-    runs-on: pub-hk-ubuntu-24.04-xlarge
-    env:
-      STACK_VERSION: "20"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Docker image
-        run: docker build --platform="linux/amd64" --pull --tag buildenv --build-arg=STACK_VERSION builds/
-      - name: Compile and package Python runtime
-        run: docker run --rm --volume="${PWD}/upload:/tmp/upload" buildenv ./build_python_runtime.sh "${{ inputs.python_version }}"
-      - name: Test Python runtime
-        run: |
-          RUN_IMAGE='heroku/heroku:${{ env.STACK_VERSION }}'
-          ARCHIVE_FILENAME='python-${{ inputs.python_version }}-ubuntu-${{ env.STACK_VERSION }}.04-amd64.tar.zst'
-          docker run --rm --volume="${PWD}/upload:/upload:ro" --volume="${PWD}/builds:/builds:ro" "${RUN_IMAGE}" /builds/test_python_runtime.sh "/upload/${ARCHIVE_FILENAME}"
-      - name: Upload Python runtime archive to S3
-        if: (!inputs.dry_run)
-        run: aws s3 sync ./upload "s3://${S3_BUCKET}"
-
   heroku-22:
     if: inputs.stack == 'heroku-22' || inputs.stack == 'auto'
     runs-on: pub-hk-ubuntu-24.04-xlarge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-20", "heroku-22", "heroku-24"]
+        stack: ["heroku-22", "heroku-24"]
     env:
       HATCHET_APP_LIMIT: 300
       HATCHET_DEFAULT_STACK: ${{ matrix.stack }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Removed support for Heroku-20. ([#1778](https://github.com/heroku/heroku-buildpack-python/pull/1778))
 
 ## [v281] - 2025-04-08
 

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -21,7 +21,7 @@ function abort() {
 }
 
 case "${STACK:?}" in
-	heroku-20 | heroku-22 | heroku-24)
+	heroku-22 | heroku-24)
 		SUPPORTED_PYTHON_VERSIONS=(
 			"3.9"
 			"3.10"

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -4,7 +4,7 @@ function checks::ensure_supported_stack() {
 	local stack="${1}"
 
 	case "${stack}" in
-		heroku-20 | heroku-22 | heroku-24)
+		heroku-22 | heroku-24)
 			return 0
 			;;
 		cedar* | heroku-16 | heroku-18)
@@ -15,7 +15,7 @@ function checks::ensure_supported_stack() {
 
 				This buildpack no longer supports the '${stack}' stack since it has
 				reached its end-of-life:
-				https://devcenter.heroku.com/articles/stack#stack-support-details-for-apps-using-classic-buildpacks
+				https://devcenter.heroku.com/articles/stack#stack-support-details
 
 				Upgrade to a newer stack to continue using this buildpack.
 			EOF

--- a/lib/python.sh
+++ b/lib/python.sh
@@ -77,7 +77,7 @@ function python::install() {
 			#    decompression/extraction as separate steps), so can't write to stdout.
 			# 2. We want to display the original stderr to the user, so can't write to stderr.
 			# 3. Curl's `--write-out` feature only supports outputting to a file (as opposed to
-			#    stdout/stderr) as of curl v8.3.0, which is newer than the curl on Heroku-20/22.
+			#    stdout/stderr) as of curl v8.3.0, which is newer than the curl on Heroku-22.
 			# This has an integration test run against all stacks, which will mean we will know
 			# if future versions of curl change the error message string.
 			#


### PR DESCRIPTION
Since the Heroku-20 stack has reached end-of-life, and as such builds using it are no longer supported by the Heroku build system: https://devcenter.heroku.com/changelog-items/3230

This fixes the integration tests failing in CI for the Heroku-20 stack, due to the build system now (as expected) rejecting the jobs.

Any non-Heroku consumers of this buildpack that wish to continue using the Heroku-20 stack should pin to the previous version of this buildpack.

GUS-W-14707057.