### PR TITLE
Add support for Python 3.9.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- The Python 3.9 version alias now resolves to Python 3.9.25. ([#1955](https://github.com/heroku/heroku-buildpack-python/pull/1955))
 - Updated uv from 0.9.5 to 0.9.7. ([#1952](https://github.com/heroku/heroku-buildpack-python/pull/1952))
 
 ## [v316] - 2025-10-27

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -4,7 +4,7 @@
 # however, it helps Shellcheck realise the options under which these functions will run.
 set -euo pipefail
 
-LATEST_PYTHON_3_9="3.9.24"
+LATEST_PYTHON_3_9="3.9.25"
 LATEST_PYTHON_3_10="3.10.19"
 LATEST_PYTHON_3_11="3.11.14"
 LATEST_PYTHON_3_12="3.12.12"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require 'hatchet'
 
 FIXTURE_DIR = Pathname.new(__FILE__).parent.join('fixtures')
 
-LATEST_PYTHON_3_9 = '3.9.24'
+LATEST_PYTHON_3_9 = '3.9.25'
 LATEST_PYTHON_3_10 = '3.10.19'
 LATEST_PYTHON_3_11 = '3.11.14'
 LATEST_PYTHON_3_12 = '3.12.12'


### PR DESCRIPTION
Changelog:
https://docs.python.org/release/3.9.25/whatsnew/changelog.html#python-3-9-25-final

Binary builds:
https://github.com/heroku/heroku-buildpack-python/actions/runs/19042194319

GUS-W-20112543.
