### PR TITLE
Remove unused `bin/report` metrics

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -87,8 +87,6 @@ ALL_OTHER_FIELDS=(
 	custom_s3_base_url
 	dependencies_install_duration
 	django_collectstatic_duration
-	duplicate_python_buildpack
-	existing_python_dir
 	nltk_downloader_duration
 	package_manager_install_duration
 	pipenv_has_lockfile


### PR DESCRIPTION
These are not set/used since #1830.
