### PR TITLE
Switch to AWS' dual-stack S3 URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed the S3 URL used to download Python to use AWS' dual-stack (IPv6 compatible) endpoint. ([#2035](https://github.com/heroku/heroku-buildpack-python/pull/2035))
 
 ## [v335] - 2026-02-10
 

--- a/lib/python.sh
+++ b/lib/python.sh
@@ -4,7 +4,7 @@
 # however, it helps Shellcheck realise the options under which these functions will run.
 set -euo pipefail
 
-S3_BASE_URL="https://heroku-buildpack-python.s3.us-east-1.amazonaws.com"
+S3_BASE_URL="https://heroku-buildpack-python.s3.dualstack.us-east-1.amazonaws.com"
 
 function python::install() {
 	local build_dir="${1}"
@@ -28,7 +28,7 @@ function python::install() {
 		local ubuntu_version="${stack/heroku-/}.04"
 		local arch
 		arch=$(dpkg --print-architecture)
-		# e.g.: https://heroku-buildpack-python.s3.us-east-1.amazonaws.com/python-3.13.0-ubuntu-24.04-amd64.tar.zst
+		# e.g.: https://heroku-buildpack-python.s3.dualstack.us-east-1.amazonaws.com/python-3.14.0-ubuntu-24.04-amd64.tar.zst
 		local python_url="${S3_BASE_URL}/python-${python_full_version}-ubuntu-${ubuntu_version}-${arch}.tar.zst"
 
 		local error_log
@@ -117,7 +117,7 @@ function python::install() {
 					Then try building again to see if the error resolves itself.
 				EOF
 				build_data::set_string "failure_reason" "install-python"
-				# e.g.: 'curl: (6) Could not resolve host: heroku-buildpack-python.s3.us-east-1.amazonaws.com'
+				# e.g.: 'curl: (6) Could not resolve host: heroku-buildpack-python.s3.dualstack.us-east-1.amazonaws.com'
 				build_data::set_string "failure_detail" "$(head --lines=1 "${error_log}" || true)"
 			fi
 


### PR DESCRIPTION
The default AWS S3 URLs only support IPv4, whereas the dual-stack URLs support both IPv4 and IPv6:
https://docs.aws.amazon.com/AmazonS3/latest/API/ipv6-access.html
https://docs.aws.amazon.com/AmazonS3/latest/API/dual-stack-endpoints.html

By switching to the dual-stack URLs, it means systems that support IPv6 will now use it instead of IPv4, which is helpful in IPv6 environments where IPv4 traffic has to fall back to being routed via NAT gateways (which has performance and ingress cost implications).

See also:
https://salesforce-internal.slack.com/archives/C01R6FJ738U/p1770827176094169

GUS-W-21335961.
