### PR TITLE
Fix intermittent test failure in uv CI test

### DIFF
--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -241,7 +241,8 @@ RSpec.describe 'Heroku CI' do
 
     it 'installs both normal and test dependencies and uses cache on subsequent runs' do
       app.run_ci do |test_run|
-        expect(clean_output(test_run.output)).to match(Regexp.new(<<~REGEX))
+        # The uv install log output order is non-deterministic, hence the regex.
+        expect(clean_output(test_run.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           -----> Python app detected
           -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
@@ -251,11 +252,9 @@ RSpec.describe 'Heroku CI' do
                  Prepared 5 packages in .+s
                  Installed 5 packages in .+s
                  Bytecode compiled .+ files in .+s
-                  \\+ iniconfig==.+
-                  \\+ packaging==.+
-                  \\+ pluggy==.+
-                  \\+ pytest==.+
-                  \\+ typing-extensions==.+
+                  .+
+                  \\+ (pytest|typing-extensions)==.+
+                  \\+ (pytest|typing-extensions)==.+
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running bin/post_compile hook
                  CI=true


### PR DESCRIPTION
uv's package install log output is non-deterministic, since uv uses concurrency and the output depends on which package install finishes first. As such, the existing test would intermittently fail, eg:
https://github.com/heroku/heroku-buildpack-python/actions/runs/15675903805/job/44159360614?pr=1818#step:5:703

To prevent this, the test assertion now uses a more relaxed regex that also permits either ordering of the final two packages (the top level packages that we care about, that will always be installed last).

GUS-W-18792940.