### PR TITLE
Update checks function names now that they error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ meta_init "${CACHE_DIR}" "python"
 meta_setup
 
 checks::ensure_supported_stack "${STACK:?Required env var STACK is not set}"
-checks::warn_if_duplicate_python_buildpack "${BUILD_DIR}"
+checks::duplicate_python_buildpack "${BUILD_DIR}"
 
 # Prepend proper path for old-school virtualenv hackery.
 # This may not be necessary.
@@ -102,7 +102,7 @@ hooks::run_hook "pre_compile"
 
 # This check must be after the pre_compile hook, so that we can check not only the original
 # app source, but also that the hook hasn't written to '.heroku/python/' either.
-checks::warn_if_existing_python_dir_present "${BUILD_DIR}"
+checks::existing_python_dir_present "${BUILD_DIR}"
 
 package_manager="$(package_manager::determine_package_manager "${BUILD_DIR}")"
 meta_set "package_manager" "${package_manager}"

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -41,7 +41,7 @@ function checks::ensure_supported_stack() {
 	esac
 }
 
-function checks::warn_if_duplicate_python_buildpack() {
+function checks::duplicate_python_buildpack() {
 	local build_dir="${1}"
 
 	# The check for the `PYTHONHOME` env var prevents this warning triggering in the case
@@ -72,7 +72,7 @@ function checks::warn_if_duplicate_python_buildpack() {
 	fi
 }
 
-function checks::warn_if_existing_python_dir_present() {
+function checks::existing_python_dir_present() {
 	local build_dir="${1}"
 
 	# We use `-e` here to catch the case where `python` is a file rather than a directory.


### PR DESCRIPTION
After #1830, the two `checks::warn_if_*` functions now error rather than warn, so the function names have been renamed so they don't mislead about their behaviour.
