### PR TITLE
Strip literal '^[' ANSI escapes in test output cleaning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,9 @@ def clean_output(output)
     # https://github.com/heroku/hatchet/issues/162
     .gsub(/ {8}(?=\R)/, '')
     # Remove ANSI colour codes used in buildpack output (e.g. error messages).
-    .gsub(/\e\[[0-9;]+m/, '')
+    # GitHub Actions runners deliver the escape byte as the two literal characters
+    # "^[" instead of 0x1B, so strip both variants.
+    .gsub(/(?:\e|\^\[)\[[0-9;]+m/, '')
 end
 
 def normalize_trailing_newlines(output)


### PR DESCRIPTION
The buildpack emits ANSI colour codes on error/warning banners. On GitHub Actions runners the escape byte arrives as the two literal characters `^[` instead of 0x1B, so `clean_output`'s regex (which only matched real ESC) left them in and broke output-matching assertions across the integration-test suite.

eg:
https://github.com/heroku/heroku-buildpack-python/actions/runs/33632972131/job/100259966770#step:5:623

Widen the regex to strip both variants, mirroring heroku/heroku-buildpack-java#303.

GUS-W-24073123.