### PR TITLE
Require a `Pipfile.lock` when using Pipenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- The build now errors when using Pipenv without its lockfile (`Pipfile.lock`). This replaces the warning displayed since November 2024. ([#1833](https://github.com/heroku/heroku-buildpack-python/pull/1833))
 
 ## [v291] - 2025-07-10
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ See the [Getting Started on Heroku with Python](https://devcenter.heroku.com/art
 
 ## Application Requirements
 
-A `requirements.txt`, `Pipfile`, `poetry.lock`, or `uv.lock` file must be present in the root (top-level) directory of your app's source code.
+A `requirements.txt`, `Pipfile.lock`, `poetry.lock`, or `uv.lock` file must be present in the root (top-level)
+directory of your app's source code.
 
 When using the package manager [uv](https://docs.astral.sh/uv/) a `.python-version` file is also required.
 

--- a/bin/detect
+++ b/bin/detect
@@ -65,8 +65,8 @@ Error: Your app is configured to use the Python buildpack,
 but we couldn't find any supported Python project files.
 
 A Python app on Heroku must have either a 'requirements.txt',
-'Pipfile' or 'poetry.lock' package manager file in the root
-directory of its source code.
+'Pipfile.lock', 'poetry.lock' or 'uv.lock' package manager file
+in the root directory of its source code.
 
 Currently the root directory of your app contains:
 

--- a/bin/report
+++ b/bin/report
@@ -89,7 +89,6 @@ ALL_OTHER_FIELDS=(
 	django_collectstatic_duration
 	nltk_downloader_duration
 	package_manager_install_duration
-	pipenv_has_lockfile
 	post_compile_hook
 	post_compile_hook_duration
 	pre_compile_hook

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -12,26 +12,29 @@ function package_manager::determine_package_manager() {
 	if [[ -f "${build_dir}/Pipfile.lock" ]]; then
 		package_managers_found+=(pipenv)
 		package_managers_found_display_text+=("Pipfile.lock (Pipenv)")
-		meta_set "pipenv_has_lockfile" "true"
 	elif [[ -f "${build_dir}/Pipfile" ]]; then
-		# TODO: Start requiring a Pipfile.lock and make this branch a "missing lockfile" error instead.
-		output::warning <<-'EOF'
-			Warning: No 'Pipfile.lock' found!
+		output::error <<-'EOF'
+			Error: No 'Pipfile.lock' found!
 
 			A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
 			Pipenv lockfile was not. This means your app dependency versions
 			aren't pinned, which means the package versions used on Heroku
 			might not match those installed in other environments.
 
-			For now, we will install your dependencies without a lockfile,
-			however, in the future this warning will become an error.
+			Using Pipenv in this way is unsafe and no longer supported.
 
 			Run 'pipenv lock' locally to generate the lockfile, and make sure
 			that 'Pipfile.lock' isn't listed in '.gitignore' or '.slugignore'.
+
+			Alternatively, if you wish to switch to another package manager,
+			delete your 'Pipfile' and then add either a 'requirements.txt',
+			'poetry.lock' or 'uv.lock' file.
+
+			Note: This error replaces the warning which was displayed in
+			build logs starting 12th November 2024.
 		EOF
-		package_managers_found+=(pipenv)
-		package_managers_found_display_text+=("Pipfile (Pipenv)")
-		meta_set "pipenv_has_lockfile" "false"
+		meta_set "failure_reason" "package-manager::pipenv-missing-lockfile"
+		exit 1
 	fi
 
 	if [[ -f "${build_dir}/requirements.txt" ]]; then
@@ -76,8 +79,8 @@ function package_manager::determine_package_manager() {
 				Error: Couldn't find any supported Python package manager files.
 
 				A Python app on Heroku must have either a 'requirements.txt',
-				'Pipfile', 'poetry.lock' or 'uv.lock' package manager file in
-				the root directory of its source code.
+				'Pipfile.lock', 'poetry.lock' or 'uv.lock' package manager file
+				in the root directory of its source code.
 
 				Currently the root directory of your app contains:
 

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -66,14 +66,8 @@ function pipenv::install_dependencies() {
 	local pipenv_install_command=(
 		pipenv
 		install
+		--deploy
 	)
-
-	# TODO: Make Pipfile.lock mandatory during package manager selection.
-	if [[ ! -f Pipfile.lock ]]; then
-		pipenv_install_command+=(--skip-lock)
-	else
-		pipenv_install_command+=(--deploy)
-	fi
 
 	# Install test dependencies too when the buildpack is invoked via `bin/test-compile` on Heroku CI.
 	if [[ -v INSTALL_TEST ]]; then

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -233,12 +233,6 @@ function python_version::read_pipenv_python_version() {
 	local pipfile_lock_path="${build_dir}/Pipfile.lock"
 	local version
 
-	# We currently permit using Pipenv without a `Pipfile.lock`, however, in the future we will
-	# require a lockfile, at which point this conditional can be removed.
-	if [[ ! -f "${pipfile_lock_path}" ]]; then
-		return 0
-	fi
-
 	if ! version=$(jq --raw-output '._meta.requires.python_full_version // ._meta.requires.python_version' "${pipfile_lock_path}" 2>&1); then
 		local jq_error_message="${version}"
 		output::error <<-EOF

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'Buildpack detection' do
           remote:  !     but we couldn't find any supported Python project files.
           remote:  !     
           remote:  !     A Python app on Heroku must have either a 'requirements.txt',
-          remote:  !     'Pipfile' or 'poetry.lock' package manager file in the root
-          remote:  !     directory of its source code.
+          remote:  !     'Pipfile.lock', 'poetry.lock' or 'uv.lock' package manager file
+          remote:  !     in the root directory of its source code.
           remote:  !     
           remote:  !     Currently the root directory of your app contains:
           remote:  !     

--- a/spec/hatchet/package_manager_spec.rb
+++ b/spec/hatchet/package_manager_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Package manager support' do
           remote:  !     Error: Couldn't find any supported Python package manager files.
           remote:  !     
           remote:  !     A Python app on Heroku must have either a 'requirements.txt',
-          remote:  !     'Pipfile', 'poetry.lock' or 'uv.lock' package manager file in
-          remote:  !     the root directory of its source code.
+          remote:  !     'Pipfile.lock', 'poetry.lock' or 'uv.lock' package manager file
+          remote:  !     in the root directory of its source code.
           remote:  !     
           remote:  !     Currently the root directory of your app contains:
           remote:  !     

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -200,79 +200,33 @@ RSpec.describe 'Pipenv support' do
   end
 
   context 'without a Pipfile.lock' do
-    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_no_lockfile') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_no_lockfile', allow_failure: true) }
 
     it 'builds with the default Python version using just the Pipfile' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Python app detected
           remote: 
-          remote:  !     Warning: No 'Pipfile.lock' found!
+          remote:  !     Error: No 'Pipfile.lock' found!
           remote:  !     
           remote:  !     A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
           remote:  !     Pipenv lockfile was not. This means your app dependency versions
           remote:  !     aren't pinned, which means the package versions used on Heroku
           remote:  !     might not match those installed in other environments.
           remote:  !     
-          remote:  !     For now, we will install your dependencies without a lockfile,
-          remote:  !     however, in the future this warning will become an error.
+          remote:  !     Using Pipenv in this way is unsafe and no longer supported.
           remote:  !     
           remote:  !     Run 'pipenv lock' locally to generate the lockfile, and make sure
           remote:  !     that 'Pipfile.lock' isn't listed in '.gitignore' or '.slugignore'.
+          remote:  !     
+          remote:  !     Alternatively, if you wish to switch to another package manager,
+          remote:  !     delete your 'Pipfile' and then add either a 'requirements.txt',
+          remote:  !     'poetry.lock' or 'uv.lock' file.
+          remote:  !     
+          remote:  !     Note: This error replaces the warning which was displayed in
+          remote:  !     build logs starting 12th November 2024.
           remote: 
-          remote: -----> No Python version was specified. Using the buildpack default: Python #{DEFAULT_PYTHON_MAJOR_VERSION}
-          remote: 
-          remote:  !     Warning: No Python version was specified.
-          remote:  !     
-          remote:  !     Your app doesn't specify a Python version and so the buildpack
-          remote:  !     picked a default version for you.
-          remote:  !     
-          remote:  !     Relying on this default version isn't recommended, since it
-          remote:  !     can change over time and may not be consistent with your local
-          remote:  !     development environment, CI or other instances of your app.
-          remote:  !     
-          remote:  !     Please configure an explicit Python version for your app.
-          remote:  !     
-          remote:  !     Create a new file in the root directory of your app named:
-          remote:  !     .python-version
-          remote:  !     
-          remote:  !     Make sure to include the '.' character at the start of the
-          remote:  !     filename. Don't add a file extension such as '.txt'.
-          remote:  !     
-          remote:  !     In the new file, specify your app's major Python version number
-          remote:  !     only. Don't include quotes or a 'python-' prefix.
-          remote:  !     
-          remote:  !     For example, to request the latest version of Python #{DEFAULT_PYTHON_MAJOR_VERSION},
-          remote:  !     update your .python-version file so it contains exactly:
-          remote:  !     #{DEFAULT_PYTHON_MAJOR_VERSION}
-          remote:  !     
-          remote:  !     We strongly recommend that you don't specify the Python patch
-          remote:  !     version number, since it will pin your app to an exact Python
-          remote:  !     version and so stop your app from receiving security updates
-          remote:  !     each time it builds.
-          remote:  !     
-          remote:  !     If your app already has a .python-version file, check that it:
-          remote:  !     
-          remote:  !     1. Is in the top level directory \\(not a subdirectory\\).
-          remote:  !     2. Is named exactly '.python-version' in all lowercase.
-          remote:  !     3. Isn't listed in '.gitignore' or '.slugignore'.
-          remote:  !     4. Has been added to the Git repository using 'git add --all'
-          remote:  !        and then committed using 'git commit'.
-          remote:  !     
-          remote:  !     In the future we will require the use of a .python-version
-          remote:  !     file and this warning will be made an error.
-          remote: 
-          remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
-          remote: -----> Installing pip #{PIP_VERSION}
-          remote: -----> Installing Pipenv #{PIPENV_VERSION}
-          remote: -----> Installing dependencies using 'pipenv install --skip-lock'
-          remote:        The flag --skip-lock has been reintroduced \\(but is not recommended\\).  Without 
-          remote:        the lock resolver it is difficult to manage multiple package indexes, and hash 
-          remote:        checking is not provided.  However it can help manage installs with current 
-          remote:        deficiencies in locking across platforms.
-          remote:        Pipfile.lock not found, creating...
-          .+
-          remote:        Installing dependencies from Pipfile...
+          remote:  !     Push rejected, failed to compile Python app.
         REGEX
       end
     end


### PR DESCRIPTION
For historical reasons, the buildpack has supported using the package manager Pipenv without a lockfile. However, doing so results in non-deterministic installs (package versions can vary across environments) and so is unsafe / not recommended.

As such, since #1695 in November 2024, we've shown a deprecation warning if apps have only a `Pipfile` and no `Pipfile.lock` file.

Plenty of time has now passed, and metrics show usage very few apps hitting this warning. In addition, upstream Pipenv has also deprecated support for `--skip-lock`:
https://github.com/pypa/pipenv/commit/8775d5998e389ac43ddddb8db752fc222d6c7c0f

As such, it's time to change this warning to an error.

Affected apps will need to run `pipenv lock` and commit the resultant `Pipfile.lock` to Git.

Closes #1702.
GUS-W-17308738.
