### PR TITLE
Delegate Ruby whitespace handling to RuboCop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,11 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.rb]
+# Required since we use heredocs to assert against Hatchet output, and sometimes that output
+# contains trailing newlines. Our RuboCop config ensures these are only allowed in heredocs.
+trim_trailing_whitespace = false
+
 [*.sh]
 binary_next_line = true
 # We sadly have to use tabs in shell scripts otherwise we can't indent here documents:


### PR DESCRIPTION
We use Ruby heredocs to assert against Hatchet output, and sometimes that output contains trailing newlines.

These trailing newlines are permitted in the RuboCop config, however, until now were being removed if people used tooling locally that used the `.editorconfig` instead (such as the VSCode `.editorconfig` extension).

See also:
https://github.com/heroku/heroku-buildpack-dotnet/pull/118

GUS-W-19580687.
