### PR TITLE
Sunset implicit setup.py support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Sunset the previously deprecated support for falling back to installing dependencies from a `setup.py` file if no Python package manager files were found. ([#1992](https://github.com/heroku/heroku-buildpack-python/pull/1992))
 
 ## [v324] - 2025-12-09
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -74,9 +74,8 @@ function cache::restore() {
 				# installed Python packages. For example, if a package entry in a requirements file is
 				# later removed, pip will not uninstall the package. This check can be removed if we
 				# ever switch to only caching pip's HTTP/wheel cache rather than site-packages.
-				# TODO: Remove the `-f` check once the setup.py fallback feature is removed.
 				# TODO: Switch this to using sha256sum like the Pipenv implementation.
-				if [[ -f "${build_dir}/requirements.txt" ]] && ! cmp --silent "${cache_dir}/.heroku/requirements.txt" "${build_dir}/requirements.txt"; then
+				if ! cmp --silent "${cache_dir}/.heroku/requirements.txt" "${build_dir}/requirements.txt"; then
 					cache_invalidation_reasons+=("The contents of requirements.txt changed")
 				fi
 				;;
@@ -202,9 +201,7 @@ function cache::save() {
 	# We continue to use that format so that the file can be read by older buildpack versions.
 	echo "python-${python_full_version}" >"${cache_dir}/.heroku/python-version"
 
-	# TODO: Simplify this once multiple package manager files being found is turned into an
-	# error and the setup.py fallback feature is removed.
-	if [[ "${package_manager}" == "pip" && -f "${build_dir}/requirements.txt" ]]; then
+	if [[ "${package_manager}" == "pip" ]]; then
 		# TODO: Switch this to using sha256sum like the Pipenv implementation.
 		cp "${build_dir}/requirements.txt" "${cache_dir}/.heroku/"
 	elif [[ "${package_manager}" == "pipenv" ]]; then

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -107,14 +107,8 @@ function pip::install_dependencies() {
 	local pip_install_command=(
 		pip
 		install
+		-r requirements.txt
 	)
-
-	# Support for the setup.py fallback is deprecated and will be removed in the future.
-	if [[ -f setup.py && ! -f requirements.txt ]]; then
-		pip_install_command+=(--editable .)
-	else
-		pip_install_command+=(-r requirements.txt)
-	fi
 
 	# Install test dependencies too when the buildpack is invoked via `bin/test-compile` on Heroku CI.
 	# We install both requirements files at the same time to allow pip to resolve version conflicts.

--- a/spec/fixtures/multiple_package_managers/setup.py
+++ b/spec/fixtures/multiple_package_managers/setup.py
@@ -1,0 +1,1 @@
+# This file tests that the setup.py sunset error is not shown when other package manager files exist.

--- a/spec/fixtures/pip_basic/setup.py
+++ b/spec/fixtures/pip_basic/setup.py
@@ -1,2 +1,1 @@
-# This tests that the setup.py fallback is not used when other package manager files exist.
-raise RuntimeError("setup.py should not be run!")
+# This file tests that the setup.py sunset error is not shown when other package manager files exist.

--- a/spec/fixtures/pipenv_basic/setup.py
+++ b/spec/fixtures/pipenv_basic/setup.py
@@ -1,2 +1,0 @@
-# This tests that the setup.py fallback is not used when other package manager files exist.
-raise RuntimeError("setup.py should not be run!")

--- a/spec/fixtures/poetry_basic/setup.py
+++ b/spec/fixtures/poetry_basic/setup.py
@@ -1,2 +1,0 @@
-# This tests that the setup.py fallback is not used when other package manager files exist.
-raise RuntimeError("setup.py should not be run!")

--- a/spec/fixtures/setup_py_only/setup.py
+++ b/spec/fixtures/setup_py_only/setup.py
@@ -1,6 +1,0 @@
-from setuptools import setup
-
-setup(
-  name='test',
-  install_requires=['six'],
-)

--- a/spec/hatchet/package_manager_spec.rb
+++ b/spec/hatchet/package_manager_spec.rb
@@ -49,46 +49,40 @@ RSpec.describe 'Package manager support' do
     end
   end
 
-  # This case will be turned into an error in the future.
   context 'when there is only a setup.py' do
-    let(:app) { Hatchet::Runner.new('spec/fixtures/setup_py_only') }
+    let(:app) { Hatchet::Runner.new('spec/fixtures/setup_py_only', allow_failure: true) }
 
-    it 'installs packages from setup.py using pip' do
+    it 'fails the build with an informative error message' do
       app.deploy do |app|
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> Python app detected
           remote: 
-          remote:  !     Warning: Implicit setup.py file support is deprecated.
+          remote:  !     Error: Implicit setup.py file support has been sunset.
           remote:  !     
           remote:  !     Your app currently only has a setup.py file and no Python
-          remote:  !     package manager files. This means that the buildpack has
-          remote:  !     to guess which package manager you want to use and also
-          remote:  !     whether to install your project in editable mode or not.
+          remote:  !     package manager files. This means that the buildpack can't
+          remote:  !     tell which package manager you want to use, and whether to
+          remote:  !     install your project in editable mode or not.
           remote:  !     
-          remote:  !     For now, we will use pip to install your dependencies in
-          remote:  !     editable mode, however, this fallback is deprecated and
-          remote:  !     will be removed in the future.
+          remote:  !     Previously the buildpack guessed and used pip to install your
+          remote:  !     dependencies in editable mode. However, this fallback was
+          remote:  !     deprecated in September 2025 and has now been sunset.
           remote:  !     
-          remote:  !     Please add an explicit package manager file to your app.
+          remote:  !     You must now add an explicit package manager file to your app,
+          remote:  !     such as a requirements.txt, poetry.lock or uv.lock file.
           remote:  !     
-          remote:  !     To continue using pip in editable mode, create a new file
-          remote:  !     in the root directory of your app named 'requirements.txt'
-          remote:  !     containing the requirement '--editable .' \\(without quotes\\).
+          remote:  !     To continue using your setup.py file with pip in editable
+          remote:  !     mode, create a new file in the root directory of your app
+          remote:  !     named 'requirements.txt' containing the requirement
+          remote:  !     '--editable .' (without quotes).
           remote:  !     
           remote:  !     Alternatively, if you wish to switch to another package
-          remote:  !     manager, we highly recommend uv:
+          remote:  !     manager, we recommend uv, since it supports lockfiles, is
+          remote:  !     faster, and is actively maintained by a full-time team:
           remote:  !     https://docs.astral.sh/uv/
           remote: 
-          remote: -----> Using Python #{DEFAULT_PYTHON_MAJOR_VERSION} specified in .python-version
-          remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
-          remote: -----> Installing pip #{PIP_VERSION}
-          remote: -----> Installing dependencies using 'pip install --editable .'
-          remote:        Obtaining file:///tmp/build_.*
-          remote:        .+
-          remote:        Installing collected packages: six, test
-          remote:        Successfully installed six-.+ test-0.0.0
-          remote: -----> Saving cache
-        REGEX
+          remote:  !     Push rejected, failed to compile Python app.
+        OUTPUT
       end
     end
   end

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe 'Pipenv support' do
   context 'without a Pipfile.lock' do
     let(:app) { Hatchet::Runner.new('spec/fixtures/pipenv_no_lockfile', allow_failure: true) }
 
-    it 'builds with the default Python version using just the Pipfile' do
+    it 'fails the build with an informative error message' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Python app detected


### PR DESCRIPTION
Previously if an app had only a `setup.py` file and no Python package manager files (such as `requirements.txt`, `Pipfile.lock`, `Poetry.lock` or `uv.lock`), the buildpack would install the project using `pip install --editable .`

However, this implicit fallback doesn't make sense now that the buildpack supports multiple package managers, and so has to guess which package manager to use, and whether to install the project in editable mode or not.

As such, in #1897 this fallback was deprecated, and is now being sunset. This also brings the classic Python buildpack's behaviour in line with the Python CNB.

Apps that only have a `setup.py` file will now need to add an explicit `requirements.txt` file containing:

```
--editable .
```

That said, in general we recommend people don't use `setup.py` to declare their dependencies, since:
- the file is deprecated in favour of `pyproject.toml`
- it's intended more for libraries rather than applications, and it's much less common (and practical) to list all transitive dependencies in a `setup.py`, meaning apps using the file typically have unpinned dependencies, which is a production reliability risk. (Apps should either be using a package manager that supports lockfiles, or else using one of the pip requirements files substitutes for lockfiles, like pip-tools or `pip freeze` etc.)

GUS-W-19275444.
