### PR TITLE
Add tests for build metadata contents

### DIFF
--- a/spec/fixtures/pip_basic/bin/compile
+++ b/spec/fixtures/pip_basic/bin/compile
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 BUILD_DIR="${1}"
+CACHE_DIR="${2}"
 
 cd "${BUILD_DIR}"
 
@@ -21,3 +22,6 @@ pip list --disable-pip-version-check
 echo
 
 python -c 'import typing_extensions; print(typing_extensions)'
+echo
+
+sort "${CACHE_DIR}/build-data/python"

--- a/spec/fixtures/pipenv_basic/bin/compile
+++ b/spec/fixtures/pipenv_basic/bin/compile
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 BUILD_DIR="${1}"
+CACHE_DIR="${2}"
 
 cd "${BUILD_DIR}"
 
@@ -22,3 +23,6 @@ pip list --disable-pip-version-check --exclude pip
 echo
 
 python -c 'import typing_extensions; print(typing_extensions)'
+echo
+
+sort "${CACHE_DIR}/build-data/python"

--- a/spec/fixtures/poetry_basic/bin/compile
+++ b/spec/fixtures/poetry_basic/bin/compile
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 BUILD_DIR="${1}"
+CACHE_DIR="${2}"
 
 cd "${BUILD_DIR}"
 
@@ -22,3 +23,6 @@ poetry show | grep -v ' (!) '
 echo
 
 python -c 'import typing_extensions; print(typing_extensions)'
+echo
+
+sort "${CACHE_DIR}/build-data/python"

--- a/spec/fixtures/uv_basic/bin/compile
+++ b/spec/fixtures/uv_basic/bin/compile
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 BUILD_DIR="${1}"
+CACHE_DIR="${2}"
 
 cd "${BUILD_DIR}"
 
@@ -20,3 +21,6 @@ uv pip list
 echo
 
 python -c 'import typing_extensions; print(typing_extensions)'
+echo
+
+sort "${CACHE_DIR}/build-data/python"

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe 'pip support' do
 
     it 're-uses packages from the cache' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Installing pip #{PIP_VERSION}
           remote: -----> Installing dependencies using 'pip install -r requirements.txt'
-          remote:        Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 5))
-          remote:          Downloading typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
-          remote:        Downloading typing_extensions-4.12.2-py3-none-any.whl (37 kB)
+          remote:        Collecting typing-extensions==4.12.2 \\(from -r requirements.txt \\(line 5\\)\\)
+          remote:          Downloading typing_extensions-4.12.2-py3-none-any.whl.metadata \\(3.0 kB\\)
+          remote:        Downloading typing_extensions-4.12.2-py3-none-any.whl \\(37 kB\\)
           remote:        Installing collected packages: typing-extensions
           remote:        Successfully installed typing-extensions-4.12.2
           remote: -----> Saving cache
@@ -30,21 +30,43 @@ RSpec.describe 'pip support' do
           remote: PYTHONPATH=/app
           remote: PYTHONUNBUFFERED=true
           remote: 
-          remote: ['',
+          remote: \\['',
           remote:  '/app',
           remote:  '/app/.heroku/python/lib/python313.zip',
           remote:  '/app/.heroku/python/lib/python3.13',
           remote:  '/app/.heroku/python/lib/python3.13/lib-dynload',
-          remote:  '/app/.heroku/python/lib/python3.13/site-packages']
+          remote:  '/app/.heroku/python/lib/python3.13/site-packages'\\]
           remote: 
-          remote: pip #{PIP_VERSION} from /app/.heroku/python/lib/python3.13/site-packages/pip (python 3.13)
+          remote: pip #{PIP_VERSION} from /app/.heroku/python/lib/python3.13/site-packages/pip \\(python 3.13\\)
           remote: Package           Version
           remote: ----------------- -------
           remote: pip               #{PIP_VERSION}
           remote: typing_extensions 4.12.2
           remote: 
           remote: <module 'typing_extensions' from '/app/.heroku/python/lib/python3.13/site-packages/typing_extensions.py'>
-        OUTPUT
+          remote: 
+          remote: 
+          remote: cache_restore_duration=[0-9.]+
+          remote: cache_save_duration=[0-9.]+
+          remote: cache_status=empty
+          remote: dependencies_install_duration=[0-9.]+
+          remote: django_collectstatic_duration=[0-9.]+
+          remote: nltk_downloader_duration=[0-9.]+
+          remote: package_manager_install_duration=[0-9.]+
+          remote: package_manager=pip
+          remote: pip_version=#{PIP_VERSION}
+          remote: post_compile_hook=false
+          remote: pre_compile_hook=false
+          remote: python_install_duration=[0-9.]+
+          remote: python_version=#{DEFAULT_PYTHON_FULL_VERSION}
+          remote: python_version_major=3.13
+          remote: python_version_origin=.python-version
+          remote: python_version_outdated=false
+          remote: python_version_pinned=false
+          remote: python_version_requested=3.13
+          remote: setup_py_only=false
+          remote: total_duration=[0-9.]+
+        REGEX
         app.commit!
         app.push!
         expect(clean_output(app.output)).to include(<<~OUTPUT)

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe 'Pipenv support' do
           remote: typing_extensions 4.12.2
           remote: 
           remote: <module 'typing_extensions' from '/app/.heroku/python/lib/python3.13/site-packages/typing_extensions.py'>
+          remote: 
+          remote: 
+          remote: cache_restore_duration=[0-9.]+
+          remote: cache_save_duration=[0-9.]+
+          remote: cache_status=empty
+          remote: dependencies_install_duration=[0-9.]+
+          remote: django_collectstatic_duration=[0-9.]+
+          remote: nltk_downloader_duration=[0-9.]+
+          remote: package_manager_install_duration=[0-9.]+
+          remote: package_manager=pipenv
+          remote: pipenv_version=#{PIPENV_VERSION}
+          remote: post_compile_hook=false
+          remote: pre_compile_hook=false
+          remote: python_install_duration=[0-9.]+
+          remote: python_version=#{DEFAULT_PYTHON_FULL_VERSION}
+          remote: python_version_major=3.13
+          remote: python_version_origin=Pipfile.lock
+          remote: python_version_outdated=false
+          remote: python_version_pinned=false
+          remote: python_version_requested=3.13
+          remote: setup_py_only=false
+          remote: total_duration=[0-9.]+
         REGEX
         app.commit!
         app.push!

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Poetry support' do
 
     it 'installs successfully using Poetry and on rebuilds uses the cache' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> Python app detected
           remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
           remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
@@ -19,7 +19,7 @@ RSpec.describe 'Poetry support' do
           remote:        
           remote:        Package operations: 1 install, 0 updates, 0 removals
           remote:        
-          remote:          - Installing typing-extensions (4.12.2)
+          remote:          - Installing typing-extensions \\(4.12.2\\)
           remote: -----> Saving cache
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
@@ -32,19 +32,41 @@ RSpec.describe 'Poetry support' do
           remote: PYTHONPATH=/app
           remote: PYTHONUNBUFFERED=true
           remote: 
-          remote: ['',
+          remote: \\['',
           remote:  '/app',
           remote:  '/app/.heroku/python/lib/python313.zip',
           remote:  '/app/.heroku/python/lib/python3.13',
           remote:  '/app/.heroku/python/lib/python3.13/lib-dynload',
-          remote:  '/app/.heroku/python/lib/python3.13/site-packages']
+          remote:  '/app/.heroku/python/lib/python3.13/site-packages'\\]
           remote: 
-          remote: Poetry (version #{POETRY_VERSION})
+          remote: Poetry \\(version #{POETRY_VERSION}\\)
           remote: Skipping virtualenv creation, as specified in config file.
           remote: typing-extensions 4.12.2 Backported and Experimental Type Hints for Python ...
           remote: 
           remote: <module 'typing_extensions' from '/app/.heroku/python/lib/python3.13/site-packages/typing_extensions.py'>
-        OUTPUT
+          remote: 
+          remote: 
+          remote: cache_restore_duration=[0-9.]+
+          remote: cache_save_duration=[0-9.]+
+          remote: cache_status=empty
+          remote: dependencies_install_duration=[0-9.]+
+          remote: django_collectstatic_duration=[0-9.]+
+          remote: nltk_downloader_duration=[0-9.]+
+          remote: package_manager_install_duration=[0-9.]+
+          remote: package_manager=poetry
+          remote: poetry_version=#{POETRY_VERSION}
+          remote: post_compile_hook=false
+          remote: pre_compile_hook=false
+          remote: python_install_duration=[0-9.]+
+          remote: python_version=#{DEFAULT_PYTHON_FULL_VERSION}
+          remote: python_version_major=3.13
+          remote: python_version_origin=.python-version
+          remote: python_version_outdated=false
+          remote: python_version_pinned=false
+          remote: python_version_requested=3.13
+          remote: setup_py_only=false
+          remote: total_duration=[0-9.]+
+        REGEX
         app.commit!
         app.push!
         expect(clean_output(app.output)).to include(<<~OUTPUT)

--- a/spec/hatchet/uv_spec.rb
+++ b/spec/hatchet/uv_spec.rb
@@ -48,6 +48,28 @@ RSpec.describe 'uv support' do
           remote: typing-extensions 4.13.2
           remote: 
           remote: <module 'typing_extensions' from '/app/.heroku/python/lib/python3.13/site-packages/typing_extensions.py'>
+          remote: 
+          remote: 
+          remote: cache_restore_duration=[0-9.]+
+          remote: cache_save_duration=[0-9.]+
+          remote: cache_status=empty
+          remote: dependencies_install_duration=[0-9.]+
+          remote: django_collectstatic_duration=[0-9.]+
+          remote: nltk_downloader_duration=[0-9.]+
+          remote: package_manager_install_duration=[0-9.]+
+          remote: package_manager=uv
+          remote: post_compile_hook=false
+          remote: pre_compile_hook=false
+          remote: python_install_duration=[0-9.]+
+          remote: python_version=#{DEFAULT_PYTHON_FULL_VERSION}
+          remote: python_version_major=3.13
+          remote: python_version_origin=.python-version
+          remote: python_version_outdated=false
+          remote: python_version_pinned=false
+          remote: python_version_requested=3.13
+          remote: setup_py_only=false
+          remote: total_duration=[0-9.]+
+          remote: uv_version=#{UV_VERSION}
         REGEX
         app.commit!
         app.push!


### PR DESCRIPTION
It's not possible to test `bin/report` functionality directly using Hatchet tests, however, we can dump the raw build metadata store values to at least test that we're storing the expected keys/values.

This complements the non-Hatchet container CI test that checks that `bin/report` exits zero.

This has been split out of the upcoming `bin/report` refactor PR to keep that PR smaller, and to more easily demonstrate the change in behaviour after that PR.

GUS-W-19384622.