### PR TITLE
Improve metrics for failed uv archive downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved metrics for failed uv archive downloads. ([#1908](https://github.com/heroku/heroku-buildpack-python/pull/1908))
 
 ## [v309] - 2025-09-19
 


### PR DESCRIPTION
For parity with what already exists for Python archive downloads:
https://github.com/heroku/heroku-buildpack-python/blob/4d20ad3e50f23e635c46120c1b013df4c1c44f8d/lib/python.sh#L120-L121

Example failure this would now track:

```
-----> Installing uv 0.8.18
curl: (56) Recv failure: Connection reset by peer

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

GUS-W-19702437.