### PR TITLE
Start rename of `python_version_reason` metric to `python_version_origin`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,6 +112,8 @@ cached_python_full_version="$(cache::cached_python_full_version "${CACHE_DIR}")"
 # without having to hardcode globals. See: https://stackoverflow.com/a/38997681
 python_version::read_requested_python_version "${BUILD_DIR}" "${package_manager}" "${cached_python_full_version}" requested_python_version python_version_origin
 meta_set "python_version_requested" "${requested_python_version}"
+meta_set "python_version_origin" "${python_version_origin}"
+# TODO: Remove this once the old Honeycomb events that don't have `python_version_origin` have aged out.
 meta_set "python_version_reason" "${python_version_origin}"
 
 # TODO: More strongly recommend specifying a Python version (eg switch the messaging to

--- a/bin/report
+++ b/bin/report
@@ -71,6 +71,7 @@ STRING_FIELDS=(
 	pipenv_version
 	poetry_version
 	python_version_major
+	python_version_origin
 	python_version_reason
 	python_version_requested
 	python_version


### PR DESCRIPTION
So that the metric name reflects the name used within the codebase.

I've left the old metric name in for now, so that existing queries continue to work. Once all old data has aged out that doesn't have the new metric name, I can migrate the queries over to the new name.

GUS-W-18437360.