### PR TITLE
Improve error messages and metrics for unhandled errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved error messages and metrics for unhandled buildpack errors. ([#1933](https://github.com/heroku/heroku-buildpack-python/pull/1933))
 
 ## [v313] - 2025-10-09
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,9 @@
 # Usage: bin/compile <build-dir> <cache-dir> <env-dir>
 # See: https://devcenter.heroku.com/articles/buildpack-api
 
-set -euo pipefail
+# We use `errtrace` and `inherit_errexit` to ensure the ERR trap and exit on error behaviour
+# propagates to buildpack functions run in subshells, such when using command substitutions.
+set -eu -o pipefail -o errtrace
 shopt -s inherit_errexit
 
 # Note: This can't be enabled via app config vars, since at this point they haven't been loaded from ENV_DIR.
@@ -38,6 +40,8 @@ compile_start_time=$(build_data::current_unix_realtime)
 # and messaging when build configuration changes) and also so that `bin/report` can generate
 # a build report that will be consumed by the build system for observability.
 build_data::setup
+
+trap 'utils::err_trap' ERR
 
 checks::ensure_supported_stack "${STACK:?"Required env var STACK isn't set"}"
 checks::duplicate_python_buildpack "${BUILD_DIR}"

--- a/lib/build_data.sh
+++ b/lib/build_data.sh
@@ -109,6 +109,19 @@ function build_data::_set() {
 	echo "${new_data_file_contents}" >"${BUILD_DATA_FILE}"
 }
 
+# Check whether an entry exists in the build data store for the current build.
+# Returns zero if the key was found and non-zero otherwise.
+#
+# Usage:
+# ```
+# build_data::has "failure_reason"
+# ```
+function build_data::has() {
+	local key="${1}"
+
+	jq --exit-status "has(\"${key}\")" "${BUILD_DATA_FILE}" >/dev/null
+}
+
 # Retrieve the value of an entry in the build data store from the previous successful build.
 # Returns the empty string if the key wasn't found in the store.
 #


### PR DESCRIPTION
Adds a Bash ERR trap to catch any unhandled buildpack errors, which displays a more helpful error message (that includes the command being run and the stack trace), as well as setting an appropriate failure reason and detail in the build event payload.

For example:

```
-----> Using Python 3.13 specified in .python-version
-----> Installing Python 3.13.8
mkdir: cannot create directory ‘/tmp/build_1/.heroku’: Not a directory

 !     Internal Error: An unhandled buildpack error occurred.
 !
 !     An unhandled error occurred while executing the command:
 !     mkdir -p "${install_dir}"
 !
 !     If this issue persists, please open a support ticket or file
 !     an issue on the buildpack's GitHub repository:
 !     https://help.heroku.com/
 !     https://github.com/heroku/heroku-buildpack-python/issues
 !
 !     Stack trace:
 !     python::install @ /tmp/buildpack/lib/python.sh:25
 !     main @ ./bin/compile:170

~ Report:
{
  ...
  "failure_detail": "mkdir -p \"${install_dir}\"",
  "failure_reason": "internal-error::unhandled",
  ...
}
```

See:
- https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html#index-trap
- https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-caller
- https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
- https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
- https://jqlang.org/manual/#has

GUS-W-19792272.
GUS-W-19792285.
