### PR TITLE
Backport error message/build output improvements from CNB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Improved the instructions for migrating from `runtime.txt` to `.python-version`. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
+- Improved the error message instructions shown when `.python-version`, `runtime.txt` or `Pipfile.lock` contain an invalid Python version. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
+- Improved the rendering of the error message shown if `.python-version` or `runtime.txt` contain stray invisible characters (such as ASCII control codes). ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
+- Improved the upgrade instructions shown for EOL and unsupported Python versions. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
 
 ## [v282] - 2025-05-02
 

--- a/bin/compile
+++ b/bin/compile
@@ -152,15 +152,20 @@ if [[ "${python_version_origin}" == "runtime.txt" ]]; then
 		Please delete your runtime.txt file and create a new file named:
 		.python-version
 
-		Make sure to include the '.' at the start of the filename.
+		Make sure to include the '.' character at the start of the
+		filename. Don't add a file extension such as '.txt'.
 
-		In the new file, specify your app's Python version without
-		quotes or a 'python-' prefix. For example:
+		In the new file, specify your app's major Python version number
+		only. Don't include quotes or a 'python-' prefix.
+
+		For example, to request the latest version of Python ${python_major_version},
+		update your .python-version file so it contains exactly:
 		${python_major_version}
 
-		We strongly recommend that you use the major version form
-		instead of pinning to an exact version, since it will allow
-		your app to receive Python security updates.
+		We strongly recommend that you don't specify the Python patch
+		version number, since it will pin your app to an exact Python
+		version and so stop your app from receiving security updates
+		each time it builds.
 
 		In the future support for runtime.txt will be removed and
 		this warning will be made an error.

--- a/bin/steps/nltk
+++ b/bin/steps/nltk
@@ -35,7 +35,7 @@ if is_module_available 'nltk'; then
 				Error: Unable to download NLTK data.
 
 				The 'python -m nltk.downloader' command to download NLTK
-				data did not exit successfully.
+				data didn't exit successfully.
 
 				See the log output above for more information.
 			EOF

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -25,12 +25,12 @@ function checks::ensure_supported_stack() {
 			;;
 		*)
 			output::error <<-EOF
-				Error: The '${stack}' stack is not recognised.
+				Error: The '${stack}' stack isn't recognised.
 
-				This buildpack does not recognise or support the '${stack}' stack.
+				This buildpack doesn't recognise or support the '${stack}' stack.
 
 				If '${stack}' is a valid stack, make sure that you are using the latest
-				version of this buildpack and have not pinned to an older release:
+				version of this buildpack and haven't pinned to an older release:
 				https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
 				https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
 			EOF
@@ -57,7 +57,7 @@ function checks::warn_if_duplicate_python_buildpack() {
 			from a buildpack run earlier in the build.
 
 			This normally means there are duplicate Python buildpacks set
-			on your app, which is not supported, can cause errors and
+			on your app, which isn't supported, can cause errors and
 			slow down builds.
 
 			Check the buildpacks set on your app and remove any duplicate
@@ -99,13 +99,13 @@ function checks::warn_if_existing_python_dir_present() {
 			$(find .heroku/python/ -maxdepth 2 || true)
 
 			Writing to internal locations used by the Python buildpack
-			is not supported and can cause unexpected errors.
+			isn't supported and can cause unexpected errors.
 
 			If you have committed a '.heroku/python/' directory to your
 			Git repo, you must delete it or use a different location.
 
 			Otherwise, check that an earlier buildpack or 'bin/pre_compile'
-			hook has not created this directory.
+			hook hasn't created this directory.
 
 			If you have a use-case that requires writing to this location,
 			please comment on:

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -20,14 +20,14 @@ function package_manager::determine_package_manager() {
 
 			A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
 			Pipenv lockfile was not. This means your app dependency versions
-			are not pinned, which means the package versions used on Heroku
+			aren't pinned, which means the package versions used on Heroku
 			might not match those installed in other environments.
 
 			For now, we will install your dependencies without a lockfile,
 			however, in the future this warning will become an error.
 
 			Run 'pipenv lock' locally to generate the lockfile, and make sure
-			that 'Pipfile.lock' is not listed in '.gitignore' or '.slugignore'.
+			that 'Pipfile.lock' isn't listed in '.gitignore' or '.slugignore'.
 		EOF
 		package_managers_found+=(pipenv)
 		package_managers_found_display_text+=("Pipfile (Pipenv)")

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -65,7 +65,7 @@ function pip::install_pip_setuptools_wheel() {
 
 			Try building again to see if the error resolves itself.
 
-			If that does not help, check the status of PyPI here:
+			If that doesn't help, check the status of PyPI here:
 			https://status.python.org
 		EOF
 		meta_set "failure_reason" "install-package-manager::pip"

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -38,7 +38,7 @@ function pipenv::install_pipenv() {
 
 			Try building again to see if the error resolves itself.
 
-			If that does not help, check the status of PyPI here:
+			If that doesn't help, check the status of PyPI here:
 			https://status.python.org
 		EOF
 		meta_set "failure_reason" "install-package-manager::pipenv"

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -85,7 +85,7 @@ function poetry::install_poetry() {
 
 				Try building again to see if the error resolves itself.
 
-				If that does not help, check the status of PyPI here:
+				If that doesn't help, check the status of PyPI here:
 				https://status.python.org
 			EOF
 			meta_set "failure_reason" "install-package-manager::poetry"

--- a/lib/python.sh
+++ b/lib/python.sh
@@ -100,7 +100,7 @@ function python::install() {
 					https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
 					https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
 
-					We also strongly recommend that you do not pin your app to an
+					We also strongly recommend that you don't pin your app to an
 					exact Python version such as ${python_full_version}, and instead only specify
 					the major Python version of ${python_major_version} in your ${python_version_origin} file.
 					This will allow your app to receive the latest available Python

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -52,7 +52,7 @@ function python_version::read_requested_python_version() {
 
 	local runtime_txt_path="${build_dir}/runtime.txt"
 	if [[ -f "${runtime_txt_path}" ]]; then
-		contents="$(cat "${runtime_txt_path}")"
+		contents="$(cat --show-nonprinting "${runtime_txt_path}")"
 		version="$(python_version::parse_runtime_txt "${contents}")"
 		origin="runtime.txt"
 		return 0
@@ -60,7 +60,7 @@ function python_version::read_requested_python_version() {
 
 	local python_version_file_path="${build_dir}/.python-version"
 	if [[ -f "${python_version_file_path}" ]]; then
-		contents="$(cat "${python_version_file_path}")"
+		contents="$(cat --show-nonprinting "${python_version_file_path}")"
 		version="$(python_version::parse_python_version_file "${contents}")"
 		origin=".python-version"
 		return 0
@@ -106,23 +106,28 @@ function python_version::parse_runtime_txt() {
 			The following file contents were found, which aren't valid:
 			${contents:0:100}
 
-			However, the runtime.txt file is deprecated since it has
-			been replaced by the .python-version file. As such, we
-			recommend that you switch to using a .python-version file
+			However, the runtime.txt file is deprecated since it has been
+			replaced by the more widely supported .python-version file.
+			As such, we recommend that you switch to using .python-version
 			instead of fixing your runtime.txt file.
 
 			Please delete your runtime.txt file and create a new file named:
 			.python-version
 
-			Make sure to include the '.' at the start of the filename.
+			Make sure to include the '.' character at the start of the
+			filename. Don't add a file extension such as '.txt'.
 
-			In the new file, specify your app's Python version without
-			quotes or a 'python-' prefix. For example:
+			In the new file, specify your app's major Python version number
+			only. Don't include quotes or a 'python-' prefix.
+
+			For example, to request the latest version of Python ${DEFAULT_PYTHON_MAJOR_VERSION},
+			update your .python-version file so it contains exactly:
 			${DEFAULT_PYTHON_MAJOR_VERSION}
 
-			We strongly recommend that you use the major version form
-			instead of pinning to an exact version, since it will allow
-			your app to receive Python security updates.
+			We strongly recommend that you don't specify the Python patch
+			version number, since it will pin your app to an exact Python
+			version and so stop your app from receiving security updates
+			each time it builds.
 		EOF
 		meta_set "failure_reason" "runtime-txt::invalid-version"
 		meta_set "failure_detail" "${contents:0:50}"
@@ -160,19 +165,20 @@ function python_version::parse_python_version_file() {
 					${line}
 
 					However, the Python version must be specified as either:
-					1. The major version only: 3.X  (recommended)
-					2. An exact patch version: 3.X.Y
+					1. The major version only, for example: ${DEFAULT_PYTHON_MAJOR_VERSION} (recommended)
+					2. An exact patch version, for example: ${DEFAULT_PYTHON_MAJOR_VERSION}.999
 
-					Don't include quotes or a 'python-' prefix. To include
-					comments, add them on their own line, prefixed with '#'.
+					Don't include quotes, a 'python-' prefix or wildcards. Any
+					code comments must be on a separate line prefixed with '#'.
 
 					For example, to request the latest version of Python ${DEFAULT_PYTHON_MAJOR_VERSION},
-					update your .python-version file so it contains:
+					update your .python-version file so it contains exactly:
 					${DEFAULT_PYTHON_MAJOR_VERSION}
 
-					We strongly recommend that you use the major version form
-					instead of pinning to an exact version, since it will allow
-					your app to receive Python security updates.
+					We strongly recommend that you don't specify the Python patch
+					version number, since it will pin your app to an exact Python
+					version and so stop your app from receiving security updates
+					each time it builds.
 				EOF
 				meta_set "failure_reason" "python-version-file::invalid-version"
 				meta_set "failure_detail" "${line:0:50}"
@@ -185,10 +191,11 @@ function python_version::parse_python_version_file() {
 
 				No Python version was found in your .python-version file.
 
-				Update the file so that it contains a valid Python version.
+				Update the file so that it contains your app's major Python
+				version number. Don't include quotes or a 'python-' prefix.
 
 				For example, to request the latest version of Python ${DEFAULT_PYTHON_MAJOR_VERSION},
-				update your .python-version file so it contains:
+				update your .python-version file so it contains exactly:
 				${DEFAULT_PYTHON_MAJOR_VERSION}
 
 				If the file already contains a version, check the line doesn't
@@ -211,6 +218,10 @@ function python_version::parse_python_version_file() {
 				)
 
 				Update the file so it contains only one Python version.
+
+				For example, to request the latest version of Python ${DEFAULT_PYTHON_MAJOR_VERSION},
+				update your .python-version file so it contains exactly:
+				${DEFAULT_PYTHON_MAJOR_VERSION}
 
 				If you have added comments to the file, make sure that those
 				lines begin with a '#', so that they are ignored.
@@ -278,15 +289,18 @@ function python_version::read_pipenv_python_version() {
 			${version}
 
 			However, the Python version must be specified as either:
-			1. The major version only: 3.X  (recommended)
-			2. An exact patch version: 3.X.Y
+			1. The major version only, for example: ${DEFAULT_PYTHON_MAJOR_VERSION} (recommended)
+			2. An exact patch version, for example: ${DEFAULT_PYTHON_MAJOR_VERSION}.999
+
+			Wildcards aren't supported.
 
 			Please update your Pipfile to use a valid Python version and
 			then run 'pipenv lock' to regenerate Pipfile.lock.
 
-			We strongly recommend that you use the major version form
-			instead of pinning to an exact version, since it will allow
-			your app to receive Python security updates.
+			We strongly recommend that you don't specify the Python patch
+			version number, since it will pin your app to an exact Python
+			version and so stop your app from receiving security updates
+			each time it builds.
 
 			For more information, see:
 			https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
@@ -329,12 +343,21 @@ function python_version::resolve_python_version() {
 				Please upgrade to at least Python 3.${OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION} by configuring an
 				explicit Python version for your app.
 
-				Create a .python-version file in the root directory of your
-				app, that contains a Python version like:
-				3.${NEWEST_SUPPORTED_PYTHON_3_MINOR_VERSION}
+				Create a new file in the root directory of your app named:
+				.python-version
 
-				When creating this file make sure to include the '.' at the
-				start of the filename.
+				Make sure to include the '.' character at the start of the
+				filename. Don't add a file extension such as '.txt'.
+
+				In the new file, specify the new major Python version number
+				only. Don't include quotes or a 'python-' prefix.
+
+				For example, to request the latest version of Python 3.${OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION},
+				update your .python-version file so it contains exactly:
+				3.${OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION}
+
+				If possible, we recommend upgrading all the way to Python ${DEFAULT_PYTHON_MAJOR_VERSION},
+				since it contains many performance and usability improvements.
 			EOF
 		else
 			output::error <<-EOF
@@ -349,6 +372,9 @@ function python_version::resolve_python_version() {
 
 				Please upgrade to at least Python 3.${OLDEST_SUPPORTED_PYTHON_3_MINOR_VERSION} by changing the
 				version in your ${python_version_origin} file.
+
+				If possible, we recommend upgrading all the way to Python ${DEFAULT_PYTHON_MAJOR_VERSION},
+				since it contains many performance and usability improvements.
 			EOF
 		fi
 		meta_set "failure_reason" "python-version::eol"
@@ -464,7 +490,7 @@ function python_version::warn_if_patch_update_available() {
 
 			Update your ${python_version_origin} file to use the new version.
 
-			We strongly recommend that you do not pin your app to an
+			We strongly recommend that you don't pin your app to an
 			exact Python version such as ${python_full_version}, and instead only specify
 			the major Python version of ${python_major_version} in your ${python_version_origin} file.
 			This will allow your app to receive the latest available Python

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -35,10 +35,10 @@ function utils::bundled_pip_module_path() {
 		echo "${bundled_pip_wheel}/pip"
 	else
 		output::error <<-EOF
-			Internal Error: Unable to locate the bundled copy of pip.
+			Internal Error: Unable to locate the Python stdlib's bundled pip.
 
-			The Python buildpack could not locate the copy of pip bundled
-			inside Python's 'ensurepip' module:
+			Couldn't find the pip wheel file bundled inside the Python
+			stdlib's 'ensurepip' module:
 
 			$(find "${bundled_wheels_dir}/" 2>&1 || find "${python_home}/" -type d 2>&1 || true)
 		EOF

--- a/spec/fixtures/python_version_file_invalid_version/.python-version
+++ b/spec/fixtures/python_version_file_invalid_version/.python-version
@@ -4,7 +4,8 @@
 # So are empty lines, and leading/trailing whitespace.
 
   
-  3.12.0invalid  
+  # The version number has a trailing control character.
+  3.12.0  
   
 
 # 2.7.18

--- a/spec/fixtures/runtime_txt_invalid_version/runtime.txt
+++ b/spec/fixtures/runtime_txt_invalid_version/runtime.txt
@@ -1,1 +1,1 @@
-python-3.12.0invalid
+python-3.12.0

--- a/spec/hatchet/checks_spec.rb
+++ b/spec/hatchet/checks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Buildpack validation checks' do
           remote:  !     from a buildpack run earlier in the build.
           remote:  !     
           remote:  !     This normally means there are duplicate Python buildpacks set
-          remote:  !     on your app, which is not supported, can cause errors and
+          remote:  !     on your app, which isn't supported, can cause errors and
           remote:  !     slow down builds.
           remote:  !     
           remote:  !     Check the buildpacks set on your app and remove any duplicate
@@ -59,13 +59,13 @@ RSpec.describe 'Buildpack validation checks' do
           remote:  !     .heroku/python/bin/python
           remote:  !     
           remote:  !     Writing to internal locations used by the Python buildpack
-          remote:  !     is not supported and can cause unexpected errors.
+          remote:  !     isn't supported and can cause unexpected errors.
           remote:  !     
           remote:  !     If you have committed a '.heroku/python/' directory to your
           remote:  !     Git repo, you must delete it or use a different location.
           remote:  !     
           remote:  !     Otherwise, check that an earlier buildpack or 'bin/pre_compile'
-          remote:  !     hook has not created this directory.
+          remote:  !     hook hasn't created this directory.
           remote:  !     
           remote:  !     If you have a use-case that requires writing to this location,
           remote:  !     please comment on:
@@ -76,10 +76,10 @@ RSpec.describe 'Buildpack validation checks' do
           remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           remote: -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: 
-          remote:  !     Internal Error: Unable to locate the bundled copy of pip.
+          remote:  !     Internal Error: Unable to locate the Python stdlib's bundled pip.
           remote:  !     
-          remote:  !     The Python buildpack could not locate the copy of pip bundled
-          remote:  !     inside Python's 'ensurepip' module:
+          remote:  !     Couldn't find the pip wheel file bundled inside the Python
+          remote:  !     stdlib's 'ensurepip' module:
           remote:  !     
           remote:  !     find: ‘/app/.heroku/python/lib/python3.13/ensurepip/_bundled/’: No such file or directory
           remote:  !     /app/.heroku/python/

--- a/spec/hatchet/nltk_spec.rb
+++ b/spec/hatchet/nltk_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'NLTK corpora support' do
           remote:  !     Error: Unable to download NLTK data.
           remote:  !     
           remote:  !     The 'python -m nltk.downloader' command to download NLTK
-          remote:  !     data did not exit successfully.
+          remote:  !     data didn't exit successfully.
           remote:  !     
           remote:  !     See the log output above for more information.
           remote: 

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     
           remote:  !     Update your Pipfile.lock file to use the new version.
           remote:  !     
-          remote:  !     We strongly recommend that you do not pin your app to an
+          remote:  !     We strongly recommend that you don't pin your app to an
           remote:  !     exact Python version such as 3.9.0, and instead only specify
           remote:  !     the major Python version of 3.9 in your Pipfile.lock file.
           remote:  !     This will allow your app to receive the latest available Python
@@ -171,14 +171,14 @@ RSpec.describe 'Pipenv support' do
           remote:  !     
           remote:  !     A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
           remote:  !     Pipenv lockfile was not. This means your app dependency versions
-          remote:  !     are not pinned, which means the package versions used on Heroku
+          remote:  !     aren't pinned, which means the package versions used on Heroku
           remote:  !     might not match those installed in other environments.
           remote:  !     
           remote:  !     For now, we will install your dependencies without a lockfile,
           remote:  !     however, in the future this warning will become an error.
           remote:  !     
           remote:  !     Run 'pipenv lock' locally to generate the lockfile, and make sure
-          remote:  !     that 'Pipfile.lock' is not listed in '.gitignore' or '.slugignore'.
+          remote:  !     that 'Pipfile.lock' isn't listed in '.gitignore' or '.slugignore'.
           remote: 
           remote: -----> No Python version was specified. Using the buildpack default: Python #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:        To use a different version, see: https://devcenter.heroku.com/articles/python-runtimes
@@ -239,15 +239,18 @@ RSpec.describe 'Pipenv support' do
           remote:  !     ^3.12
           remote:  !     
           remote:  !     However, the Python version must be specified as either:
-          remote:  !     1. The major version only: 3.X  (recommended)
-          remote:  !     2. An exact patch version: 3.X.Y
+          remote:  !     1. The major version only, for example: #{DEFAULT_PYTHON_MAJOR_VERSION} (recommended)
+          remote:  !     2. An exact patch version, for example: #{DEFAULT_PYTHON_MAJOR_VERSION}.999
+          remote:  !     
+          remote:  !     Wildcards aren't supported.
           remote:  !     
           remote:  !     Please update your Pipfile to use a valid Python version and
           remote:  !     then run 'pipenv lock' to regenerate Pipfile.lock.
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote:  !     
           remote:  !     For more information, see:
           remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
@@ -275,15 +278,18 @@ RSpec.describe 'Pipenv support' do
           remote:  !     3.9.*
           remote:  !     
           remote:  !     However, the Python version must be specified as either:
-          remote:  !     1. The major version only: 3.X  (recommended)
-          remote:  !     2. An exact patch version: 3.X.Y
+          remote:  !     1. The major version only, for example: #{DEFAULT_PYTHON_MAJOR_VERSION} (recommended)
+          remote:  !     2. An exact patch version, for example: #{DEFAULT_PYTHON_MAJOR_VERSION}.999
+          remote:  !     
+          remote:  !     Wildcards aren't supported.
           remote:  !     
           remote:  !     Please update your Pipfile to use a valid Python version and
           remote:  !     then run 'pipenv lock' to regenerate Pipfile.lock.
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote:  !     
           remote:  !     For more information, see:
           remote:  !     https://pipenv.pypa.io/en/stable/specifiers.html#specifying-versions-of-python
@@ -314,6 +320,9 @@ RSpec.describe 'Pipenv support' do
           remote:  !     
           remote:  !     Please upgrade to at least Python 3.9 by changing the
           remote:  !     version in your Pipfile.lock file.
+          remote:  !     
+          remote:  !     If possible, we recommend upgrading all the way to Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     since it contains many performance and usability improvements.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe 'Poetry support' do
           remote:  !     
           remote:  !     Update your .python-version file to use the new version.
           remote:  !     
-          remote:  !     We strongly recommend that you do not pin your app to an
+          remote:  !     We strongly recommend that you don't pin your app to an
           remote:  !     exact Python version such as 3.9.0, and instead only specify
           remote:  !     the major Python version of 3.9 in your .python-version file.
           remote:  !     This will allow your app to receive the latest available Python

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -24,15 +24,20 @@ RSpec.describe 'Python update warnings' do
           remote:  !     Please delete your runtime.txt file and create a new file named:
           remote:  !     .python-version
           remote:  !     
-          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     Make sure to include the '.' character at the start of the
+          remote:  !     filename. Don't add a file extension such as '.txt'.
           remote:  !     
-          remote:  !     In the new file, specify your app's Python version without
-          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     In the new file, specify your app's major Python version number
+          remote:  !     only. Don't include quotes or a 'python-' prefix.
+          remote:  !     
+          remote:  !     For example, to request the latest version of Python 3.9,
+          remote:  !     update your .python-version file so it contains exactly:
           remote:  !     3.9
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote:  !     
           remote:  !     In the future support for runtime.txt will be removed and
           remote:  !     this warning will be made an error.
@@ -64,7 +69,7 @@ RSpec.describe 'Python update warnings' do
           remote:  !     
           remote:  !     Update your runtime.txt file to use the new version.
           remote:  !     
-          remote:  !     We strongly recommend that you do not pin your app to an
+          remote:  !     We strongly recommend that you don't pin your app to an
           remote:  !     exact Python version such as 3.9.0, and instead only specify
           remote:  !     the major Python version of 3.9 in your runtime.txt file.
           remote:  !     This will allow your app to receive the latest available Python
@@ -96,7 +101,7 @@ RSpec.describe 'Python update warnings' do
           remote:  !     
           remote:  !     Update your .python-version file to use the new version.
           remote:  !     
-          remote:  !     We strongly recommend that you do not pin your app to an
+          remote:  !     We strongly recommend that you don't pin your app to an
           remote:  !     exact Python version such as 3.10.0, and instead only specify
           remote:  !     the major Python version of 3.10 in your .python-version file.
           remote:  !     This will allow your app to receive the latest available Python

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -152,22 +152,23 @@ RSpec.describe 'Python version support' do
           remote:  !     isn't in the correct format.
           remote:  !     
           remote:  !     The following version was found:
-          remote:  !       3.12.0invalid  
+          remote:  !       3.12.0^[  
           remote:  !     
           remote:  !     However, the Python version must be specified as either:
-          remote:  !     1. The major version only: 3.X  (recommended)
-          remote:  !     2. An exact patch version: 3.X.Y
+          remote:  !     1. The major version only, for example: #{DEFAULT_PYTHON_MAJOR_VERSION} (recommended)
+          remote:  !     2. An exact patch version, for example: #{DEFAULT_PYTHON_MAJOR_VERSION}.999
           remote:  !     
-          remote:  !     Don't include quotes or a 'python-' prefix. To include
-          remote:  !     comments, add them on their own line, prefixed with '#'.
+          remote:  !     Don't include quotes, a 'python-' prefix or wildcards. Any
+          remote:  !     code comments must be on a separate line prefixed with '#'.
           remote:  !     
           remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-          remote:  !     update your .python-version file so it contains:
+          remote:  !     update your .python-version file so it contains exactly:
           remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -187,10 +188,11 @@ RSpec.describe 'Python version support' do
           remote:  !     
           remote:  !     No Python version was found in your .python-version file.
           remote:  !     
-          remote:  !     Update the file so that it contains a valid Python version.
+          remote:  !     Update the file so that it contains your app's major Python
+          remote:  !     version number. Don't include quotes or a 'python-' prefix.
           remote:  !     
           remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-          remote:  !     update your .python-version file so it contains:
+          remote:  !     update your .python-version file so it contains exactly:
           remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:  !     
           remote:  !     If the file already contains a version, check the line doesn't
@@ -219,6 +221,10 @@ RSpec.describe 'Python version support' do
           remote:  !     2.7
           remote:  !     
           remote:  !     Update the file so it contains only one Python version.
+          remote:  !     
+          remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     update your .python-version file so it contains exactly:
+          remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:  !     
           remote:  !     If you have added comments to the file, make sure that those
           remote:  !     lines begin with a '#', so that they are ignored.
@@ -249,6 +255,9 @@ RSpec.describe 'Python version support' do
           remote:  !     
           remote:  !     Please upgrade to at least Python 3.9 by changing the
           remote:  !     version in your .python-version file.
+          remote:  !     
+          remote:  !     If possible, we recommend upgrading all the way to Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     since it contains many performance and usability improvements.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -317,7 +326,7 @@ RSpec.describe 'Python version support' do
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
           remote:  !     
-          remote:  !     We also strongly recommend that you do not pin your app to an
+          remote:  !     We also strongly recommend that you don't pin your app to an
           remote:  !     exact Python version such as 3.12.999, and instead only specify
           remote:  !     the major Python version of 3.12 in your .python-version file.
           remote:  !     This will allow your app to receive the latest available Python
@@ -343,25 +352,30 @@ RSpec.describe 'Python version support' do
           remote:  !     in the correct format.
           remote:  !     
           remote:  !     The following file contents were found, which aren't valid:
-          remote:  !     python-3.12.0invalid
+          remote:  !     python-3.12.0^[
           remote:  !     
-          remote:  !     However, the runtime.txt file is deprecated since it has
-          remote:  !     been replaced by the .python-version file. As such, we
-          remote:  !     recommend that you switch to using a .python-version file
+          remote:  !     However, the runtime.txt file is deprecated since it has been
+          remote:  !     replaced by the more widely supported .python-version file.
+          remote:  !     As such, we recommend that you switch to using .python-version
           remote:  !     instead of fixing your runtime.txt file.
           remote:  !     
           remote:  !     Please delete your runtime.txt file and create a new file named:
           remote:  !     .python-version
           remote:  !     
-          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     Make sure to include the '.' character at the start of the
+          remote:  !     filename. Don't add a file extension such as '.txt'.
           remote:  !     
-          remote:  !     In the new file, specify your app's Python version without
-          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     In the new file, specify your app's major Python version number
+          remote:  !     only. Don't include quotes or a 'python-' prefix.
+          remote:  !     
+          remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     update your .python-version file so it contains exactly:
           remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -389,6 +403,9 @@ RSpec.describe 'Python version support' do
           remote:  !     
           remote:  !     Please upgrade to at least Python 3.9 by changing the
           remote:  !     version in your runtime.txt file.
+          remote:  !     
+          remote:  !     If possible, we recommend upgrading all the way to Python #{DEFAULT_PYTHON_MAJOR_VERSION},
+          remote:  !     since it contains many performance and usability improvements.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
@@ -416,15 +433,20 @@ RSpec.describe 'Python version support' do
           remote:  !     Please delete your runtime.txt file and create a new file named:
           remote:  !     .python-version
           remote:  !     
-          remote:  !     Make sure to include the '.' at the start of the filename.
+          remote:  !     Make sure to include the '.' character at the start of the
+          remote:  !     filename. Don't add a file extension such as '.txt'.
           remote:  !     
-          remote:  !     In the new file, specify your app's Python version without
-          remote:  !     quotes or a 'python-' prefix. For example:
+          remote:  !     In the new file, specify your app's major Python version number
+          remote:  !     only. Don't include quotes or a 'python-' prefix.
+          remote:  !     
+          remote:  !     For example, to request the latest version of Python 3.13,
+          remote:  !     update your .python-version file so it contains exactly:
           remote:  !     3.13
           remote:  !     
-          remote:  !     We strongly recommend that you use the major version form
-          remote:  !     instead of pinning to an exact version, since it will allow
-          remote:  !     your app to receive Python security updates.
+          remote:  !     We strongly recommend that you don't specify the Python patch
+          remote:  !     version number, since it will pin your app to an exact Python
+          remote:  !     version and so stop your app from receiving security updates
+          remote:  !     each time it builds.
           remote:  !     
           remote:  !     In the future support for runtime.txt will be removed and
           remote:  !     this warning will be made an error.


### PR DESCRIPTION
Backports the error message/build output improvements made as part of:
- https://github.com/heroku/buildpacks-python/pull/352
- https://github.com/heroku/buildpacks-python/pull/353
- https://github.com/heroku/buildpacks-python/pull/354
- https://github.com/heroku/buildpacks-python/pull/355

Plus:
- applies similar changes to equivalent error messages that only exist in the classic buildpack (eg the Pipenv errors)
- switches to use of contractions as per the CX team's style guidelines

GUS-W-18225347.
GUS-W-18421778.
