### PR TITLE
Work around tmpfs default permissions regression in runc 1.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format:
 
 run:
 	@echo "Running buildpack using: STACK=$(STACK) FIXTURE=$(FIXTURE)"
-	@docker run --rm -v $(PWD):/src:ro --tmpfs /app -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
+	@docker run --rm -v $(PWD):/src:ro --tmpfs /app:mode=1777 -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
 		bash -euo pipefail -O dotglob -c '\
 			mkdir /tmp/buildpack /tmp/cache /tmp/env; \
 			cp -r /src/{bin,lib,requirements,vendor} /tmp/buildpack; \


### PR DESCRIPTION
The Python classic repo's CI just started failing in the container-test job with:
`mkdir: cannot create directory '/app/.heroku': Permission denied`

eg:
https://github.com/heroku/heroku-buildpack-python/actions/runs/19368179568/job/55418539741

After updating Docker locally, I was able to reproduce the error, and have found it's due to the recent runc 1.3.3 release: https://github.com/opencontainers/runc/releases/tag/v1.3.3

This runc release includes a number of security fixes, one of which has a regression:
https://github.com/opencontainers/runc/issues/4971

There is a fix for this upstream:
https://github.com/opencontainers/runc/pull/4973

...but it's not released yet.

However, we can work around the issue by explicitly setting the previous tmpfs permissions using `:mode=1777`:
https://docs.docker.com/engine/storage/tmpfs/#options-for---tmpfs

GUS-W-20221627.
