### PR TITLE
Use `pip install --isolated` when bootstrapping pip/Pipenv/Poetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed the `pip install` command used to install the pip, Pipenv and Poetry package managers to now use `--isolated` mode. ([#1915](https://github.com/heroku/heroku-buildpack-python/pull/1915))
 - Added more Python project related file and directory names to the list recognised by buildpack detection. ([#1914](https://github.com/heroku/heroku-buildpack-python/pull/1914))
 
 ## [v310] - 2025-09-23

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -46,11 +46,14 @@ function pip::install_pip_setuptools_wheel() {
 	# app's requirements.txt in the last build). The install will be a no-op if the versions match.
 	output::step "Installing ${packages_display_text}"
 
+	# `--isolated`: Prevents any custom pip configuration added by third party buildpacks (via env
+	#               vars or global config files) from breaking package manager bootstrapping.
 	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 	if ! {
 		python "${bundled_pip_module_path}" \
 			install \
 			--disable-pip-version-check \
+			--isolated \
 			--no-cache-dir \
 			--no-input \
 			--quiet \

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -60,11 +60,14 @@ function pipenv::install_pipenv() {
 		# We must call the venv Python directly here, rather than relying on pip's `--python`
 		# option, since `--python` was only added in pip v22.3, so isn't supported by the older
 		# pip versions bundled with Python 3.9/3.10.
+		# `--isolated`: Prevents any custom pip configuration added by third party buildpacks (via env
+		#               vars or global config files) from breaking package manager bootstrapping.
 		# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 		if ! {
 			"${pipenv_venv_dir}/bin/python" "${bundled_pip_module_path}" \
 				install \
 				--disable-pip-version-check \
+				--isolated \
 				--no-cache-dir \
 				--no-input \
 				--quiet \

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -66,11 +66,14 @@ function poetry::install_poetry() {
 		# We must call the venv Python directly here, rather than relying on pip's `--python`
 		# option, since `--python` was only added in pip v22.3, so isn't supported by the older
 		# pip versions bundled with Python 3.9/3.10.
+		# `--isolated`: Prevents any custom pip configuration added by third party buildpacks (via env
+		#               vars or global config files) from breaking package manager bootstrapping.
 		# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 		if ! {
 			"${poetry_venv_dir}/bin/python" "${bundled_pip_module_path}" \
 				install \
 				--disable-pip-version-check \
+				--isolated \
 				--no-cache-dir \
 				--no-input \
 				--quiet \


### PR DESCRIPTION
So that any invalid global pip config set by earlier buildpacks (either via `PIP_*` env vars or global pip config files in the HOME directory) don't affect/break the bootstrapping of the package managers.

(Such config is still loaded during the later `pip install` used to install the app's own dependencies; this change only affects the internal buildpack bootstrapping stage.)

This will help resolve issues seen via Honeycomb such as the bootstrapping step attempting to use custom package index URLs configured via third-party buildpacks like:
https://github.com/meetalbert/albert-public-codeartifact-buildpack
(which succeeds eventually, but only after delays from timeouts/retries)

See:
- https://pip.pypa.io/en/stable/cli/pip/#cmdoption-isolated
- https://pip.pypa.io/en/stable/topics/configuration/

GUS-W-19770470.
