### PR TITLE
Adjust the error message shown for missing SQLite headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Adjusted the error message shown if SQLite headers aren't found during package installation. ([#2006](https://github.com/heroku/heroku-buildpack-python/pull/2006))
 
 ## [v326] - 2026-01-05
 

--- a/bin/warnings
+++ b/bin/warnings
@@ -29,16 +29,9 @@ show-warnings() {
 			2. Replace any `pysqlite3` imports in your app with `sqlite3`.
 
 			Alternatively, if you can't use the `sqlite3` stdlib module,
-			switch from the `pysqlite3` package to `pysqlite3-binary`,
-			which is pre-compiled and doesn't need the SQLite headers to
-			be installed.
-
-			If instead you need the SQLite headers for another reason
-			(or wish to continue to compile the `pysqlite3` package from
-			source), then install the `libsqlite3-dev` and `libsqlite3-0`
-			packages using the APT buildpack (make sure the APT buildpack
-			runs before the Python buildpack, not after):
-			https://github.com/heroku/heroku-buildpack-apt
+			update your `pysqlite3` package to 0.6.0 or newer, since the
+			newer versions are published with pre-compiled wheels and so
+			don't need the SQLite headers to be installed.
 		EOF
 		build_data::set_string "failure_detail" "sqlite3.h: No such file or directory"
 	elif grep -qi 'Please use pip<24.1 if you need to use this version' "${install_log}"; then

--- a/spec/fixtures/pip_pysqlite3/requirements.txt
+++ b/spec/fixtures/pip_pysqlite3/requirements.txt
@@ -1,1 +1,3 @@
-pysqlite3
+# We have to use an older version to test the custom SQLite headers error message,
+# since pysqlite3 0.6.0+ ships with precompiled wheels and so doesn't error.
+pysqlite3==0.5.4

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -449,16 +449,9 @@ RSpec.describe 'pip support' do
           remote:  !     2. Replace any `pysqlite3` imports in your app with `sqlite3`.
           remote:  !     
           remote:  !     Alternatively, if you can't use the `sqlite3` stdlib module,
-          remote:  !     switch from the `pysqlite3` package to `pysqlite3-binary`,
-          remote:  !     which is pre-compiled and doesn't need the SQLite headers to
-          remote:  !     be installed.
-          remote:  !     
-          remote:  !     If instead you need the SQLite headers for another reason
-          remote:  !     (or wish to continue to compile the `pysqlite3` package from
-          remote:  !     source), then install the `libsqlite3-dev` and `libsqlite3-0`
-          remote:  !     packages using the APT buildpack (make sure the APT buildpack
-          remote:  !     runs before the Python buildpack, not after):
-          remote:  !     https://github.com/heroku/heroku-buildpack-apt
+          remote:  !     update your `pysqlite3` package to 0.6.0 or newer, since the
+          remote:  !     newer versions are published with pre-compiled wheels and so
+          remote:  !     don't need the SQLite headers to be installed.
           remote: 
           remote: 
           remote:  !     Error: Unable to install dependencies using pip.


### PR DESCRIPTION
Since `pysqlite3` 0.6.0 was [just released](https://pypi.org/project/pysqlite3/0.6.0/#history), that now ships with precompiled wheels, which means:

1. Our test for the error handling [started failing](https://github.com/heroku/heroku-buildpack-python/actions/runs/20731066897/job/59518854569?pr=2005#step:5:429), since the package now works out of the box rather than erroring.
2. Our advice for which package to use has now changed, since users now only need to update to a newer version of `pysqlite3` rather than switch to the `pysqlite3-binary` package.

GUS-W-20804528.
