### PR TITLE
Re-apply Pipenv `--system` bug workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Re-apply a workaround for a Pipenv bug when using `--system`, that causes packages to not be installed correctly if they are also a dependency of Pipenv (such as `certifi` or `packaging`). ([#2011](https://github.com/heroku/heroku-buildpack-python/pull/2011))
 
 ## [v329] - 2026-01-08
 
@@ -197,7 +198,7 @@
 
 ## [v293] - 2025-07-23
 
-- Work around a Pipenv bug when using `--system`, that causes packages to not be installed correctly if they are also a dependency of Pipenv (such as `certifi` ). ([#1842](https://github.com/heroku/heroku-buildpack-python/pull/1842))
+- Work around a Pipenv bug when using `--system`, that causes packages to not be installed correctly if they are also a dependency of Pipenv (such as `certifi`). ([#1842](https://github.com/heroku/heroku-buildpack-python/pull/1842))
 
 ## [v292] - 2025-07-23
 

--- a/lib/pipenv.sh
+++ b/lib/pipenv.sh
@@ -81,17 +81,31 @@ function pipenv::install_pipenv() {
 	export PATH="${pipenv_bin_dir}:${PATH}"
 	# Force Pipenv to manage the system Python site-packages instead of using venvs.
 	export PIPENV_SYSTEM="1"
+	# Hide Pipenv's notice about finding/using an existing virtual environment.
+	export PIPENV_VERBOSITY="-1"
+	# Work around a Pipenv bug when using `--system`, whereby it doesn't correctly install dependencies
+	# that happen to also be a dependency of Pipenv (such as `certifi` and `packaging`). In general
+	# Pipenv's support for its `--system` mode is very buggy. Longer term we should explore moving
+	# to venvs, however, that will need to be coordinated across all package managers and will also
+	# change paths for Python which could break other use cases. Be careful removing this even if the
+	# `pip_basic` test that installs certifi/packaging still passes, since the repro seems to depend
+	# on specific package version combinations / other factors and so the testcase is very fragile.
+	export VIRTUAL_ENV="${python_home}"
 
 	# Set the same env vars in the environment used by later buildpacks.
 	cat >>"${export_file}" <<-EOF
 		export PATH="${pipenv_bin_dir}:\${PATH}"
 		export PIPENV_SYSTEM="1"
+		export PIPENV_VERBOSITY="-1"
+		export VIRTUAL_ENV="${python_home}"
 	EOF
 
 	# And the environment used at app run-time.
 	cat >>"${profile_d_file}" <<-EOF
 		export PATH="${pipenv_bin_dir}:\${PATH}"
 		export PIPENV_SYSTEM="1"
+		export PIPENV_VERBOSITY="-1"
+		export VIRTUAL_ENV="${python_home}"
 	EOF
 }
 

--- a/spec/fixtures/pipenv_basic/Pipfile
+++ b/spec/fixtures/pipenv_basic/Pipfile
@@ -4,8 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-certifi = "*"
 typing-extensions = "*"
+# Test that dependencies that happen to also be vendored dependencies of Pipenv are correctly installed,
+# since Pipenv's --system mode is buggy and requires a workaround to ensure they aren't skipped.
+certifi = "*"
+packaging = "*"
 
 [dev-packages]
 

--- a/spec/fixtures/pipenv_basic/Pipfile.lock
+++ b/spec/fixtures/pipenv_basic/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f362a119150f17832636f824f9f334a4d5580c6713519ed0865b89c4cc4e845"
+            "sha256": "0ef98f1284f466d096b821c028367648e5141cc11150e42daa0b60172cbe5f43"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,12 +18,21 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b",
-                "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"
+                "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c",
+                "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2025.11.12"
+            "version": "==2026.1.4"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==25.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/spec/fixtures/pipenv_basic/bin/compile
+++ b/spec/fixtures/pipenv_basic/bin/compile
@@ -23,6 +23,10 @@ pip list --disable-pip-version-check --exclude pip
 echo
 
 python -c 'import typing_extensions; print(typing_extensions)'
+# Test that dependencies that happen to also be vendored dependencies of Pipenv are correctly installed,
+# since Pipenv's --system mode is buggy and requires a workaround to ensure they aren't skipped.
+python -c 'import certifi; print(certifi)'
+python -c 'import packaging; print(packaging)'
 echo
 
 jq --sort-keys '.' "${CACHE_DIR}/build-data/python.json"

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -105,8 +105,6 @@ RSpec.describe 'Heroku CI' do
           -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
           -----> Installing Pipenv #{PIPENV_VERSION}
           -----> Installing dependencies using 'pipenv install --deploy --dev'
-                 Installing dependencies from Pipfile.lock \\(.+\\)...
-                 Installing dependencies from Pipfile.lock \\(.+\\)...
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running bin/post_compile hook
                  BUILD_DIR=/app
@@ -123,8 +121,10 @@ RSpec.describe 'Heroku CI' do
                  LIBRARY_PATH=/app/.heroku/python/lib
                  PATH=/app/.heroku/python/pipenv/bin:/app/.heroku/python/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
                  PIPENV_SYSTEM=1
+                 PIPENV_VERBOSITY=-1
                  PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
                  PYTHONUNBUFFERED=1
+                 VIRTUAL_ENV=/app/.heroku/python
           -----> Saving cache
 
            !     Note: We recently added support for the package manager uv:
@@ -143,9 +143,11 @@ RSpec.describe 'Heroku CI' do
           LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/app/.heroku/python/pipenv/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/
           PIPENV_SYSTEM=1
+          PIPENV_VERBOSITY=-1
           PYTHONHOME=/app/.heroku/python
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
+          VIRTUAL_ENV=/app/.heroku/python
           -----> No test-setup command provided. Skipping.
           -----> Running test command `./bin/print-env-vars.sh && pytest --version`...
           CI=true
@@ -157,9 +159,11 @@ RSpec.describe 'Heroku CI' do
           LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/app/.heroku/python/pipenv/bin:/usr/local/bin:/usr/bin:/bin:/app/.sprettur/bin/:/app/.sprettur/bin/
           PIPENV_SYSTEM=1
+          PIPENV_VERBOSITY=-1
           PYTHONHOME=/app/.heroku/python
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
+          VIRTUAL_ENV=/app/.heroku/python
           WEB_CONCURRENCY=5
           pytest .+
           -----> test command `./bin/print-env-vars.sh && pytest --version` completed successfully
@@ -173,8 +177,6 @@ RSpec.describe 'Heroku CI' do
           -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
           -----> Using cached Pipenv #{PIPENV_VERSION}
           -----> Installing dependencies using 'pipenv install --deploy --dev'
-                 Installing dependencies from Pipfile.lock \\(.+\\)...
-                 Installing dependencies from Pipfile.lock \\(.+\\)...
           -----> Skipping Django collectstatic since the env var DISABLE_COLLECTSTATIC is set.
           -----> Running bin/post_compile hook
         REGEX

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
           remote:        BUILD_DIR=/tmp/build_.+
           remote:        CACHE_DIR=/tmp/codon/tmp/cache
@@ -27,8 +26,10 @@ RSpec.describe 'Pipenv support' do
           remote:        LIBRARY_PATH=/app/.heroku/python/lib
           remote:        PATH=/app/.heroku/python/pipenv/bin:/app/.heroku/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote:        PIPENV_SYSTEM=1
+          remote:        PIPENV_VERBOSITY=-1
           remote:        PKG_CONFIG_PATH=/app/.heroku/python/lib/pkg-config
           remote:        PYTHONUNBUFFERED=1
+          remote:        VIRTUAL_ENV=/app/.heroku/python
           remote: -----> Saving cache
           remote: 
           remote:  !     Note: We recently added support for the package manager uv:
@@ -47,9 +48,11 @@ RSpec.describe 'Pipenv support' do
           remote: LIBRARY_PATH=/app/.heroku/python/lib
           remote: PATH=/app/.heroku/python/bin:/app/.heroku/python/pipenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           remote: PIPENV_SYSTEM=1
+          remote: PIPENV_VERBOSITY=-1
           remote: PYTHONHOME=/app/.heroku/python
           remote: PYTHONPATH=/app
           remote: PYTHONUNBUFFERED=true
+          remote: VIRTUAL_ENV=/app/.heroku/python
           remote: 
           remote: \\['',
           remote:  '/app',
@@ -61,10 +64,13 @@ RSpec.describe 'Pipenv support' do
           remote: pipenv, version #{PIPENV_VERSION}
           remote: Package           Version
           remote: ----------------- -+
-          remote: certifi           2025.11.12
+          remote: certifi           2026.1.4
+          remote: packaging         25.0
           remote: typing_extensions 4.15.0
           remote: 
           remote: <module 'typing_extensions' from '/app/.heroku/python/lib/python3.14/site-packages/typing_extensions.py'>
+          remote: <module 'certifi' from '/app/.heroku/python/lib/python3.14/site-packages/certifi/__init__.py'>
+          remote: <module 'packaging' from '/app/.heroku/python/lib/python3.14/site-packages/packaging/__init__.py'>
           remote: 
           remote: \\{
           remote:   "cache_restore_duration": [0-9.]+,
@@ -99,7 +105,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Using cached install of Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Using cached Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
           remote:        .+
           remote: -----> Saving cache
@@ -115,9 +120,11 @@ RSpec.describe 'Pipenv support' do
           LIBRARY_PATH=/app/.heroku/python/lib
           PATH=/app/.heroku/python/bin:/app/.heroku/python/pipenv/bin:/usr/local/bin:/usr/bin:/bin
           PIPENV_SYSTEM=1
+          PIPENV_VERBOSITY=-1
           PYTHONHOME=/app/.heroku/python
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
+          VIRTUAL_ENV=/app/.heroku/python
           WEB_CONCURRENCY=2
           pipenv, version #{PIPENV_VERSION}
         OUTPUT
@@ -143,7 +150,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
         REGEX
       end
@@ -198,7 +204,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python 3.10.0
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
         REGEX
       end
@@ -216,7 +221,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python #{LATEST_PYTHON_3_13}
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
         REGEX
       end
@@ -275,7 +279,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python #{DEFAULT_PYTHON_FULL_VERSION}
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
         REGEX
       end
@@ -468,7 +471,6 @@ RSpec.describe 'Pipenv support' do
           remote: -----> Installing Python #{LATEST_PYTHON_3_14}
           remote: -----> Installing Pipenv #{PIPENV_VERSION}
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Saving cache
         REGEX
       end
@@ -483,7 +485,6 @@ RSpec.describe 'Pipenv support' do
       app.deploy do |app|
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
           remote:        __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote:        __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}
@@ -526,7 +527,6 @@ RSpec.describe 'Pipenv support' do
         app.push!
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> Installing dependencies using 'pipenv install --deploy'
-          remote:        Installing dependencies from Pipfile.lock \\(.+\\)...
           remote: -----> Running bin/post_compile hook
           remote:        __editable___gunicorn_23_0_0_finder.py:/app/.heroku/python/src/gunicorn/gunicorn'}
           remote:        __editable___local_package_pyproject_toml_0_0_1_finder.py:/tmp/build_.+/packages/local_package_pyproject_toml/local_package_pyproject_toml'}


### PR DESCRIPTION
In #2000, Pipenv was updated to v2026.0.3, which contained a number of fixes for the historically very buggy `--system` mode.

Since that Pipenv release was meant to fix many of the `--system` bugs, one of the workarounds for those bugs was removed, since even without the workaround the regression test for that bug still passed (implying the upstream fixes had worked as expected).

However, it appears that the bug still exists in some form that was not being picked up by the original testcase, as reported in:
https://github.com/heroku/heroku-buildpack-python/pull/2000#discussion_r2672712400

As such, I've had to re-add the workaround. This also affects the logs, since in the new Pipenv version, if `PIPENV_VERBOSITY="-1"` is set (which is required to stop an annoying multi-line warning about a venv being present), then the `Installing dependencies from ...` line is no longer printed.

It seems the bug now only reproduces with different versions of the `certifi` package, so I've updated the test fixture accordingly. (My first thought was that perhaps the difference is whether our testcase's `certifi` matches the Pipenv vendored version exactly or not, however, varying to another older version also didn't reproduce?).

I've also added `packaging` as another testcase dependency, in the hope that in the future at least one of these packages will be able to reproduce the issue, should we try and remove the workaround again.

Longer term, these continual Pipenv bugs are making me inclined to deprecate/strongly discourage Pipenv usage, given there are now much more reliable/better maintained/faster alternatives (such as [uv](https://docs.astral.sh/uv/)) that don't suffer from these chronic bugs.

GUS-W-20819376.
