### PR TITLE
Speed up cache restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved performance of Python build cache restoration. ([#1845](https://github.com/heroku/heroku-buildpack-python/pull/1845))
 - Added a build log message for the build cache saving step. ([#1844](https://github.com/heroku/heroku-buildpack-python/pull/1844))
 
 ## [v293] - 2025-07-23


### PR DESCRIPTION
By moving the Python directory instead of copying, which internally performs a rename instead of a copy if the cache directory is on the same filesystem mount as the build directory (which is the case for standard builds).

This should be particularly beneficial for apps with a large number of Python dependencies (and so a large site-packages) - where we see cache restoration taking up to 30 seconds in Honeycomb (P99.9).

GUS-W-19144883.