### PR TITLE
Always use `|&` with `output::indent`

### DIFF
--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -67,7 +67,7 @@ export PYTHONPATH
 COLLECTSTATIC_LOG=$(mktemp)
 
 set +e
-python "${MANAGE_FILE}" collectstatic --noinput --traceback 2>&1 | tee "${COLLECTSTATIC_LOG}" | sed --unbuffered '/^Post-processed/d;/^Copying/d;/^$/d' | output::indent
+python "${MANAGE_FILE}" collectstatic --noinput --traceback |& tee "${COLLECTSTATIC_LOG}" |& sed --unbuffered '/^Post-processed/d;/^Copying/d;/^$/d' |& output::indent
 COLLECTSTATIC_STATUS="${PIPESTATUS[0]}"
 set -e
 

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -23,7 +23,7 @@ function output::step() {
 #
 # Usage:
 # ```
-# pip install ... | output::indent
+# pip install ... |& output::indent
 # ```
 function output::indent() {
 	sed --unbuffered "s/^/       /"


### PR DESCRIPTION
To ensure any stderr is intended too.
(All other call sites currently use `|&`)

See:
https://www.gnu.org/software/bash/manual/html_node/Pipelines.html