### PR TITLE
Set `WEB_CONCURRENCY_SET_BY` if appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- The web server concurrency calculation profile script now sets the env var `WEB_CONCURRENCY_SET_BY="heroku/python"` if `WEB_CONCURRENCY` was set automatically by the buildpack. ([#2015](https://github.com/heroku/heroku-buildpack-python/pull/2015))
 
 ## [v331] - 2026-01-11
 

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe 'Heroku CI' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=5
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pytest .+
           -----> test command `./bin/print-env-vars.sh && pytest --version` completed successfully
         REGEX
@@ -165,6 +166,7 @@ RSpec.describe 'Heroku CI' do
           PYTHONUNBUFFERED=true
           VIRTUAL_ENV=/app/.heroku/python
           WEB_CONCURRENCY=5
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pytest .+
           -----> test command `./bin/print-env-vars.sh && pytest --version` completed successfully
         REGEX
@@ -258,6 +260,7 @@ RSpec.describe 'Heroku CI' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=5
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pytest .+
           -----> test command `./bin/print-env-vars.sh && pytest --version` completed successfully
         REGEX
@@ -345,6 +348,7 @@ RSpec.describe 'Heroku CI' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=5
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pytest .+
           -----> test command `./bin/print-env-vars.sh && pytest --version` completed successfully
         REGEX

--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe 'pip support' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=2
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pip #{PIP_VERSION} from /app/.heroku/python/lib/python3.14/site-packages/pip (python 3.14)
         OUTPUT
         expect($CHILD_STATUS.exitstatus).to eq(0)

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe 'Pipenv support' do
           PYTHONUNBUFFERED=true
           VIRTUAL_ENV=/app/.heroku/python
           WEB_CONCURRENCY=2
+          WEB_CONCURRENCY_SET_BY=heroku/python
           pipenv, version #{PIPENV_VERSION}
         OUTPUT
         expect($CHILD_STATUS.exitstatus).to eq(0)

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe 'Poetry support' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=2
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
         expect($CHILD_STATUS.exitstatus).to eq(0)
       end

--- a/spec/hatchet/profile_d_scripts_spec.rb
+++ b/spec/hatchet/profile_d_scripts_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe '.profile.d/ scripts' do
         OUTPUT
       end
 
-      list_concurrency_envs_cmd = 'printenv | sort | grep -E "^(DYNO_RAM|WEB_CONCURRENCY)="'
+      list_concurrency_envs_cmd = 'printenv | sort | grep -E "^(DYNO_RAM|WEB_CONCURRENCY.*)="'
 
       # Check WEB_CONCURRENCY support when using a Standard-1X dyno.
       # We set the process type to `web` so that we can test the web-dyno-only log output.
@@ -53,6 +53,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 2 based on the available memory.
           DYNO_RAM=512
           WEB_CONCURRENCY=2
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -63,6 +64,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 4 based on the available memory.
           DYNO_RAM=1024
           WEB_CONCURRENCY=4
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -73,6 +75,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 5 based on the number of CPU cores.
           DYNO_RAM=2560
           WEB_CONCURRENCY=5
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -83,6 +86,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 17 based on the number of CPU cores.
           DYNO_RAM=14336
           WEB_CONCURRENCY=17
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -93,6 +97,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 9 based on the number of CPU cores.
           DYNO_RAM=30720
           WEB_CONCURRENCY=9
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -103,6 +108,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 17 based on the number of CPU cores.
           DYNO_RAM=63488
           WEB_CONCURRENCY=17
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 
@@ -113,6 +119,7 @@ RSpec.describe '.profile.d/ scripts' do
           Python buildpack: Defaulting WEB_CONCURRENCY to 33 based on the number of CPU cores.
           DYNO_RAM=129024
           WEB_CONCURRENCY=33
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
       end
 

--- a/spec/hatchet/uv_spec.rb
+++ b/spec/hatchet/uv_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe 'uv support' do
           PYTHONPATH=/app
           PYTHONUNBUFFERED=true
           WEB_CONCURRENCY=2
+          WEB_CONCURRENCY_SET_BY=heroku/python
         OUTPUT
         expect($CHILD_STATUS.exitstatus).to eq(0)
       end

--- a/vendor/WEB_CONCURRENCY.sh
+++ b/vendor/WEB_CONCURRENCY.sh
@@ -75,6 +75,9 @@ if [[ -v WEB_CONCURRENCY ]]; then
 	return 0
 fi
 
+# Make it possible to differentiate between user and buildpack set WEB_CONCURRENCY values.
+export WEB_CONCURRENCY_SET_BY="heroku/python"
+
 minimum_memory_per_process_in_mb=256
 
 # Prevents WEB_CONCURRENCY being set to zero if the environment is extremely memory constrained.


### PR DESCRIPTION
The Python buildpack sets the `WEB_CONCURRENCY` env var at app boot based on the current dyno size, so long as the user hasn't specified a custom value via the app's config vars.

Now, in addition to setting the `WEB_CONCURRENCY` env var, the buildpack will also set `WEB_CONCURRENCY_SET_BY=heroku/python` to allow the app, other boot time scripts, or humans more easily differentiate between user and buildpack provided `WEB_CONCURRENCY` values (plus determine which buildpack actually set it).

In addition to assisting with debugging, this allows for UX improvements in other buildpacks such as the PHP buildpack, which can now check for `WEB_CONCURRENCY_SET_BY` in its boot time Apache/Nginx `heroku-php-...` scripts - helping detect the case where users have ordered the buildpacks on their app in the wrong order. (The "primary" language is supposed to be listed last, otherwise the wrong concurrency value will be used.)

See also:

- https://github.com/heroku/heroku-buildpack-php/pull/883
- https://github.com/heroku/heroku-buildpack-nodejs/pull/932
- https://github.com/heroku/heroku-buildpack-ruby/pull/1700

GUS-W-20866598.