### PR TITLE
Pin GDAL version in tests

### DIFF
--- a/spec/fixtures/pip_gdal/requirements.txt
+++ b/spec/fixtures/pip_gdal/requirements.txt
@@ -1,1 +1,2 @@
-GDAL
+# Pinned due to https://github.com/OSGeo/gdal/issues/13329
+GDAL==3.11.4


### PR DESCRIPTION
To work around:

```
remote: -----> Installing dependencies using 'pip install -r requirements.txt'
remote:        Collecting GDAL (from -r requirements.txt (line 1))
remote:          Downloading gdal-3.12.0.tar.gz (229 kB)
remote:          Installing build dependencies: started
remote:          Installing build dependencies: finished with status 'done'
remote:          Getting requirements to build wheel: started
remote:          Getting requirements to build wheel: finished with status 'error'
remote:          error: subprocess-exited-with-error
remote:          
remote:          × Getting requirements to build wheel did not run successfully.
remote:          │ exit code: 1
remote:          ╰─> [12 lines of output]
remote:              Using numpy 2.3.4
remote:              /tmp/pip-build-env-5ffoncnf/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsWarning: `license` overwritten by `pyproject.toml`
remote:                corresp(dist, value, root_dir)
remote:              /tmp/pip-build-env-5ffoncnf/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsWarning: `extras_require` overwritten in `pyproject.toml` (optional-dependencies)
remote:                corresp(dist, value, root_dir)
remote:              running egg_info
remote:              writing gdal-utils/GDAL.egg-info/PKG-INFO
remote:              writing dependency_links to gdal-utils/GDAL.egg-info/dependency_links.txt
remote:              writing entry points to gdal-utils/GDAL.egg-info/entry_points.txt
remote:              writing requirements to gdal-utils/GDAL.egg-info/requires.txt
remote:              writing top-level names to gdal-utils/GDAL.egg-info/top_level.txt
remote:              error: package directory 'osgeo' does not exist
remote:              [end of output]
```

(https://github.com/heroku/heroku-buildpack-python/actions/runs/18997765580/job/54260036112#step:5:409)

Which started now because GDAL 3.12.0rc0 seems to have accidentally been released upstream as a stable version instead of a release candidate:
https://github.com/OSGeo/gdal/issues/13329

GUS-W-20111893.