### PR TITLE
Unpin GDAL version in tests

### DIFF
--- a/spec/fixtures/pip_gdal/requirements.txt
+++ b/spec/fixtures/pip_gdal/requirements.txt
@@ -1,2 +1,1 @@
-# Pinned due to https://github.com/OSGeo/gdal/issues/13329
-GDAL==3.11.4
+GDAL


### PR DESCRIPTION
Since the issue that required it be pinned (in #1954) has since been fixed upstream in:
https://github.com/OSGeo/gdal/commit/4dcd9099b4fc39ddce1ba9f214f72d661b6a8fb7

GUS-W-20582833.