### PR TITLE
Add metrics for misspelled `.python-version` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added metrics for misspelled `.python-version` files. ([#1904](https://github.com/heroku/heroku-buildpack-python/pull/1904))
 
 ## [v308] - 2025-09-19
 

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -50,6 +50,17 @@ function python_version::read_requested_python_version() {
 	declare -n origin="${5}"
 	local contents
 
+	# Record the names of files similar to .python-version in the root of the app, to determine
+	# how often that file is misspelled, as a temporary first step before deciding whether to add
+	# a new warning/error (and if so, which for which misspelled filenames it should check).
+	local python_version_files
+	python_version_files="$(
+		find . -maxdepth 1 -type f -iregex '\./\.?python.?version.*' -printf '%P\n' | sort | tr '\n' ',' || true
+	)"
+	if [[ -n "${python_version_files}" ]]; then
+		build_data::set_string "python_version_files" "${python_version_files}"
+	fi
+
 	local runtime_txt_path="${build_dir}/runtime.txt"
 	if [[ -f "${runtime_txt_path}" ]]; then
 		contents="$(utils::read_file_with_special_chars_substituted "${runtime_txt_path}")"

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe 'pip support' do
           remote:   "pre_compile_hook": false,
           remote:   "python_install_duration": [0-9.]+,
           remote:   "python_version": "#{DEFAULT_PYTHON_FULL_VERSION}",
+          remote:   "python_version_files": ".python-version,",
           remote:   "python_version_major": "3.13",
           remote:   "python_version_origin": ".python-version",
           remote:   "python_version_outdated": false,

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe 'Poetry support' do
           remote:   "pre_compile_hook": false,
           remote:   "python_install_duration": [0-9.]+,
           remote:   "python_version": "#{DEFAULT_PYTHON_FULL_VERSION}",
+          remote:   "python_version_files": ".python-version,",
           remote:   "python_version_major": "3.13",
           remote:   "python_version_origin": ".python-version",
           remote:   "python_version_outdated": false,

--- a/spec/hatchet/uv_spec.rb
+++ b/spec/hatchet/uv_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'uv support' do
           remote:   "pre_compile_hook": false,
           remote:   "python_install_duration": [0-9.]+,
           remote:   "python_version": "#{DEFAULT_PYTHON_FULL_VERSION}",
+          remote:   "python_version_files": ".python-version,",
           remote:   "python_version_major": "3.13",
           remote:   "python_version_origin": ".python-version",
           remote:   "python_version_outdated": false,


### PR DESCRIPTION
Record the names of files similar to `.python-version` in the root of the app, to determine how often that file is misspelled, as a temporary first step before deciding whether to add a new warning/error (and if so, which for which misspelled filenames it should check).

GUS-W-19271516.
