### PR TITLE
Use `cp --no-dereference` when saving the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed errors saving the build cache when installed packages contain broken symlinks. ([#1909](https://github.com/heroku/heroku-buildpack-python/pull/1909))
 - Improved metrics for failed uv archive downloads. ([#1908](https://github.com/heroku/heroku-buildpack-python/pull/1908))
 
 ## [v309] - 2025-09-19

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -189,7 +189,10 @@ function cache::save() {
 		local additional_copy_args=()
 	fi
 
-	cp --recursive "${additional_copy_args[@]}" "${build_dir}/.heroku/python" "${cache_dir}/.heroku/"
+	# We must explicitly use `--no-dereference` since the default cp behaviour varies based on other
+	# options used (such as `--link`), and we don't want symlinks to be resolved since otherwise the
+	# copy will fail when copying packages that contain broken symlinks.
+	cp --recursive --no-dereference "${additional_copy_args[@]}" "${build_dir}/.heroku/python" "${cache_dir}/.heroku/"
 
 	# Metadata used by subsequent builds to determine whether the cache can be reused.
 	# These are written/consumed via separate files and not the build data store for compatibility


### PR DESCRIPTION
When copying files, `cp` can either follow (dereference) symlinks or preserve them. If no explicit `--dereference` or `--no-dereference` option is passed, the default behaviour is currently unspecified by the POSIX specification, and in practice arbitrarily varies based on other options that are passed.

Specifically, when using `--link` after #1902, cp now defaults to following symlinks, which:
(a) means the files aren't copied/linked verbatim
(b) means the copy will fail if any of the symlinks are broken

For the files owned by the buildpack there are no broken symlinks, however, Python packages in the wild can contain broken symlinks, which causes the build to fail with errors like:

```
-----> Saving cache
cp: cannot stat '/tmp/build_123/.heroku/python/src/django-admin-autocomplete-list-filter/.pylintrc': No such file or directory
```

(As seen in salomvary/django-admin-autocomplete-list-filter#1)

Now, `--no-dereference` is passed, to explicitly disable dereferencing, so we're not dependant on the unspecified defaults.

See:
https://manpages.ubuntu.com/manpages/noble/en/man1/cp.1.html

GUS-W-19714036.
