### PR TITLE
Further expand buildpack detection known file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added more Python project related file and directory names to the list recognised by buildpack detection. ([#1914](https://github.com/heroku/heroku-buildpack-python/pull/1914))
 
 ## [v310] - 2025-09-23
 

--- a/bin/detect
+++ b/bin/detect
@@ -37,14 +37,17 @@ KNOWN_PYTHON_PROJECT_FILES=(
 	uv.lock
 	# Commonly seen misspellings of requirements.txt. (Which occur since pip doesn't
 	# create/manage requirements files itself, so the filenames are manually typed.)
+	requeriments.txt
 	requirement.txt
-	Requirements.txt
+	requirements
 	requirements.text
+	Requirements.txt
 	requirements.txt.txt
 	requirments.txt
-	# Whilst virtual environments shouldn't be committed to Git (and so shouldn't
-	# normally be present during the build), they are often present for beginner
+	# Whilst the pyc cache and virtual environments shouldn't be committed to Git (and so
+	# shouldn't normally be present during the build), they are often present for beginner
 	# Python apps that are missing all of the other Python related files above.
+	__pycache__/
 	.venv/
 	venv/
 )


### PR DESCRIPTION
Similar to #1729, this adds more files to the buildpack's detection list - based on files commonly seen for apps that fail detection due to e.g. misspelled files.

GUS-W-19769721.
