### PR TITLE
Stop using a global warnings log file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,12 +53,6 @@ export PATH=":/usr/local/bin:${PATH}"
 # Exported for use in subshells, such as the steps run via sub_env.
 export BUILD_DIR CACHE_DIR ENV_DIR
 
-# Common Problem Warnings:
-# This section creates a temporary file in which to stick the output of `pip install`.
-# The `warnings` subscript then greps through this for common problems and guides
-# the user towards resolution of known issues.
-WARNINGS_LOG=$(mktemp)
-
 # Sanitize externally-provided environment variables:
 # The following environment variables are either problematic or simply unnecessary
 # for the buildpack to have knowledge of, so we unset them, to keep the environment

--- a/bin/warnings
+++ b/bin/warnings
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 show-warnings() {
+	local install_log="${1}"
+
 	# shellcheck disable=SC2154 # TODO: Env var is referenced but not assigned.
-	if grep -qi 'Could not find gdal-config' "${WARNINGS_LOG}"; then
+	if grep -qi 'Could not find gdal-config' "${install_log}"; then
 		output::error <<-'EOF'
 			Error: Package installation failed since the GDAL library wasn't found.
 
@@ -10,7 +12,7 @@ show-warnings() {
 			https://github.com/heroku/heroku-geo-buildpack
 		EOF
 		build_data::set_string "failure_detail" "Could not find gdal-config"
-	elif grep -qi 'sqlite3.h: No such file or directory' "${WARNINGS_LOG}"; then
+	elif grep -qi 'sqlite3.h: No such file or directory' "${install_log}"; then
 		output::error <<-'EOF'
 			Error: Package installation failed since SQLite headers weren't found.
 
@@ -39,7 +41,7 @@ show-warnings() {
 			https://github.com/heroku/heroku-buildpack-apt
 		EOF
 		build_data::set_string "failure_detail" "sqlite3.h: No such file or directory"
-	elif grep -qi 'Please use pip<24.1 if you need to use this version' "${WARNINGS_LOG}"; then
+	elif grep -qi 'Please use pip<24.1 if you need to use this version' "${install_log}"; then
 		output::error <<-'EOF'
 			Error: One of your dependencies contains broken metadata.
 

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -109,6 +109,9 @@ function pip::install_dependencies() {
 	# We only display the most relevant command args here, to improve the signal to noise ratio.
 	output::step "Installing dependencies using '${pip_install_command[*]}'"
 
+	local install_log
+	install_log=$(mktemp)
+
 	# TODO: Remove --disable-pip-version-check in favour of exporting PIP_DISABLE_PIP_VERSION_CHECK.
 	# The sed usage is to reduce the verbosity of output lines like:
 	# ...when using Python 3.10 and older:
@@ -124,13 +127,13 @@ function pip::install_dependencies() {
 			--no-input \
 			--progress-bar off \
 			--src='/app/.heroku/python/src' \
-			|& tee "${WARNINGS_LOG:?}" \
+			|& tee "${install_log}" \
 			|& sed --unbuffered --regexp-extended \
 				--expression 's# in (/app|\.)/\.heroku/python/lib/python[0-9.]+/site-packages##' \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling.
-		show-warnings
+		show-warnings "${install_log}"
 
 		output::error <<-EOF
 			Error: Unable to install dependencies using pip.

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -142,6 +142,9 @@ function pipenv::install_dependencies() {
 	# We only display the most relevant command args here, to improve the signal to noise ratio.
 	output::step "Installing dependencies using '${pipenv_install_command[*]}'"
 
+	local install_log
+	install_log=$(mktemp)
+
 	# TODO: Expose app config vars to the install command as part of doing so for all package managers.
 	# `PIPENV_NOSPIN`: Disable progress spinners.
 	# `PIP_SRC`: Override the editable VCS repo location from its default of inside the build directory
@@ -150,11 +153,11 @@ function pipenv::install_dependencies() {
 	if ! {
 		PIPENV_NOSPIN="1" PIP_SRC="/app/.heroku/python/src" \
 			"${pipenv_install_command[@]}" \
-			|& tee "${WARNINGS_LOG:?}" \
+			|& tee "${install_log}" \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling.
-		show-warnings
+		show-warnings "${install_log}"
 
 		output::error <<-EOF
 			Error: Unable to install dependencies using Pipenv.

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -130,6 +130,9 @@ function poetry::install_dependencies() {
 	# We only display the most relevant command args here, to improve the signal to noise ratio.
 	output::step "Installing dependencies using '${poetry_install_command[*]}'"
 
+	local install_log
+	install_log=$(mktemp)
+
 	# `--compile`: Compiles Python bytecode, to improve app boot times (pip does this by default).
 	# `--no-ansi`: Whilst we'd prefer to enable colour if possible, Poetry also emits ANSI escape
 	#              codes for redrawing lines, which renders badly in persisted build logs.
@@ -139,12 +142,12 @@ function poetry::install_dependencies() {
 			--compile \
 			--no-ansi \
 			--no-interaction \
-			|& tee "${WARNINGS_LOG:?}" \
+			|& tee "${install_log}" \
 			|& sed --unbuffered --expression '/Skipping virtualenv creation/d' \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling.
-		show-warnings
+		show-warnings "${install_log}"
 
 		output::error <<-EOF
 			Error: Unable to install dependencies using Poetry.

--- a/lib/uv.sh
+++ b/lib/uv.sh
@@ -149,6 +149,9 @@ function uv::install_dependencies() {
 	# We only display the most relevant command args here, to improve the signal to noise ratio.
 	output::step "Installing dependencies using '${uv_install_command[*]}'"
 
+	local install_log
+	install_log=$(mktemp)
+
 	# TODO: Expose app config vars to the install command as part of doing so for all package managers.
 	# `--compile-bytecode`: Improves app boot times (pip does this by default).
 	# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
@@ -157,11 +160,11 @@ function uv::install_dependencies() {
 			--color always \
 			--compile-bytecode \
 			--no-progress \
-			|& tee "${WARNINGS_LOG:?}" \
+			|& tee "${install_log}" \
 			|& output::indent
 	}; then
 		# TODO: Overhaul warnings and combine them with error handling (for all package managers).
-		show-warnings
+		show-warnings "${install_log}"
 
 		output::error <<-EOF
 			Error: Unable to install dependencies using uv.


### PR DESCRIPTION
In favour of per-install step temporary log files.

This is a first step towards refactoring warnings handling.

GUS-W-19969173.
