### PR TITLE
Add more messaging to the build log recommending uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deprecated support for Python 3.10. ([#1972](https://github.com/heroku/heroku-buildpack-python/pull/1972))
 - Updated uv from 0.9.9 to 0.9.11. ([#1973](https://github.com/heroku/heroku-buildpack-python/pull/1973))
+- Added more messaging to the build log recommending uv. ([#1975](https://github.com/heroku/heroku-buildpack-python/pull/1975))
 - Switched from using `--disable-pip-version-check` to the env var `PIP_DISABLE_PIP_VERSION_CHECK=1` when using pip. ([#1974](https://github.com/heroku/heroku-buildpack-python/pull/1974))
 
 ## [v320] - 2025-11-20

--- a/bin/compile
+++ b/bin/compile
@@ -290,4 +290,18 @@ hooks::run_hook "post_compile"
 
 cache::save "${BUILD_DIR}" "${CACHE_DIR}" "${STACK}" "${python_full_version}" "${package_manager}"
 
+if [[ "${package_manager}" != "uv" ]]; then
+	output::notice <<-EOF
+		Note: We recently added support for the package manager uv:
+		https://devcenter.heroku.com/changelog-items/3238
+
+		It's now our recommended Python package manager, since it
+		supports lockfiles, is faster, gives more helpful error
+		messages, and is actively maintained by a full-time team.
+
+		If you haven't tried it yet, we suggest you take a look!
+		https://docs.astral.sh/uv/
+	EOF
+fi
+
 build_data::set_duration "total_duration" "${compile_start_time}"

--- a/bin/detect
+++ b/bin/detect
@@ -86,6 +86,11 @@ If your app already has a package manager file, check that it:
 Otherwise, add a package manager file to your app. If your app has
 no dependencies, then create an empty 'requirements.txt' file.
 
+If you aren't sure which package manager to use, we recommend
+trying uv, since it supports lockfiles, is extremely fast, and
+is actively maintained by a full-time team:
+https://docs.astral.sh/uv/
+
 For help with using Python on Heroku, see:
 https://devcenter.heroku.com/articles/getting-started-with-python
 https://devcenter.heroku.com/articles/python-support

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -30,8 +30,10 @@ function package_manager::determine_package_manager() {
 			delete your 'Pipfile' and then add either a 'requirements.txt',
 			'poetry.lock' or 'uv.lock' file.
 
-			Note: This error replaces the warning which was displayed in
-			build logs starting 12th November 2024.
+			If you aren't sure which package manager to use, we recommend
+			trying uv, since it supports lockfiles, is extremely fast, and
+			is actively maintained by a full-time team:
+			https://docs.astral.sh/uv/
 		EOF
 		build_data::set_string "failure_reason" "package-manager::pipenv-missing-lockfile"
 		exit 1

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe 'Heroku CI' do
                  PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
                  PYTHONUNBUFFERED=1
           -----> Saving cache
+
+           !     Note: We recently added support for the package manager uv:
+           !     https://devcenter.heroku.com/changelog-items/3238
+           !     
+           !     It's now our recommended Python package manager, since it
+           !     supports lockfiles, is faster, gives more helpful error
+           !     messages, and is actively maintained by a full-time team.
+           !     
+           !     If you haven't tried it yet, we suggest you take a look!
+           !     https://docs.astral.sh/uv/
+
           -----> Inline app detected
           LANG=en_US.UTF-8
           LD_LIBRARY_PATH=/app/.heroku/python/lib
@@ -117,6 +128,17 @@ RSpec.describe 'Heroku CI' do
                  PYTHONUNBUFFERED=1
                  VIRTUAL_ENV=/app/.heroku/python
           -----> Saving cache
+
+           !     Note: We recently added support for the package manager uv:
+           !     https://devcenter.heroku.com/changelog-items/3238
+           !     
+           !     It's now our recommended Python package manager, since it
+           !     supports lockfiles, is faster, gives more helpful error
+           !     messages, and is actively maintained by a full-time team.
+           !     
+           !     If you haven't tried it yet, we suggest you take a look!
+           !     https://docs.astral.sh/uv/
+
           -----> Inline app detected
           LANG=en_US.UTF-8
           LD_LIBRARY_PATH=/app/.heroku/python/lib
@@ -205,6 +227,17 @@ RSpec.describe 'Heroku CI' do
                  POETRY_VIRTUALENVS_USE_POETRY_PYTHON=true
                  PYTHONUNBUFFERED=1
           -----> Saving cache
+
+           !     Note: We recently added support for the package manager uv:
+           !     https://devcenter.heroku.com/changelog-items/3238
+           !     
+           !     It's now our recommended Python package manager, since it
+           !     supports lockfiles, is faster, gives more helpful error
+           !     messages, and is actively maintained by a full-time team.
+           !     
+           !     If you haven't tried it yet, we suggest you take a look!
+           !     https://docs.astral.sh/uv/
+
           -----> Inline app detected
           LANG=en_US.UTF-8
           LD_LIBRARY_PATH=/app/.heroku/python/lib

--- a/spec/hatchet/detect_spec.rb
+++ b/spec/hatchet/detect_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe 'Buildpack detection' do
           remote:  !     Otherwise, add a package manager file to your app. If your app has
           remote:  !     no dependencies, then create an empty 'requirements.txt' file.
           remote:  !     
+          remote:  !     If you aren't sure which package manager to use, we recommend
+          remote:  !     trying uv, since it supports lockfiles, is extremely fast, and
+          remote:  !     is actively maintained by a full-time team:
+          remote:  !     https://docs.astral.sh/uv/
+          remote:  !     
           remote:  !     For help with using Python on Heroku, see:
           remote:  !     https://devcenter.heroku.com/articles/getting-started-with-python
           remote:  !     https://devcenter.heroku.com/articles/python-support

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe 'pip support' do
           remote:        PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           remote:        PYTHONUNBUFFERED=1
           remote: -----> Saving cache
+          remote: 
+          remote:  !     Note: We recently added support for the package manager uv:
+          remote:  !     https://devcenter.heroku.com/changelog-items/3238
+          remote:  !     
+          remote:  !     It's now our recommended Python package manager, since it
+          remote:  !     supports lockfiles, is faster, gives more helpful error
+          remote:  !     messages, and is actively maintained by a full-time team.
+          remote:  !     
+          remote:  !     If you haven't tried it yet, we suggest you take a look!
+          remote:  !     https://docs.astral.sh/uv/
+          remote: 
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
           remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
@@ -96,7 +107,6 @@ RSpec.describe 'pip support' do
           remote: -----> Running bin/post_compile hook
           remote:        .+
           remote: -----> Saving cache
-          remote: -----> Inline app detected
         REGEX
 
         # For historical reasons pip is made available at run-time too, unlike some of the other package managers.
@@ -162,7 +172,7 @@ RSpec.describe 'pip support' do
 
     it 'rewrites .pth, .egg-link and finder paths correctly for hooks, later buildpacks, runtime and cached builds' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running bin/post_compile hook
           remote:        easy-install.pth:/app/.heroku/python/src/gunicorn
           remote:        easy-install.pth:/tmp/build_.+/packages/local_package_setup_py
@@ -174,6 +184,7 @@ RSpec.describe 'pip support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: easy-install.pth:/app/.heroku/python/src/gunicorn
           remote: easy-install.pth:/tmp/build_.+/packages/local_package_setup_py
@@ -202,7 +213,7 @@ RSpec.describe 'pip support' do
         # Test that the cached .pth files work correctly.
         app.commit!
         app.push!
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Running bin/post_compile hook
           remote:        easy-install.pth:/app/.heroku/python/src/gunicorn
           remote:        easy-install.pth:/tmp/build_.+/packages/local_package_setup_py
@@ -214,6 +225,7 @@ RSpec.describe 'pip support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 20.1.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: easy-install.pth:/app/.heroku/python/src/gunicorn
           remote: easy-install.pth:/tmp/build_.+/packages/local_package_setup_py

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe 'Pipenv support' do
           remote:        PYTHONUNBUFFERED=1
           remote:        VIRTUAL_ENV=/app/.heroku/python
           remote: -----> Saving cache
+          remote: 
+          remote:  !     Note: We recently added support for the package manager uv:
+          remote:  !     https://devcenter.heroku.com/changelog-items/3238
+          remote:  !     
+          remote:  !     It's now our recommended Python package manager, since it
+          remote:  !     supports lockfiles, is faster, gives more helpful error
+          remote:  !     messages, and is actively maintained by a full-time team.
+          remote:  !     
+          remote:  !     If you haven't tried it yet, we suggest you take a look!
+          remote:  !     https://docs.astral.sh/uv/
+          remote: 
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
           remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
@@ -96,7 +107,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Running bin/post_compile hook
           remote:        .+
           remote: -----> Saving cache
-          remote: -----> Inline app detected
         REGEX
 
         # For historical reasons Pipenv is made available at run-time too, unlike some of the other package managers.
@@ -141,7 +151,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing dependencies using 'pipenv install --deploy'
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
-          remote: -----> Discovering process types
         REGEX
       end
     end
@@ -303,8 +312,10 @@ RSpec.describe 'Pipenv support' do
           remote:  !     delete your 'Pipfile' and then add either a 'requirements.txt',
           remote:  !     'poetry.lock' or 'uv.lock' file.
           remote:  !     
-          remote:  !     Note: This error replaces the warning which was displayed in
-          remote:  !     build logs starting 12th November 2024.
+          remote:  !     If you aren't sure which package manager to use, we recommend
+          remote:  !     trying uv, since it supports lockfiles, is extremely fast, and
+          remote:  !     is actively maintained by a full-time team:
+          remote:  !     https://docs.astral.sh/uv/
           remote: 
           remote:  !     Push rejected, failed to compile Python app.
         REGEX
@@ -465,7 +476,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing dependencies using 'pipenv install --deploy'
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
-          remote: -----> Discovering process types
         REGEX
       end
     end
@@ -477,7 +487,7 @@ RSpec.describe 'Pipenv support' do
 
     it 'rewrites .pth and finder paths correctly for hooks, later buildpacks, runtime and cached builds' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'pipenv install --deploy'
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
@@ -491,6 +501,7 @@ RSpec.describe 'Pipenv support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 23.0.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
@@ -519,7 +530,7 @@ RSpec.describe 'Pipenv support' do
         # Test that the cached .pth files work correctly.
         app.commit!
         app.push!
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'pipenv install --deploy'
           remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
@@ -533,6 +544,7 @@ RSpec.describe 'Pipenv support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 23.0.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe 'Poetry support' do
           remote:        POETRY_VIRTUALENVS_USE_POETRY_PYTHON=true
           remote:        PYTHONUNBUFFERED=1
           remote: -----> Saving cache
+          remote: 
+          remote:  !     Note: We recently added support for the package manager uv:
+          remote:  !     https://devcenter.heroku.com/changelog-items/3238
+          remote:  !     
+          remote:  !     It's now our recommended Python package manager, since it
+          remote:  !     supports lockfiles, is faster, gives more helpful error
+          remote:  !     messages, and is actively maintained by a full-time team.
+          remote:  !     
+          remote:  !     If you haven't tried it yet, we suggest you take a look!
+          remote:  !     https://docs.astral.sh/uv/
+          remote: 
           remote: -----> Inline app detected
           remote: LANG=en_US.UTF-8
           remote: LD_LIBRARY_PATH=/app/.heroku/python/lib
@@ -98,7 +109,6 @@ RSpec.describe 'Poetry support' do
           remote: -----> Running bin/post_compile hook
           remote:        .+
           remote: -----> Saving cache
-          remote: -----> Inline app detected
         REGEX
 
         command = 'bin/print-env-vars.sh && if command -v poetry; then echo "Poetry unexpectedly found!" && exit 1; fi'
@@ -145,7 +155,6 @@ RSpec.describe 'Poetry support' do
           remote:        
           remote:          - Installing typing-extensions (4.12.2)
           remote: -----> Saving cache
-          remote: -----> Discovering process types
         OUTPUT
       end
     end
@@ -157,7 +166,7 @@ RSpec.describe 'Poetry support' do
 
     it 'rewrites .pth and finder paths correctly for hooks, later buildpacks, runtime and cached builds' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'poetry sync --only main'
           remote:        Installing dependencies from lock file
           remote:        
@@ -180,6 +189,7 @@ RSpec.describe 'Poetry support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 23.0.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
@@ -208,7 +218,7 @@ RSpec.describe 'Poetry support' do
         # Test that the cached .pth files work correctly.
         app.commit!
         app.push!
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'poetry sync --only main'
           remote:        Installing dependencies from lock file
           remote:        
@@ -230,6 +240,7 @@ RSpec.describe 'Poetry support' do
           remote:        Running entrypoint for the setup.py-based local package: Hello from setup.py!
           remote:        Running entrypoint for the VCS package: gunicorn \\(version 23.0.0\\)
           remote: -----> Saving cache
+          .+
           remote: -----> Inline app detected
           remote: __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote: __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}


### PR DESCRIPTION
The package manager [uv](https://docs.astral.sh/uv/) offers many benefits for users over the alternatives, such as it:
- Supporting lockfiles (unlike pip)
- Being much faster
- Giving more helpful error messages
- Being actively maintained by a full time team

As such we want to encourage users who may not have heard of it (or be aware that the buildpack now supports it) to try it out - and so now mention uv at the env of the build log for successful builds.

GUS-W-19124925.
