### PR TITLE
Use contractions in user-facing messages

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ compile_start_time=$(build_data::current_unix_time_ms)
 # a build report that will be consumed by the build system for observability.
 build_data::setup
 
-checks::ensure_supported_stack "${STACK:?Required env var STACK is not set}"
+checks::ensure_supported_stack "${STACK:?"Required env var STACK isn't set"}"
 checks::duplicate_python_buildpack "${BUILD_DIR}"
 
 # Prepend proper path for old-school virtualenv hackery.

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -36,7 +36,7 @@ case "${STACK:?}" in
 esac
 
 if [[ " ${SUPPORTED_PYTHON_VERSIONS[*]} " != *" ${PYTHON_MAJOR_VERSION} "* ]]; then
-	abort "Python ${PYTHON_MAJOR_VERSION} is not supported on ${STACK}!"
+	abort "Python ${PYTHON_MAJOR_VERSION} isn't supported on ${STACK}!"
 fi
 
 # The release keys can be found on https://www.python.org/downloads/ -> "OpenPGP Public Keys".

--- a/builds/test_python_runtime.sh
+++ b/builds/test_python_runtime.sh
@@ -36,7 +36,7 @@ set +x
 UNEXPECTED_BIN_FILES="$(find "${INSTALL_DIR}/bin" -type 'f,l' -not -name 'python*')"
 if [[ -n "${UNEXPECTED_BIN_FILES}" ]]; then
 	echo "${UNEXPECTED_BIN_FILES}"
-	abort "The above files were found in the bin/ directory but were not expected!"
+	abort "The above files were found in the bin/ directory but weren't expected!"
 else
 	echo "No unexpected files found in the bin/ directory."
 fi
@@ -44,7 +44,7 @@ fi
 # Check that all dynamically linked libraries exist in the run image (since it has fewer packages than the build image).
 LDD_OUTPUT=$(find "${INSTALL_DIR}" -type f,l \( -name 'python3' -o -name '*.so*' \) -exec ldd '{}' +)
 if grep 'not found' <<<"${LDD_OUTPUT}" | sort --unique; then
-	abort "The above dynamically linked libraries were not found!"
+	abort "The above dynamically linked libraries weren't found!"
 else
 	echo "All dynamically linked libraries were found."
 fi

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -32,7 +32,7 @@ current_github_release_version=$(gh release view --json tagName --jq '.tagName' 
 current_registry_version="$(heroku buildpacks:versions "${buildpack_registry_name}" | awk 'FNR == 3 { print $1 }')"
 
 if [[ "${current_github_release_version}" != "${current_registry_version}" ]]; then
-	abort "The current GitHub release version (v${current_github_release_version}) does not match the registry version (v${current_registry_version}), likely due to a registry rollback. Fix this first!"
+	abort "The current GitHub release version (v${current_github_release_version}) doesn't match the registry version (v${current_registry_version}), likely due to a registry rollback. Fix this first!"
 fi
 
 new_version="$((current_github_release_version + 1))"

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -17,7 +17,7 @@ function package_manager::determine_package_manager() {
 			Error: No 'Pipfile.lock' found!
 
 			A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
-			Pipenv lockfile was not. This means your app dependency versions
+			Pipenv lockfile wasn't. This means your app dependency versions
 			aren't pinned, which means the package versions used on Heroku
 			might not match those installed in other environments.
 

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe 'Pipenv support' do
           remote:  !     Error: No 'Pipfile.lock' found!
           remote:  !     
           remote:  !     A 'Pipfile' file was found, however, the associated 'Pipfile.lock'
-          remote:  !     Pipenv lockfile was not. This means your app dependency versions
+          remote:  !     Pipenv lockfile wasn't. This means your app dependency versions
           remote:  !     aren't pinned, which means the package versions used on Heroku
           remote:  !     might not match those installed in other environments.
           remote:  !     


### PR DESCRIPTION
Per the CX team's style guide.

Only the `package_manager.sh` change is user-facing, but I've updated the other places to reduce false positives when grepping.
