### PR TITLE
Cleanup pip's `Requirement already satisfied` output on older Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Updated uv from 0.7.20 to 0.8.4. ([#1847](https://github.com/heroku/heroku-buildpack-python/pull/1847))
+- Reduced the verbosity of pip's `Requirement already satisfied:` log lines when using Python 3.10 and older. ([#1851](https://github.com/heroku/heroku-buildpack-python/pull/1851))
 
 ## [v294] - 2025-07-28
 

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -108,6 +108,9 @@ function pip::install_dependencies() {
 
 	# TODO: Remove --disable-pip-version-check in favour of exporting PIP_DISABLE_PIP_VERSION_CHECK.
 	# The sed usage is to reduce the verbosity of output lines like:
+	# ...when using Python 3.10 and older:
+	# "Requirement already satisfied: typing-extensions==4.12.2 in ./.heroku/python/lib/python3.10/site-packages (from -r requirements.txt (line 2)) (4.12.2)"
+	# ...when using Python 3.11+:
 	# "Requirement already satisfied: typing-extensions==4.12.2 in /app/.heroku/python/lib/python3.13/site-packages (from -r requirements.txt (line 5)) (4.12.2)"
 	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 	if ! {
@@ -119,7 +122,8 @@ function pip::install_dependencies() {
 			--progress-bar off \
 			--src='/app/.heroku/python/src' \
 			|& tee "${WARNINGS_LOG:?}" \
-			|& sed --unbuffered --expression 's# in /app/.heroku/python/lib/python.*/site-packages##' \
+			|& sed --unbuffered --regexp-extended \
+				--expression 's# in (/app|\.)/\.heroku/python/lib/python[0-9.]+/site-packages##' \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling.

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe 'pip support' do
         # regex variant can be removed once support for Python 3.10 and older is dropped.
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Installing dependencies using 'pip install -r requirements.txt'
-          remote:        Requirement already satisfied: typing-extensions==4.14.1 in ./.heroku/python/lib/python3.9/site-packages (from -r requirements.txt (line 2)) (4.14.1)
+          remote:        Requirement already satisfied: typing-extensions==4.14.1 (from -r requirements.txt (line 2)) (4.14.1)
           remote: -----> Saving cache
         OUTPUT
       end


### PR DESCRIPTION
On older Python pip outputs paths in a different format.

The log output clean-up regex has now been updated to match against that output too (in addition to that of newer Python), so the log lines are cleaned up on Python 3.10 and older too.

GUS-W-19183260.
