### PR TITLE
Fix the stack check error message for Heroku-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the stack version check to correctly show the "stack not supported" error message for the EOL Heroku-20, instead of "stack not recognised". ([#1860](https://github.com/heroku/heroku-buildpack-python/pull/1860))
 
 ## [v297] - 2025-08-06
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -7,7 +7,7 @@ function checks::ensure_supported_stack() {
 		heroku-22 | heroku-24)
 			return 0
 			;;
-		cedar* | heroku-16 | heroku-18)
+		cedar* | heroku-16 | heroku-18 | heroku-20)
 			# This error will only ever be seen on non-Heroku environments, since the
 			# Heroku build system rejects builds using EOL stacks.
 			output::error <<-EOF


### PR DESCRIPTION
The `heroku-20` entry was removed completely in #1778 rather than moving it to the EOL branch of the conditional, causing the "stack not recognised" message variant to be shown, instead of the "stack no longer supported" version.

This error messages can never occur on Heroku (since our build system can only scheduled builds for supported stacks), but these cases can be hit for non-Heroku uses of this buildpack (such as Dokku).

GUS-W-19274871.
