### PR TITLE
Route builds/Dockerfile Dependabot bumps to maintainer in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,5 @@
 CHANGELOG.md @edmorley
 Gemfile.lock @edmorley
 /.github/workflows/ @edmorley
+/builds/Dockerfile @edmorley
 /requirements/ @edmorley


### PR DESCRIPTION
builds/Dockerfile matched only the `* @heroku/languages` catch-all, so Dependabot cosign bumps requested team review. Add an override to route it to the maintainer, like the other Dependabot-touched paths.

GUS-W-23276629.