### PR TITLE
Switch from GPG to Sigstore for Python source verification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "docker"
+      - "skip changelog"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -1,4 +1,5 @@
 ARG STACK_VERSION="24"
+FROM ghcr.io/sigstore/cosign/cosign:v2.6.1@sha256:68839b7f13dac5a6744a5d8818e984dd39183374e37855c19e14d623d9bc9037 AS cosign
 FROM heroku/heroku:${STACK_VERSION}-build
 
 ARG STACK_VERSION
@@ -13,6 +14,7 @@ RUN apt-get update --error-on=any \
       libreadline-dev \
       libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
 
 WORKDIR /tmp
 COPY build_python_runtime.sh python-3.13-ubuntu-22.04-libexpat-workaround.patch .


### PR DESCRIPTION
The build scripts that download and compile the Python source archives (for upload to S3, where they are then consumed by the buildpack during customer builds) currently use GPG to verify the Python source archive downloads.

However, use of PGP signatures for Python artifact verification was deprecated previously in PEP 761, in favour of Sigstore:
https://peps.python.org/pep-0761/
https://www.python.org/downloads/metadata/sigstore/

Until now the PGP signatures have still been available for all stable releases, however, as of Python 3.14 (due to be released this week), Sigstore will be the only supported verification mechanism:
https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-no-more-pgp

As such, we must now switch over to Sigstore.

We use the `cosign` CLI for verification since it's a standalone binary available via a Docker image, rather than the Python `sigstore` CLI which requires a Python environment (and so would need pip, venv etc, and more setup to ensure it stays isolated from the Python we're trying to build).

See:
- https://www.python.org/downloads/metadata/sigstore/
- https://docs.sigstore.dev/cosign/system_config/installation/#container-images
- https://docs.sigstore.dev/cosign/verifying/verify/
- https://github.com/sigstore/cosign/blob/main/doc/cosign_verify-blob.md

GUS-W-18244071.