### PR TITLE
Remove redundant internal error handling for venv creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Removed redundant internal error handling for venv creation. ([#1937](https://github.com/heroku/heroku-buildpack-python/pull/1937))
 
 ## [v314] - 2025-10-15
 

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -40,19 +40,7 @@ function pipenv::install_pipenv() {
 
 		# We use the pip wheel bundled within Python's standard library to install Pipenv,
 		# since Pipenv vendors its own pip, so doesn't need an install in the venv.
-		# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
-		if ! python -m venv --without-pip "${pipenv_venv_dir}" |& output::indent; then
-			output::error <<-EOF
-				Internal Error: Unable to create virtual environment for Pipenv.
-
-				The 'python -m venv' command to create a virtual environment did
-				not exit successfully.
-
-				See the log output above for more information.
-			EOF
-			build_data::set_string "failure_reason" "internal-error::create-venv::pipenv"
-			exit 1
-		fi
+		python -m venv --without-pip "${pipenv_venv_dir}"
 
 		local bundled_pip_module_path
 		bundled_pip_module_path="$(utils::bundled_pip_module_path "${python_home}" "${python_major_version}")"

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -46,19 +46,7 @@ function poetry::install_poetry() {
 		# it bundles its own copy for use as a fallback. As such we don't need to install pip
 		# into the Poetry venv (and in fact, Poetry wouldn't use this install anyway, since
 		# it only finds an external pip if it exists in the target venv).
-		# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
-		if ! python -m venv --without-pip "${poetry_venv_dir}" |& output::indent; then
-			output::error <<-EOF
-				Internal Error: Unable to create virtual environment for Poetry.
-
-				The 'python -m venv' command to create a virtual environment did
-				not exit successfully.
-
-				See the log output above for more information.
-			EOF
-			build_data::set_string "failure_reason" "internal-error::create-venv::poetry"
-			exit 1
-		fi
+		python -m venv --without-pip "${poetry_venv_dir}"
 
 		local bundled_pip_module_path
 		bundled_pip_module_path="$(utils::bundled_pip_module_path "${python_home}" "${python_major_version}")"


### PR DESCRIPTION
Since:
- The underlying cause of the errors (a bug in older `ensurepip`) was fixed in #1761 and friends.
- As of #1933 the generic error trap now handles all internal errors, meaning we don't custom handling for them any more.

GUS-W-19898848.
