### PR TITLE
Hardcode the setuptools version instead of using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    ignore:
-      # We're not updating to setuptools v71+ due to its new approach to vendored dependencies:
-      # https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653
-      - dependency-name: "setuptools"
     labels:
       - "dependencies"
       - "python"

--- a/lib/pip.sh
+++ b/lib/pip.sh
@@ -5,7 +5,10 @@
 set -euo pipefail
 
 PIP_VERSION=$(utils::get_requirement_version 'pip')
-SETUPTOOLS_VERSION=$(utils::get_requirement_version 'setuptools')
+# This is hardcoded rather than managed by Dependabot since we can't update to newer versions due to:
+# https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653
+# Also, once we drop support for older Pythons we'll stop installing setuptools entirely.
+SETUPTOOLS_VERSION='70.3.0'
 
 function pip::install_pip() {
 	local python_home="${1}"

--- a/requirements/setuptools.txt
+++ b/requirements/setuptools.txt
@@ -1,1 +1,0 @@
-setuptools==70.3.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,10 +28,12 @@ def get_requirement_version(package_name)
 end
 
 PIP_VERSION = get_requirement_version('pip')
-SETUPTOOLS_VERSION = get_requirement_version('setuptools')
 PIPENV_VERSION = get_requirement_version('pipenv')
 POETRY_VERSION = get_requirement_version('poetry')
 UV_VERSION = get_requirement_version('uv')
+# This is hardcoded rather than managed by Dependabot since we can't update to newer versions due to:
+# https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653
+SETUPTOOLS_VERSION = '70.3.0'
 
 # Work around the return value for `default_buildpack` changing after deploy:
 # https://github.com/heroku/hatchet/issues/180


### PR DESCRIPTION
We're not updating setuptools to v71+ due to its new approach to vendored dependencies, so it doesn't need to be managed by Dependabot:
https://github.com/heroku/heroku-buildpack-python/pull/1630#issuecomment-2324236653

Remove the requirements file and Dependabot ignore entry, and hardcode the version directly where it's used. This also prevents Dependabot security updates from constantly re-opening PRs for it (which bypass the ignore list) - e.g. #2118.

GUS-W-23572996.