### PR TITLE
Deprecate support for Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Deprecated support for Python 3.10. ([#1972](https://github.com/heroku/heroku-buildpack-python/pull/1972))
 
 ## [v320] - 2025-11-20
 

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -692,12 +692,29 @@ function python_version::warn_if_deprecated_major_version() {
 		output::warning <<-EOF
 			Warning: Support for Python 3.9 is ending soon!
 
-			Python 3.9 will reach its upstream end-of-life in October 2025,
-			at which point it will no longer receive security updates:
+			Python 3.9 reached its upstream end-of-life on 31st October 2025,
+			and so no longer receives security updates:
 			https://devguide.python.org/versions/#supported-versions
 
 			As such, support for Python 3.9 will be removed from this
 			buildpack on 7th January 2026.
+
+			Upgrade to a newer Python version as soon as possible, by
+			changing the version in your ${version_origin} file.
+
+			For more information, see:
+			https://devcenter.heroku.com/articles/python-support#supported-python-versions
+		EOF
+	elif [[ "${requested_major_version}" == "3.10" ]]; then
+		output::warning <<-EOF
+			Warning: Support for Python 3.10 is deprecated!
+
+			Python 3.10 will reach its upstream end-of-life in October 2026,
+			at which point it will no longer receive security updates:
+			https://devguide.python.org/versions/#supported-versions
+
+			As such, support for Python 3.10 will be removed from this
+			buildpack on 6th January 2027.
 
 			Upgrade to a newer Python version as soon as possible, by
 			changing the version in your ${version_origin} file.

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -272,8 +272,8 @@ RSpec.describe 'pip support' do
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!
           remote:  !     
-          remote:  !     Python 3.9 will reach its upstream end-of-life in October 2025,
-          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     Python 3.9 reached its upstream end-of-life on 31st October 2025,
+          remote:  !     and so no longer receives security updates:
           remote:  !     https://devguide.python.org/versions/#supported-versions
           remote:  !     
           remote:  !     As such, support for Python 3.9 will be removed from this

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe 'Pipenv support' do
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!
           remote:  !     
-          remote:  !     Python 3.9 will reach its upstream end-of-life in October 2025,
-          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     Python 3.9 reached its upstream end-of-life on 31st October 2025,
+          remote:  !     and so no longer receives security updates:
           remote:  !     https://devguide.python.org/versions/#supported-versions
           remote:  !     
           remote:  !     As such, support for Python 3.9 will be removed from this

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -260,8 +260,8 @@ RSpec.describe 'Poetry support' do
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!
           remote:  !     
-          remote:  !     Python 3.9 will reach its upstream end-of-life in October 2025,
-          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     Python 3.9 reached its upstream end-of-life on 31st October 2025,
+          remote:  !     and so no longer receives security updates:
           remote:  !     https://devguide.python.org/versions/#supported-versions
           remote:  !     
           remote:  !     As such, support for Python 3.9 will be removed from this

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -262,8 +262,8 @@ RSpec.describe 'Python version support' do
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!
           remote:  !     
-          remote:  !     Python 3.9 will reach its upstream end-of-life in October 2025,
-          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     Python 3.9 reached its upstream end-of-life on 31st October 2025,
+          remote:  !     and so no longer receives security updates:
           remote:  !     https://devguide.python.org/versions/#supported-versions
           remote:  !     
           remote:  !     As such, support for Python 3.9 will be removed from this
@@ -289,7 +289,36 @@ RSpec.describe 'Python version support' do
   context 'when .python-version contains Python 3.10' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/python_3.10') }
 
-    it_behaves_like 'builds with the requested Python version', '3.10', LATEST_PYTHON_3_10
+    it 'builds with Python 3.10 but shows a deprecation warning' do
+      app.deploy do |app|
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Python app detected
+          remote: -----> Using Python 3.10 specified in .python-version
+          remote: 
+          remote:  !     Warning: Support for Python 3.10 is deprecated!
+          remote:  !     
+          remote:  !     Python 3.10 will reach its upstream end-of-life in October 2026,
+          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     https://devguide.python.org/versions/#supported-versions
+          remote:  !     
+          remote:  !     As such, support for Python 3.10 will be removed from this
+          remote:  !     buildpack on 6th January 2027.
+          remote:  !     
+          remote:  !     Upgrade to a newer Python version as soon as possible, by
+          remote:  !     changing the version in your .python-version file.
+          remote:  !     
+          remote:  !     For more information, see:
+          remote:  !     https://devcenter.heroku.com/articles/python-support#supported-python-versions
+          remote: 
+          remote: -----> Installing Python #{LATEST_PYTHON_3_10}
+          remote: -----> Installing pip #{PIP_VERSION}, setuptools #{SETUPTOOLS_VERSION} and wheel #{WHEEL_VERSION}
+          remote: -----> Installing dependencies using 'pip install -r requirements.txt'
+          remote:        Collecting typing-extensions==4.12.2 (from -r requirements.txt (line 2))
+        OUTPUT
+        expect(app.run('python -V')).to eq("Python #{LATEST_PYTHON_3_10}\n")
+        expect($CHILD_STATUS.exitstatus).to eq(0)
+      end
+    end
   end
 
   context 'when .python-version contains Python 3.11' do

--- a/spec/hatchet/uv_spec.rb
+++ b/spec/hatchet/uv_spec.rb
@@ -262,8 +262,8 @@ RSpec.describe 'uv support' do
           remote: 
           remote:  !     Warning: Support for Python 3.9 is ending soon!
           remote:  !     
-          remote:  !     Python 3.9 will reach its upstream end-of-life in October 2025,
-          remote:  !     at which point it will no longer receive security updates:
+          remote:  !     Python 3.9 reached its upstream end-of-life on 31st October 2025,
+          remote:  !     and so no longer receives security updates:
           remote:  !     https://devguide.python.org/versions/#supported-versions
           remote:  !     
           remote:  !     As such, support for Python 3.9 will be removed from this


### PR DESCRIPTION
Since Python 3.10 reaches upstream EOL in October 2026:
https://devguide.python.org/versions/#supported-versions

The Python version support policy is that supported versions follows the upstream EOL lifecycle:
https://devcenter.heroku.com/articles/python-support#python-version-support-policy

To raise awareness of this, a deprecation warning is now shown, similar to that for Python 3.9.

In addition the Python 3.9 warning has been updated to use the past tense to refer to the upstream EOL date, since it's now in the past.

GUS-W-17595557.