### PR TITLE
Improve escaping of newlines in metrics key-value store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [Unreleased]
 
+- Improved internal buildpack metrics handling of attributes that contain newline characters. ([#1792](https://github.com/heroku/heroku-buildpack-python/pull/1792))
 
 ## [v284] - 2025-05-06
 
-- Fix parsing of `runtime.txt` and `.python-version` files that contain CRLF characters. ([#1789](https://github.com/heroku/heroku-buildpack-python/pull/1789))
+- Fixed parsing of `runtime.txt` and `.python-version` files that contain CRLF characters. ([#1789](https://github.com/heroku/heroku-buildpack-python/pull/1789))
 
 ## [v283] - 2025-05-06
 

--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -32,8 +32,10 @@ kv_set() {
 		# metadata store or bloating the payload passed back to Vacuole/submitted to Honeycomb given the
 		# extra content in those cases is not normally useful.)
 		local value="${3:0:100}"
-		# Replace newlines since the data store file format requires that keys don't span multiple lines.
-		value="${value//$'\n'/ }"
+		# Replace newlines and carriage returns since the data store file format requires that keys don't
+		# span multiple lines.
+		value="${value//$'\n'/\\n}"
+		value="${value//$'\r'/\\r}"
 
 		if [[ -f "${f}" ]]; then
 			echo "${key}=${value}" >>"${f}"


### PR DESCRIPTION
Since otherwise any field that contains a carriage return character could span multiple lines in the internal metrics data store, which then wouldn't be read back in its entirety by `bin/report`, which would lead to a truncated field in Honeycomb.

Such characters are much less likely now after #1789, however, they can still be present in the user-provided input in some cases (that ends up in metrics fields like `failure_detail`), plus from a general correctness point of view, the key-value store's attribute saving functions should be escaping all forms of newline characters.

I've also changed the escaping strategy to use literal `\n` and `\r` strings instead of spaces, so that it's possible to distinguish between multi-line and single line (but space delimited) values more easily in Honeycomb.

GUS-W-18471014.