### PR TITLE
Use a consistent `failure_reason` prefix for all internal errors

### DIFF
--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -50,7 +50,7 @@ function pipenv::install_pipenv() {
 
 				See the log output above for more information.
 			EOF
-			build_data::set_string "failure_reason" "create-venv::pipenv"
+			build_data::set_string "failure_reason" "internal-error::create-venv::pipenv"
 			exit 1
 		fi
 

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -56,7 +56,7 @@ function poetry::install_poetry() {
 
 				See the log output above for more information.
 			EOF
-			build_data::set_string "failure_reason" "create-venv::poetry"
+			build_data::set_string "failure_reason" "internal-error::create-venv::poetry"
 			exit 1
 		fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -51,7 +51,7 @@ function utils::bundled_pip_module_path() {
 
 			$(find "${bundled_wheels_dir}/" 2>&1 || find "${python_home}/" -type d 2>&1 || true)
 		EOF
-		build_data::set_string "failure_reason" "bundled-pip-not-found"
+		build_data::set_string "failure_reason" "internal-error::bundled-pip-not-found"
 		exit 1
 	fi
 }
@@ -62,7 +62,7 @@ function utils::abort_internal_error() {
 	output::error <<-EOF
 		Internal error: ${message}.
 	EOF
-	build_data::set_string "failure_reason" "internal-error"
+	build_data::set_string "failure_reason" "internal-error::abort"
 	build_data::set_string "failure_detail" "${message}"
 	exit 1
 }


### PR DESCRIPTION
Always use the prefix `internal-error::` for the buildpack build data event `failure_reason` field for internal errors, in preparation for adding an ERR trap with a new `internal-error::` variant.

GUS-W-19792272.