### PR TITLE
Unpin Poetry's `dulwich` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed regex for null bytes character replacement to replace all occurrences, not just the first. ([#1966](https://github.com/heroku/heroku-buildpack-python/pull/1966))
+- Unpinned Poetry's `dulwich` version, since the upstream incompatibility with older Python has been fixed. ([#1967](https://github.com/heroku/heroku-buildpack-python/pull/1967))
 
 ## [v319] - 2025-11-14
 

--- a/lib/poetry.sh
+++ b/lib/poetry.sh
@@ -68,7 +68,6 @@ function poetry::install_poetry() {
 				--no-input \
 				--quiet \
 				"poetry==${POETRY_VERSION}" \
-				dulwich==0.24.5 \
 				|& output::indent
 		}; then
 			output::error <<-EOF


### PR DESCRIPTION
Since the incompatibility with older Python has now been fixed upstream:
https://github.com/jelmer/dulwich/issues/1948
https://github.com/jelmer/dulwich/pull/1949

GUS-W-20241443.