### PR TITLE
Fix lint errors with Shellcheck v0.11.0

### DIFF
--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -35,7 +35,7 @@ case "${STACK:?}" in
 		;;
 esac
 
-if [[ ! " ${SUPPORTED_PYTHON_VERSIONS[*]} " == *" ${PYTHON_MAJOR_VERSION} "* ]]; then
+if [[ " ${SUPPORTED_PYTHON_VERSIONS[*]} " != *" ${PYTHON_MAJOR_VERSION} "* ]]; then
 	abort "Python ${PYTHON_MAJOR_VERSION} is not supported on ${STACK}!"
 fi
 


### PR DESCRIPTION
A new Shellcheck version was just released:
https://github.com/koalaman/shellcheck/releases/tag/v0.11.0

...which reports some new lint errors:

```
$ make lint

In builds/build_python_runtime.sh line 38:
if [[ ! " ${SUPPORTED_PYTHON_VERSIONS[*]} " == *" ${PYTHON_MAJOR_VERSION} "* ]]; then
   ^-- SC2335 (style): Use a != b instead of ! a == b.

For more information:
 https://www.shellcheck.net/wiki/SC2335 -- Use a != b instead of ! a == b.
make: *** [lint-scripts] Error 1
```

GUS-W-19245644.