### PR TITLE
Remove support for `BUILDPACK_S3_BASE_URL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Removed support for `BUILDPACK_S3_BASE_URL`. ([#1875](https://github.com/heroku/heroku-buildpack-python/pull/1875))
 
 ## [v301] - 2025-08-18
 

--- a/bin/report
+++ b/bin/report
@@ -79,7 +79,6 @@ STRING_FIELDS=(
 ALL_OTHER_FIELDS=(
 	cache_restore_duration
 	cache_save_duration
-	custom_s3_base_url
 	dependencies_install_duration
 	django_collectstatic_duration
 	nltk_downloader_duration

--- a/lib/python.sh
+++ b/lib/python.sh
@@ -4,7 +4,7 @@
 # however, it helps Shellcheck realise the options under which these functions will run.
 set -euo pipefail
 
-DEFAULT_S3_BASE_URL="https://heroku-buildpack-python.s3.us-east-1.amazonaws.com"
+S3_BASE_URL="https://heroku-buildpack-python.s3.us-east-1.amazonaws.com"
 
 function python::install() {
 	local build_dir="${1}"
@@ -24,21 +24,12 @@ function python::install() {
 
 		mkdir -p "${install_dir}"
 
-		# Note: This can't be used via app config vars, since it doesn't reference the value from ENV_DIR.
-		# TODO: Remove this for parity with the Python CNB, if metrics show it to be unused on Heroku.
-		if [[ -v BUILDPACK_S3_BASE_URL ]]; then
-			local s3_base_url="${BUILDPACK_S3_BASE_URL}"
-			meta_set "custom_s3_base_url" "true"
-		else
-			local s3_base_url="${DEFAULT_S3_BASE_URL}"
-		fi
-
 		# Calculating the Ubuntu version from the stack name saves having to shell out to `lsb_release`.
 		local ubuntu_version="${stack/heroku-/}.04"
 		local arch
 		arch=$(dpkg --print-architecture)
 		# e.g.: https://heroku-buildpack-python.s3.us-east-1.amazonaws.com/python-3.13.0-ubuntu-24.04-amd64.tar.zst
-		local python_url="${s3_base_url}/python-${python_full_version}-ubuntu-${ubuntu_version}-${arch}.tar.zst"
+		local python_url="${S3_BASE_URL}/python-${python_full_version}-ubuntu-${ubuntu_version}-${arch}.tar.zst"
 
 		local error_log
 		error_log=$(mktemp)


### PR DESCRIPTION
Since:
- Metrics show it to be unused on Heroku.
- It's not supported by the Python CNB, so removing it improves parity.
- As a feature it's pretty fragile, since unless someone managed to keep up with all changes we make to our S3 bucket, builds would break every time we bump versions. (And as such, anyone using it should be carefully curating the buildpack versions, and so can patch the buildpack as part of that repackaging/automation process.)

GUS-W-19372843.
