### PR TITLE
Fix CHANGELOG for release that didn't occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 - Updated pip from 26.1.1 to 26.1.2. ([#2098](https://github.com/heroku/heroku-buildpack-python/pull/2098))
 - Updated Poetry from 2.4.0 to 2.4.1. ([#2098](https://github.com/heroku/heroku-buildpack-python/pull/2098))
 - Updated uv from 0.11.11 to 0.11.19. ([#2098](https://github.com/heroku/heroku-buildpack-python/pull/2098))
-
-## [v345] - 2026-05-11
-
 - The Python 3.14 version alias now resolves to Python 3.14.5. ([#2094](https://github.com/heroku/heroku-buildpack-python/pull/2094))
 
 ## [v344] - 2026-05-07
@@ -1541,7 +1538,6 @@ Default Python is now latest 2.7.10. Updated pip and Distribute.
 - pip updated to v7.0.1
 
 [unreleased]: https://github.com/heroku/heroku-buildpack-python/compare/v345...main
-[v345]: https://github.com/heroku/heroku-buildpack-python/compare/v344...v345
 [v345]: https://github.com/heroku/heroku-buildpack-python/compare/v344...v345
 [v344]: https://github.com/heroku/heroku-buildpack-python/compare/v343...v344
 [v343]: https://github.com/heroku/heroku-buildpack-python/compare/v342...v343


### PR DESCRIPTION
The original v345 release (prepared in #2095) never ended up being published (I forgot to run the final `make publish` step), and so was superseded by #2100 - which resulted in two v345 entries being present in CHANGELOG.

Longer term we should add a self-check to the prepare release GitHub Actions workflow so that it fails if the changelog is in an inconsistent state. (Though that said, the new release automation triggered on merge of the prepare-release PR would prevent the need to manually run `make publish`, and so prevent this issue too.)