### PR TITLE
Enable Dependabot updates for transitive dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    allow:
+      # Update transitive dependencies too.
+      - dependency-type: "all"
     labels:
       - "dependencies"
       - "ruby"
@@ -38,6 +41,9 @@ updates:
     # chance of picking up a too-new release).
     cooldown:
       default-days: 0
+    allow:
+      # Update transitive dependencies too.
+      - dependency-type: "all"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
Configure Dependabot's `allow` key with `dependency-type: all` so it also updates transitive dependencies (those only in the lockfile), not just direct dependencies. This removes the need to manually refresh lockfiles.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#allow--

GUS-W-24099599.