### PR TITLE
Remove superseded `python_version_reason` metric

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -114,8 +114,6 @@ cached_python_full_version="$(cache::cached_python_full_version "${CACHE_DIR}")"
 python_version::read_requested_python_version "${BUILD_DIR}" "${package_manager}" "${cached_python_full_version}" requested_python_version python_version_origin
 meta_set "python_version_requested" "${requested_python_version}"
 meta_set "python_version_origin" "${python_version_origin}"
-# TODO: Remove this once the old Honeycomb events that don't have `python_version_origin` have aged out.
-meta_set "python_version_reason" "${python_version_origin}"
 
 case "${python_version_origin}" in
 	default)

--- a/bin/report
+++ b/bin/report
@@ -72,7 +72,6 @@ STRING_FIELDS=(
 	poetry_version
 	python_version_major
 	python_version_origin
-	python_version_reason
 	python_version_requested
 	python_version
 	setuptools_version


### PR DESCRIPTION
Since more than 60 days have passed since the replacement metric (`python_version_origin`) was added in #1785, so all build events within the Honeycomb retention time span now have the new metric name.

GUS-W-19116066.