### PR TITLE
Simplify handling of caches written by older buildpack versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Simplified the handling of caches written by older buildpack versions. ([#1870](https://github.com/heroku/heroku-buildpack-python/pull/1870))
 
 ## [v300] - 2025-08-15
 

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Stack changes' do
           remote: -----> Discarding cache since:
           remote:        - The stack has changed from heroku-22 to heroku-24
           remote:        - The Python version has changed from 3.12.3 to #{LATEST_PYTHON_3_12}
-          remote:        - The pip version has changed
+          remote:        - The buildpack cache format has changed
           remote:        - The legacy SQLite3 headers and CLI binary need to be uninstalled
           remote: -----> Installing Python #{LATEST_PYTHON_3_12}
           remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}


### PR DESCRIPTION
It's been a year since the current metadata store implementation was added, so it's fine to now simplify the handling/messaging around reading older cache versions.

This cleanup will also help with the upcoming switch to the new JSON metadata store implementation.

GUS-W-19361163.
