### PR TITLE
Change the `python/` directory related warnings to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Updated uv from 0.7.13 to 0.7.20. ([#1827](https://github.com/heroku/heroku-buildpack-python/pull/1827) and [#1829](https://github.com/heroku/heroku-buildpack-python/pull/1829))
+- The build now errors if the Python buildpack has been run multiple times in the same build. This replaces the warning displayed since December 2024. ([#1830](https://github.com/heroku/heroku-buildpack-python/pull/1830))
+- The build now errors if an existing `.heroku/python/` directory is found in the app source. This replaces the warning displayed since December 2024. ([#1830](https://github.com/heroku/heroku-buildpack-python/pull/1830))
 
 ## [v290] - 2025-06-17
 
@@ -112,8 +114,8 @@
 
 ## [v272] - 2024-12-13
 
-- Added a warning if the Python buildpack has been run multiple times in the same build. In January 2025 this warning will be made an error. ([#1724](https://github.com/heroku/heroku-buildpack-python/pull/1724))
-- Added a warning if an existing `.heroku/python/` directory is found in the app source. In January 2025 this warning will be made an error. ([#1724](https://github.com/heroku/heroku-buildpack-python/pull/1724))
+- Added a warning if the Python buildpack has been run multiple times in the same build. In the future this warning will be made an error. ([#1724](https://github.com/heroku/heroku-buildpack-python/pull/1724))
+- Added a warning if an existing `.heroku/python/` directory is found in the app source. In the future this warning will be made an error. ([#1724](https://github.com/heroku/heroku-buildpack-python/pull/1724))
 - Improved the error message shown if the buildpack is used on an unsupported stack. ([#1724](https://github.com/heroku/heroku-buildpack-python/pull/1724))
 - Fixed Dev Center links to reflect recent article URL changes. ([#1723](https://github.com/heroku/heroku-buildpack-python/pull/1723))
 - Added metrics for the existence of a uv lockfile. ([#1725](https://github.com/heroku/heroku-buildpack-python/pull/1725))

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -41,7 +41,6 @@ function checks::ensure_supported_stack() {
 	esac
 }
 
-# TODO: Turn this into an error in January 2025.
 function checks::warn_if_duplicate_python_buildpack() {
 	local build_dir="${1}"
 
@@ -50,8 +49,8 @@ function checks::warn_if_duplicate_python_buildpack() {
 	# (The env var can only have come from the `export` file of an earlier buildpack,
 	# since app provided config vars haven't been exported to the environment here.)
 	if [[ -f "${build_dir}/.heroku/python/bin/python" && -v PYTHONHOME ]]; then
-		output::warning <<-EOF
-			Warning: The Python buildpack has already been run this build.
+		output::error <<-EOF
+			Error: The Python buildpack has already been run this build.
 
 			An existing Python installation was found in the build directory
 			from a buildpack run earlier in the build.
@@ -65,32 +64,21 @@ function checks::warn_if_duplicate_python_buildpack() {
 			https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
 			https://devcenter.heroku.com/articles/managing-buildpacks#remove-classic-buildpacks
 
-			If you have a use-case that requires duplicate buildpacks,
-			please comment on:
-			https://github.com/heroku/heroku-buildpack-python/issues/1704
-
-			In January 2025 this warning will be made an error.
+			Note: This error replaces the deprecation warning which was
+			displayed in build logs starting 13th December 2024.
 		EOF
-		meta_set "duplicate_python_buildpack" "true"
-		# shellcheck disable=SC2034 # This is used below until we make this check an error.
-		DUPLICATE_PYTHON_BUILDPACK=1
+		meta_set "failure_reason" "checks::duplicate-python-buildpack"
+		exit 1
 	fi
 }
 
-# TODO: Turn this into an error in January 2025.
 function checks::warn_if_existing_python_dir_present() {
 	local build_dir="${1}"
 
-	# Avoid warning twice in the case of duplicate buildpacks.
-	# TODO: Remove this once `warn_if_duplicate_python_buildpack` becomes an error.
-	if [[ -v DUPLICATE_PYTHON_BUILDPACK ]]; then
-		return 0
-	fi
-
 	# We use `-e` here to catch the case where `python` is a file rather than a directory.
 	if [[ -e "${build_dir}/.heroku/python" ]]; then
-		output::warning <<-EOF
-			Warning: Existing '.heroku/python/' directory found.
+		output::error <<-EOF
+			Error: Existing '.heroku/python/' directory found.
 
 			Your app's source code contains an existing directory named
 			'.heroku/python/', which is where the Python buildpack needs
@@ -107,12 +95,10 @@ function checks::warn_if_existing_python_dir_present() {
 			Otherwise, check that an earlier buildpack or 'bin/pre_compile'
 			hook hasn't created this directory.
 
-			If you have a use-case that requires writing to this location,
-			please comment on:
-			https://github.com/heroku/heroku-buildpack-python/issues/1704
-
-			In January 2025 this warning will be made an error.
+			Note: This error replaces the deprecation warning which was
+			displayed in build logs starting 13th December 2024.
 		EOF
-		meta_set "existing_python_dir" "true"
+		meta_set "failure_reason" "checks::existing-python-dir"
+		exit 1
 	fi
 }

--- a/spec/hatchet/checks_spec.rb
+++ b/spec/hatchet/checks_spec.rb
@@ -5,14 +5,14 @@ require_relative '../spec_helper'
 RSpec.describe 'Buildpack validation checks' do
   context 'when there are duplicate Python buildpacks set on the app' do
     let(:buildpacks) { %i[default default] }
-    let(:app) { Hatchet::Runner.new("spec/fixtures/python_#{DEFAULT_PYTHON_MAJOR_VERSION}", buildpacks:) }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/python_version_unspecified', buildpacks:, allow_failure: true) }
 
     it 'fails detection' do
       app.deploy do |app|
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: 
-          remote:  !     Warning: The Python buildpack has already been run this build.
+          remote:  !     Error: The Python buildpack has already been run this build.
           remote:  !     
           remote:  !     An existing Python installation was found in the build directory
           remote:  !     from a buildpack run earlier in the build.
@@ -26,15 +26,10 @@ RSpec.describe 'Buildpack validation checks' do
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#view-your-buildpacks
           remote:  !     https://devcenter.heroku.com/articles/managing-buildpacks#remove-classic-buildpacks
           remote:  !     
-          remote:  !     If you have a use-case that requires duplicate buildpacks,
-          remote:  !     please comment on:
-          remote:  !     https://github.com/heroku/heroku-buildpack-python/issues/1704
-          remote:  !     
-          remote:  !     In January 2025 this warning will be made an error.
+          remote:  !     Note: This error replaces the deprecation warning which was
+          remote:  !     displayed in build logs starting 13th December 2024.
           remote: 
-          remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
-          remote: -----> Restoring cache
-          remote: -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
+          remote:  !     Push rejected, failed to compile Python app.
         OUTPUT
       end
     end
@@ -48,7 +43,7 @@ RSpec.describe 'Buildpack validation checks' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: 
-          remote:  !     Warning: Existing '.heroku/python/' directory found.
+          remote:  !     Error: Existing '.heroku/python/' directory found.
           remote:  !     
           remote:  !     Your app's source code contains an existing directory named
           remote:  !     '.heroku/python/', which is where the Python buildpack needs
@@ -67,23 +62,8 @@ RSpec.describe 'Buildpack validation checks' do
           remote:  !     Otherwise, check that an earlier buildpack or 'bin/pre_compile'
           remote:  !     hook hasn't created this directory.
           remote:  !     
-          remote:  !     If you have a use-case that requires writing to this location,
-          remote:  !     please comment on:
-          remote:  !     https://github.com/heroku/heroku-buildpack-python/issues/1704
-          remote:  !     
-          remote:  !     In January 2025 this warning will be made an error.
-          remote: 
-          remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
-          remote: -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
-          remote: 
-          remote:  !     Internal Error: Unable to locate the Python stdlib's bundled pip.
-          remote:  !     
-          remote:  !     Couldn't find the pip wheel file bundled inside the Python
-          remote:  !     stdlib's 'ensurepip' module:
-          remote:  !     
-          remote:  !     find: ‘/app/.heroku/python/lib/python3.13/ensurepip/_bundled/’: No such file or directory
-          remote:  !     /app/.heroku/python/
-          remote:  !     /app/.heroku/python/bin
+          remote:  !     Note: This error replaces the deprecation warning which was
+          remote:  !     displayed in build logs starting 13th December 2024.
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         OUTPUT


### PR DESCRIPTION
Builds will now error if either:
- The Python buildpack has been run multiple times in the same build.
- An existing `.heroku/python/` directory is found in the app source for any other reason (e.g. accidentally committed to Git)

This upgrades the warnings added in #1724 in December 2024 to errors.

No feedback/concerns were raised in the GitHub issue linked from the warning:
https://github.com/heroku/heroku-buildpack-python/issues/1704

And Honeycomb data shows:
- the number of apps hitting the warnings was minimal
- in most cases, the builds hitting the warnings were failing already (eg due to broken `python/` directories having been committed to Git, and so turning the warning into an error will actually give them a better error message than before).

Closes #1704.
GUS-W-17309720.
