### PR TITLE
Pin Poetry's `dulwich` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Pinned `dulwich` version when using Poetry to work around an incompatibility with Python <3.9.2. ([#1943](https://github.com/heroku/heroku-buildpack-python/pull/1943))
 - Removed redundant internal error handling for venv creation. ([#1937](https://github.com/heroku/heroku-buildpack-python/pull/1937))
 
 ## [v314] - 2025-10-15

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -56,6 +56,8 @@ function poetry::install_poetry() {
 		# pip versions bundled with Python 3.9/3.10.
 		# `--isolated`: Prevents any custom pip configuration added by third party buildpacks (via env
 		#               vars or global config files) from breaking package manager bootstrapping.
+		# We pin to an older dulwich version to work around https://github.com/jelmer/dulwich/issues/1948
+		# on Python 3.9.0/3.9.1. TODO: Remove this pin when we drop support for Python 3.9 in Jan 2026.
 		# shellcheck disable=SC2310 # This function is invoked in an 'if' condition so set -e will be disabled.
 		if ! {
 			"${poetry_venv_dir}/bin/python" "${bundled_pip_module_path}" \
@@ -66,6 +68,7 @@ function poetry::install_poetry() {
 				--no-input \
 				--quiet \
 				"poetry==${POETRY_VERSION}" \
+				dulwich==0.24.5 \
 				|& output::indent
 		}; then
 			output::error <<-EOF


### PR DESCRIPTION
After the recent upstream `dulwich` 0.24.6 release, CI in this repo started failing in the test that runs Poetry with our oldest supported Python patch version (3.9.0).

eg:

```
remote: -----> Installing Poetry 2.2.1
remote: -----> Installing dependencies using 'poetry sync --only main'
remote:
remote:        unhashable type: 'list'
remote:
remote:  !     Error: Unable to install dependencies using Poetry.
remote:  !
remote:  !     See the log output above for more information.
remote:
remote:  !     Push rejected, failed to compile Python app.
```

Investigation showed this only affects Python 3.9.0 and 3.9.1, which are multiple years behind the latest 3.9.x patch version (3.9.24).

For more details see the upstream issue I opened:
https://github.com/jelmer/dulwich/issues/1948

Our options are either to drop support for 3.9.0 and 3.9.1 (and require use of Python 3.9.2+), or to pin the dulwich version.

Given we'll be dropping support for Python 3.9 in January 2026, for now we'll temporarily pin the dulwich version. (It's also possible the dulwich project might adjust it's `requires-python` and yank the 0.24.6 release, in which case we'll be able to remove the pin before then.)

GUS-W-20000280.
