### PR TITLE
Always use `local` for vars inside functions

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -105,6 +105,7 @@ function checks::existing_python_dir_present() {
 
 function checks::existing_venv_dir_present() {
 	local build_dir="${1}"
+	local venv_name
 
 	for venv_name in ".venv" "venv"; do
 		if [[ -f "${build_dir}/${venv_name}/pyvenv.cfg" ]]; then

--- a/vendor/buildpack-stdlib_v8.sh
+++ b/vendor/buildpack-stdlib_v8.sh
@@ -48,6 +48,7 @@ export_env() {
 	local blacklist
 	blacklist="$(_env_blacklist "${3:-}")"
 	if [[ -d "${env_dir}" ]]; then
+		local e
 		# Environment variable names won't contain characters affected by:
 		# shellcheck disable=SC2045
 		for e in $(ls "${env_dir}"); do


### PR DESCRIPTION
Adds a couple of stray missing `local` declarations for completeness.

(Previously they were implicitly created as global via the `for` loop definition.)
