### PR TITLE
Fix intermittent one-off dyno test failures from extra trailing newline

### DIFF
--- a/spec/hatchet/pip_spec.rb
+++ b/spec/hatchet/pip_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'pip support' do
         REGEX
 
         # For historical reasons pip is made available at run-time too, unlike some of the other package managers.
-        expect(app.run('bin/print-env-vars.sh && pip --version')).to eq(<<~OUTPUT)
+        expect(normalize_trailing_newlines(app.run('bin/print-env-vars.sh && pip --version'))).to eq(<<~OUTPUT)
           DYNO_RAM=512
           FORWARDED_ALLOW_IPS=*
           GUNICORN_CMD_ARGS=--access-logfile -

--- a/spec/hatchet/pipenv_spec.rb
+++ b/spec/hatchet/pipenv_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Pipenv support' do
         REGEX
 
         # For historical reasons Pipenv is made available at run-time too, unlike some of the other package managers.
-        expect(clean_output(app.run('bin/print-env-vars.sh && pipenv --version'))).to eq(<<~OUTPUT)
+        expect(normalize_trailing_newlines(app.run('bin/print-env-vars.sh && pipenv --version'))).to eq(<<~OUTPUT)
           DYNO_RAM=512
           FORWARDED_ALLOW_IPS=*
           GUNICORN_CMD_ARGS=--access-logfile -

--- a/spec/hatchet/poetry_spec.rb
+++ b/spec/hatchet/poetry_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Poetry support' do
         REGEX
 
         command = 'bin/print-env-vars.sh && if command -v poetry; then echo "Poetry unexpectedly found!" && exit 1; fi'
-        expect(app.run(command)).to eq(<<~OUTPUT)
+        expect(normalize_trailing_newlines(app.run(command))).to eq(<<~OUTPUT)
           DYNO_RAM=512
           FORWARDED_ALLOW_IPS=*
           GUNICORN_CMD_ARGS=--access-logfile -

--- a/spec/hatchet/python_version_spec.rb
+++ b/spec/hatchet/python_version_spec.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'builds with the requested Python version' do |requested_v
           remote:        Collecting typing-extensions==4.15.0 (from -r requirements.txt (line 2))
         OUTPUT
       end
-      expect(app.run('python -V')).to eq("Python #{resolved_version}\n")
+      expect(normalize_trailing_newlines(app.run('python -V'))).to eq("Python #{resolved_version}\n")
       expect($CHILD_STATUS.exitstatus).to eq(0)
     end
   end
@@ -153,7 +153,7 @@ RSpec.describe 'Python version support' do
             remote: -----> Installing Python #{LATEST_PYTHON_3_14}
             remote: -----> Installing pip #{PIP_VERSION}
           OUTPUT
-          expect(app.run('python -V')).to eq("Python #{LATEST_PYTHON_3_14}\n")
+          expect(normalize_trailing_newlines(app.run('python -V'))).to eq("Python #{LATEST_PYTHON_3_14}\n")
           expect($CHILD_STATUS.exitstatus).to eq(0)
         end
       end
@@ -277,7 +277,7 @@ RSpec.describe 'Python version support' do
           remote: -----> Installing dependencies using 'pip install -r requirements.txt'
           remote:        Collecting typing-extensions==4.15.0 (from -r requirements.txt (line 2))
         OUTPUT
-        expect(app.run('python -V')).to eq("Python #{LATEST_PYTHON_3_10}\n")
+        expect(normalize_trailing_newlines(app.run('python -V'))).to eq("Python #{LATEST_PYTHON_3_10}\n")
         expect($CHILD_STATUS.exitstatus).to eq(0)
       end
     end

--- a/spec/hatchet/uv_spec.rb
+++ b/spec/hatchet/uv_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'uv support' do
         REGEX
 
         command = 'bin/print-env-vars.sh && if command -v uv; then echo "uv unexpectedly found!" && exit 1; fi'
-        expect(app.run(command)).to eq(<<~OUTPUT)
+        expect(normalize_trailing_newlines(app.run(command))).to eq(<<~OUTPUT)
           DYNO_RAM=512
           FORWARDED_ALLOW_IPS=*
           GUNICORN_CMD_ARGS=--access-logfile -


### PR DESCRIPTION
The platform log stream that captures one-off dyno (`app.run`) output occasionally appends an extra trailing newline, which intermittently breaks exact-match (`.to eq`) output assertions. For example:
https://github.com/heroku/heroku-buildpack-python/actions/runs/28526498507/job/85081876325?pr=2110#step:5:589

This is the same flakiness that #2102 fixed for the `profile.d/` scripts test. Reuses the existing `normalize_trailing_newlines` spec helper to absorb the spurious newline while still asserting on the rest of the output exactly, applying it to the seven `app.run` exact-match assertions.

GUS-W-23366753.