### PR TITLE
Remove unnecessary tar `--no-anchored`

### DIFF
--- a/lib/uv.sh
+++ b/lib/uv.sh
@@ -56,7 +56,6 @@ function uv::install_uv() {
 						--directory "${uv_dir}" \
 						--extract \
 						--gzip \
-						--no-anchored \
 						--strip-components 1
 			} \
 				|& tee "${error_log}" \


### PR DESCRIPTION
Since it was a leftover from when this tar command also passed the uv binary name to only extract the single file from the archive.
