### PR TITLE
Refactor Python version file related warnings and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [Unreleased]
 
 - Improved the instructions for migrating from `runtime.txt` to `.python-version`. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
-- Improved the error message instructions shown when `.python-version`, `runtime.txt` or `Pipfile.lock` contain an invalid Python version. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
+- Improved the error message instructions shown when `.python-version`, `runtime.txt` or `Pipfile.lock` contain an invalid Python version. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783) and [#1786](https://github.com/heroku/heroku-buildpack-python/pull/1786))
 - Improved the rendering of the error message shown if `.python-version` or `runtime.txt` contain stray invisible characters (such as ASCII control codes). ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
-- Improved the upgrade instructions shown for EOL and unsupported Python versions. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783))
+- Improved the upgrade instructions shown for EOL and unsupported Python versions. ([#1783](https://github.com/heroku/heroku-buildpack-python/pull/1783) and [#1786](https://github.com/heroku/heroku-buildpack-python/pull/1786))
 
 ## [v282] - 2025-05-02
 

--- a/bin/compile
+++ b/bin/compile
@@ -141,37 +141,11 @@ else
 	meta_set "python_version_pinned" "false"
 fi
 
-if [[ "${python_version_origin}" == "runtime.txt" ]]; then
-	output::warning <<-EOF
-		Warning: The runtime.txt file is deprecated.
-
-		The runtime.txt file is deprecated since it has been replaced
-		by the more widely supported .python-version file:
-		https://devcenter.heroku.com/changelog-items/3141
-
-		Please delete your runtime.txt file and create a new file named:
-		.python-version
-
-		Make sure to include the '.' character at the start of the
-		filename. Don't add a file extension such as '.txt'.
-
-		In the new file, specify your app's major Python version number
-		only. Don't include quotes or a 'python-' prefix.
-
-		For example, to request the latest version of Python ${python_major_version},
-		update your .python-version file so it contains exactly:
-		${python_major_version}
-
-		We strongly recommend that you don't specify the Python patch
-		version number, since it will pin your app to an exact Python
-		version and so stop your app from receiving security updates
-		each time it builds.
-
-		In the future support for runtime.txt will be removed and
-		this warning will be made an error.
-	EOF
-fi
-
+# We wait until after Python version resolution to show these warnings, to avoid causing confusion
+# as to what was a warning vs an error. In addition, several of the error messages contain similar
+# content to the warnings (such as encouraging use of .python-version and major version syntax),
+# which would mean duplicate content if we showed both.
+python_version::warn_if_python_version_file_missing "${python_version_origin}" "${python_major_version}"
 python_version::warn_if_deprecated_major_version "${python_major_version}" "${python_version_origin}"
 python_version::warn_if_patch_update_available "${python_full_version}" "${python_major_version}" "${python_version_origin}"
 

--- a/spec/hatchet/python_update_warning_spec.rb
+++ b/spec/hatchet/python_update_warning_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe 'Python update warnings' do
           remote:  !     by the more widely supported .python-version file:
           remote:  !     https://devcenter.heroku.com/changelog-items/3141
           remote:  !     
-          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     Please switch to using a .python-version file instead.
+          remote:  !     
+          remote:  !     Delete your runtime.txt file and create a new file in the
+          remote:  !     root directory of your app named:
           remote:  !     .python-version
           remote:  !     
           remote:  !     Make sure to include the '.' character at the start of the

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -113,15 +113,17 @@ RSpec.describe 'Python version support' do
             remote:  !     Make sure to include the '.' character at the start of the
             remote:  !     filename. Don't add a file extension such as '.txt'.
             remote:  !     
-            remote:  !     In the new file, specify the new major Python version number
+            remote:  !     In the new file, specify your app's major Python version number
             remote:  !     only. Don't include quotes or a 'python-' prefix.
             remote:  !     
             remote:  !     For example, to request the latest version of Python 3.9,
             remote:  !     update your .python-version file so it contains exactly:
             remote:  !     3.9
             remote:  !     
-            remote:  !     If possible, we recommend upgrading all the way to Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-            remote:  !     since it contains many performance and usability improvements.
+            remote:  !     We strongly recommend that you don't specify the Python patch
+            remote:  !     version number, since it will pin your app to an exact Python
+            remote:  !     version and so stop your app from receiving security updates
+            remote:  !     each time it builds.
             remote: 
             remote:  !     Push rejected, failed to compile Python app.
           OUTPUT
@@ -378,7 +380,7 @@ RSpec.describe 'Python version support' do
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#classic-buildpacks-references
           remote:  !     
-          remote:  !     Otherwise, switch to a supported version (such as Python #{DEFAULT_PYTHON_MAJOR_VERSION})
+          remote:  !     Otherwise, switch to a supported version (such as Python 3.13)
           remote:  !     by changing the version in your .python-version file.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
@@ -445,11 +447,14 @@ RSpec.describe 'Python version support' do
           remote:  !     python-3.12.0^[
           remote:  !     
           remote:  !     However, the runtime.txt file is deprecated since it has been
-          remote:  !     replaced by the more widely supported .python-version file.
+          remote:  !     replaced by the more widely supported .python-version file:
+          remote:  !     https://devcenter.heroku.com/changelog-items/3141
+          remote:  !     
           remote:  !     As such, we recommend that you switch to using .python-version
           remote:  !     instead of fixing your runtime.txt file.
           remote:  !     
-          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     Delete your runtime.txt file and create a new file in the
+          remote:  !     root directory of your app named:
           remote:  !     .python-version
           remote:  !     
           remote:  !     Make sure to include the '.' character at the start of the
@@ -520,7 +525,10 @@ RSpec.describe 'Python version support' do
           remote:  !     by the more widely supported .python-version file:
           remote:  !     https://devcenter.heroku.com/changelog-items/3141
           remote:  !     
-          remote:  !     Please delete your runtime.txt file and create a new file named:
+          remote:  !     Please switch to using a .python-version file instead.
+          remote:  !     
+          remote:  !     Delete your runtime.txt file and create a new file in the
+          remote:  !     root directory of your app named:
           remote:  !     .python-version
           remote:  !     
           remote:  !     Make sure to include the '.' character at the start of the


### PR DESCRIPTION
To reduce duplication of content, particularly since there are more error/warning message variants that need to be added for uv support (due to the `.python-version` file needing to be made mandatory when using uv).

GUS-W-18439072.