### PR TITLE
Fix Dependabot config file syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,5 @@ updates:
       # We don't limit grouping for Python to just minor/patch versions, since pip doesn't follow
       # semver, plus having to update CHANGELOG.md means it's easier to just have a single PR.
       python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Since the schema requires at least one property to be specified under the `groups` key, even if we're not wanting to add filters.

See:
https://www.schemastore.org/dependabot-2.0.json

GUS-W-22400243.