### PR TITLE
Stop using global variable in `warn_or_error_if_python_version_file_missing()`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -139,7 +139,7 @@ fi
 # as to what was a warning vs an error. In addition, several of the error messages contain similar
 # content to the warnings (such as encouraging use of .python-version and major version syntax),
 # which would mean duplicate content if we showed both.
-python_version::warn_or_error_if_python_version_file_missing "${python_version_origin}" "${python_major_version}"
+python_version::warn_or_error_if_python_version_file_missing "${python_version_origin}" "${python_major_version}" "${package_manager}"
 python_version::warn_if_deprecated_major_version "${python_major_version}" "${python_version_origin}"
 python_version::warn_if_patch_update_available "${python_full_version}" "${python_major_version}" "${python_version_origin}"
 

--- a/lib/python_version.sh
+++ b/lib/python_version.sh
@@ -539,6 +539,7 @@ function python_version::resolve_python_version() {
 function python_version::warn_or_error_if_python_version_file_missing() {
 	local python_version_origin="${1}"
 	local python_major_version="${2}"
+	local package_manager="${3}"
 
 	if [[ "${python_version_origin}" == ".python-version" ]]; then
 		return 0


### PR DESCRIPTION
Longer term I'll refactor `bin/compile` to reduce the number of globals set, to prevent accidentally relying on globals in the library functions.

GUS-W-21939949.