### PR TITLE
Fix collectstatic and NLTK downloader for apps with `CACHE_DIR` set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Django collectstatic and NLTK downloader support for apps that use config vars that shadow internal buildpack variable names (such as `CACHE_DIR`). ([#1888](https://github.com/heroku/heroku-buildpack-python/pull/1888))
 
 ## [v303] - 2025-08-26
 

--- a/bin/compile
+++ b/bin/compile
@@ -207,13 +207,15 @@ build_data::set_duration "dependencies_install_duration" "${dependencies_install
 
 # Support for NLTK corpora.
 nltk_downloader_start_time=$(build_data::current_unix_realtime)
-sub_env "${BUILDPACK_DIR}/bin/steps/nltk"
+# TODO: Migrate this script to functions under `lib/` and stop running it in a subshell.
+"${BUILDPACK_DIR}/bin/steps/nltk"
 build_data::set_duration "nltk_downloader_duration" "${nltk_downloader_start_time}"
 
 # Django collectstatic support.
 # The buildpack automatically runs collectstatic for Django applications.
 collectstatic_start_time=$(build_data::current_unix_realtime)
-sub_env "${BUILDPACK_DIR}/bin/steps/collectstatic"
+# TODO: Migrate this script to functions under `lib/` and stop running it in a subshell.
+"${BUILDPACK_DIR}/bin/steps/collectstatic"
 build_data::set_duration "django_collectstatic_duration" "${collectstatic_start_time}"
 
 # Programmatically create .profile.d script for application runtime environment variables.

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -10,13 +10,20 @@
 #   - $DISABLE_COLLECTSTATIC: disables this functionality.
 #   - $DEBUG_COLLECTSTATIC: upon failure, print out environment variables.
 
-# This script is run in a subshell via sub_env so doesn't inherit the options/vars/utils from `bin/compile`.
-# TODO: Stop running this script in a subshell.
+# This script is run in a subshell so doesn't inherit the options/vars/utils from `bin/compile`.
+# TODO: Migrate this script to functions under `lib/` and stop running the entire script in a subshell,
+# and instead only the parts that need the user-provided config vars loaded.
 set -euo pipefail
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")" && pwd)
 source "${BUILDPACK_DIR}/bin/utils"
 source "${BUILDPACK_DIR}/lib/build_data.sh"
 source "${BUILDPACK_DIR}/lib/output.sh"
+
+# This must be after the imports above, to prevent user-provided config vars from overwriting
+# env vars used by the buildpack such as `CACHE_DIR`:
+# https://github.com/heroku/heroku-buildpack-python/issues/972
+# TODO: Reduce the scope of this even further, as part of refactoring this file.
+export_env "${ENV_DIR}"
 
 if [[ -f .heroku/collectstatic_disabled ]]; then
 	output::step "Skipping Django collectstatic since the file '.heroku/collectstatic_disabled' exists."

--- a/bin/steps/nltk
+++ b/bin/steps/nltk
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script is run in a subshell via sub_env so doesn't inherit the options/vars/utils from `bin/compile`.
-# TODO: Stop running this script in a subshell.
+# TODO: Migrate this script to functions under `lib/` and stop running the entire script in a subshell.
 set -euo pipefail
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")" && pwd)
 source "${BUILDPACK_DIR}/bin/utils"
@@ -27,7 +27,8 @@ if is_module_available 'nltk'; then
 
 		nltk_data_dir="/app/.heroku/python/nltk_data"
 
-		if ! python -m nltk.downloader -d "${nltk_data_dir}" "${nltk_packages[@]}" |& output::indent; then
+		# TODO: Does this even need user-provided env vars, or can we remove the sub_env usage here?
+		if ! sub_env python -m nltk.downloader -d "${nltk_data_dir}" "${nltk_packages[@]}" |& output::indent; then
 			output::error <<-EOF
 				Error: Unable to download NLTK data.
 

--- a/spec/hatchet/django_spec.rb
+++ b/spec/hatchet/django_spec.rb
@@ -10,8 +10,7 @@ require_relative '../spec_helper'
 BROKEN_CONFIG_VARS = {
   BUILD_DIR: '/invalid-path',
   C_INCLUDE_PATH: '/invalid-path',
-  # TODO: This currently fails xref: https://github.com/heroku/heroku-buildpack-python/issues/1886
-  # CACHE_DIR: '/invalid-path',
+  CACHE_DIR: '/invalid-path',
   CPLUS_INCLUDE_PATH: '/invalid-path',
   ENV_DIR: '/invalid-path',
   LD_LIBRARY_PATH: '/invalid-path',
@@ -78,7 +77,7 @@ RSpec.describe 'Django support' do
           remote: -----> \\$ python manage.py collectstatic --noinput
           remote:        \\{'BUILDPACK_LOG_FILE': '/dev/null',
           remote:         'BUILD_DIR': '/invalid-path',
-          remote:         'CACHE_DIR': '/tmp/codon/tmp/cache',
+          remote:         'CACHE_DIR': '/invalid-path',
           remote:         'CPLUS_INCLUDE_PATH': '/invalid-path',
           remote:         'C_INCLUDE_PATH': '/invalid-path',
           remote:         'DJANGO_SETTINGS_MODULE': 'testproject.settings',

--- a/vendor/buildpack-stdlib_v8.sh
+++ b/vendor/buildpack-stdlib_v8.sh
@@ -46,7 +46,7 @@ export_env() {
 	local env_dir="${1:-${ENV_DIR}}"
 	local whitelist="${2:-}"
 	local blacklist
-	blacklist="$(_env_blacklist "${3}")"
+	blacklist="$(_env_blacklist "${3:-}")"
 	if [[ -d "${env_dir}" ]]; then
 		# Environment variable names won't contain characters affected by:
 		# shellcheck disable=SC2045


### PR DESCRIPTION
By default, user-provided env vars (app config vars) are not loaded into the buildpack environment by the build system, and instead buildpacks must load them explicitly when required:
https://devcenter.heroku.com/articles/buildpack-api#bin-compile

In general, this buildpack (like many of the others) tries to limit the places where user-provided env vars are loaded, in order to prevent them from breaking the build process.

However, there are key parts of the build where they must be loaded, so that the app runs as expected.

For example, when running the Django collectstatic command (to generate the app's static assets), the Django app's config will be loaded, and parts of it may reference/depend upon the app config vars.

For some time, the entire collectstatic step has been run in a subshell with the user config vars loaded, which meant there was a chance for env var shadowing. In particular, it turns out that if an app had the env var `CACHE_DIR` set, it would cause the build data store writes to fail. 

Until the recent `bin/report` refactor these failing writes were silently ignored, however, those failures now (intentionally) are surfaced, which caused the build to fail as seen in #1886.

The Django collectstatic and NLTK downloader steps are the last two parts of the buildpack that haven't been refactored and moved to `lib/` and so are still using the old/fragile implementations written many years ago.

I will be refactoring them more fully in the future, but for now the `CACHE_DIR` issue has been resolved by more narrowly scoping where user provided env vars are loaded.

Fixes #1886.
GUS-W-19443067.