### PR TITLE
Enable retries for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,11 @@ jobs:
       matrix:
         stack: ["heroku-22", "heroku-24", "heroku-26"]
     env:
-      HATCHET_APP_LIMIT: 300
       HATCHET_DEFAULT_STACK: ${{ matrix.stack }}
-      HATCHET_EXPENSIVE_MODE: 1
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
       HEROKU_DISABLE_AUTOUPDATE: 1
       PARALLEL_SPLIT_TEST_PROCESSES: 90
-      RSPEC_RETRY_RETRY_COUNT: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+ENV['HATCHET_APP_LIMIT'] ||= ENV['CI'] ? '300' : '50'
 ENV['HATCHET_BUILDPACK_BASE'] ||= 'https://github.com/heroku/heroku-buildpack-python.git'
 ENV['HATCHET_DEFAULT_STACK'] ||= 'heroku-26'
+ENV['HATCHET_EXPENSIVE_MODE'] ||= '1'
 
 require 'English' # for $CHILD_STATUS
 require 'rspec/core'
@@ -53,6 +55,10 @@ RSpec.configure do |config|
   config.filter_run_excluding stacks: ->(stacks) { !stacks.include?(ENV.fetch('HATCHET_DEFAULT_STACK')) }
   # Make rspec-retry output a retry message when it's had to retry a test.
   config.verbose_retry = true
+  # This is the number of total attempts, not retries.
+  config.default_retry_count = ENV['CI'] ? 2 : 1
+  # By default there is no sleep between retries.
+  config.default_sleep_interval = 5
 end
 
 def clean_output(output)


### PR DESCRIPTION
Enable `rspec-retry` retries for the Hatchet integration tests, so that transient errors (such as network blips when deploying test apps or installing packages) don't fail the whole CI run.

The retry count and sleep interval are set via `rspec-retry`'s config options in `spec_helper.rb`, with retries enabled only when running in CI.

The `HATCHET_APP_LIMIT` and `HATCHET_EXPENSIVE_MODE` settings are also moved from the CI workflow into `spec_helper.rb`, so they apply to local test runs too (with `HATCHET_APP_LIMIT` scaled down for local use).

GUS-W-24117502.