### PR TITLE
Update Dependabot config for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/builds"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
Since it appears the docker updater doesn't traverse the repo and needs the specific directory containing the `Dockerfile`.

Fixes:
https://github.com/heroku/heroku-buildpack-python/network/updates/1118250366

GUS-W-19898523.