### PR TITLE
Add binary build support for Heroku-26

### DIFF
--- a/.github/workflows/build_python_runtime.yml
+++ b/.github/workflows/build_python_runtime.yml
@@ -15,6 +15,7 @@ on:
           - auto
           - heroku-22
           - heroku-24
+          - heroku-26
         default: auto
         required: false
       dry_run:
@@ -65,6 +66,31 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-xlarge' || 'pub-hk-ubuntu-24.04-xlarge' }}
     env:
       STACK_VERSION: "24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Build Docker image
+        run: docker build --platform="linux/${{ matrix.arch }}" --pull --tag buildenv --build-arg=STACK_VERSION builds/
+      - name: Compile and package Python runtime
+        run: docker run --rm --volume="${PWD}/upload:/tmp/upload" buildenv ./build_python_runtime.sh "${{ inputs.python_version }}"
+      - name: Test Python runtime
+        run: |
+          RUN_IMAGE='heroku/heroku:${{ env.STACK_VERSION }}'
+          ARCHIVE_FILENAME='python-${{ inputs.python_version }}-ubuntu-${{ env.STACK_VERSION }}.04-${{ matrix.arch }}.tar.zst'
+          docker run --rm --volume="${PWD}/upload:/upload:ro" --volume="${PWD}/builds:/builds:ro" "${RUN_IMAGE}" /builds/test_python_runtime.sh "/upload/${ARCHIVE_FILENAME}"
+      - name: Upload Python runtime archive to S3
+        if: (!inputs.dry_run)
+        run: aws s3 sync ./upload "s3://${S3_BUCKET}"
+
+  heroku-26:
+    if: inputs.stack == 'heroku-26' || inputs.stack == 'auto'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm64"]
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-xlarge' || 'pub-hk-ubuntu-24.04-xlarge' }}
+    env:
+      STACK_VERSION: "26"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/builds/Dockerfile
+++ b/builds/Dockerfile
@@ -8,8 +8,12 @@ ENV STACK="heroku-${STACK_VERSION}"
 # For Heroku-24 and newer, the build image sets a non-root default `USER`.
 USER root
 
+# `libcrypt-dev` can be removed once we drop support for Python 3.12,
+# since the `crypt` module was removed in Python 3.13:
+# https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-pep594
 RUN apt-get update --error-on=any \
     && apt-get install -y --no-install-recommends \
+      libcrypt-dev \
       libdb-dev \
       libreadline-dev \
       libsqlite3-dev \

--- a/builds/build_python_runtime.sh
+++ b/builds/build_python_runtime.sh
@@ -25,7 +25,7 @@ function abort() {
 }
 
 case "${STACK:?}" in
-	heroku-22 | heroku-24)
+	heroku-22 | heroku-24 | heroku-26)
 		SUPPORTED_PYTHON_VERSIONS=(
 			"3.10"
 			"3.11"

--- a/builds/test_python_runtime.sh
+++ b/builds/test_python_runtime.sh
@@ -68,10 +68,19 @@ optional_stdlib_modules=(
 	zlib
 )
 
+# zstd support was added in Python 3.14:
 # https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-zstandard
 if [[ "${major_python_version}" == "3.14" ]]; then
 	optional_stdlib_modules+=(
 		compression.zstd
+	)
+fi
+
+# crypt was removed in Python 3.13:
+# https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-pep594
+if [[ "${major_python_version}" == +(3.10|3.11|3.12) ]]; then
+	optional_stdlib_modules+=(
+		crypt
 	)
 fi
 


### PR DESCRIPTION
This adds support for building the binaries for the upcoming Heroku-26 stack based on Ubuntu 26.04.

A later PR will add support for the stack to the buildpack itself, once the Heroku build system supports Heroku-26 (since until that point we can't run Hatchet in CI anyway).

The `libcrypt-dev` library had to be added to the `Dockerfile` used for binary building, since the headers package is no longer in `heroku/heroku:26-build` as it was previously only a transitive dependency in the build image, and with the upstream Ubuntu 26.04 package changes is now no longer pulled in. (From searching it doesn't appear to be widely used, so I don't think it's worth adding back to the Heroku-26 build image.)

Doing so fixes this warning on Python 3.12 and older (the `crypt` module only exists in older Python versions):

```
*** WARNING: renaming "_crypt" since importing it failed: /tmp/src/build/lib.linux-x86_64-3.10/_crypt.cpython-310-x86_64-linux-gnu.so: undefined symbol: crypt

...

Following modules built successfully but were removed because they could not be imported:
_crypt
```

Dry-run test builds using this branch succeeded. e.g.:
https://github.com/heroku/heroku-buildpack-python/actions/runs/23343385460
https://github.com/heroku/heroku-buildpack-python/actions/runs/23343379302

GUS-W-20775546.
